### PR TITLE
Clippy unused errors

### DIFF
--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -19,8 +19,6 @@ use std::sync::Arc;
 use super::{
     commitment::commitment_scheme::CommitmentScheme, multilinear_polynomial::MultilinearPolynomial,
 };
-#[cfg(feature = "allocative")]
-use crate::utils::profiling::print_data_structure_heap_usage;
 use crate::{
     field::JoltField,
     transcripts::Transcript,

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -149,10 +149,7 @@ impl BatchedSumcheck {
 
                 // Print final batched_claim for Stage 7 debugging
                 if remaining_rounds == 1 && sumcheck_instances.len() == 1 && max_num_rounds <= 8 {
-                    eprintln!(
-                        "BatchedSumcheck::prove final batched_claim={:?}",
-                        batched_claim
-                    );
+                    eprintln!("BatchedSumcheck::prove final batched_claim={batched_claim:?}");
                 }
             }
 

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -146,11 +146,6 @@ impl BatchedSumcheck {
                     "round {round}: H(0) + H(1) = {h0} + {h1} != {batched_claim}"
                 );
                 batched_claim = batched_univariate_poly.evaluate(&r_j);
-
-                // Print final batched_claim for Stage 7 debugging
-                if remaining_rounds == 1 && sumcheck_instances.len() == 1 && max_num_rounds <= 8 {
-                    eprintln!("BatchedSumcheck::prove final batched_claim={batched_claim:?}");
-                }
             }
 
             for sumcheck in sumcheck_instances.iter_mut() {

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1112,12 +1112,12 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
 
         // Dense polynomials: RamInc and RdInc (from IncReduction in Stage 6)
         // These are at r_cycle_stage6 only (length log_T)
-        let (ram_inc_point, ram_inc_claim) =
+        let (_ram_inc_point, ram_inc_claim) =
             self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RamInc,
                 SumcheckId::IncReduction,
             );
-        let (rd_inc_point, rd_inc_claim) = self
+        let (_rd_inc_point, rd_inc_claim) = self
             .opening_accumulator
             .get_committed_polynomial_opening(CommittedPolynomial::RdInc, SumcheckId::IncReduction);
 
@@ -1132,12 +1132,12 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             let r_cycle_from_unified = &unified_point.r[log_k_chunk..];
 
             debug_assert_eq!(
-                ram_inc_point.r.as_slice(),
+                _ram_inc_point.r.as_slice(),
                 r_cycle_from_unified,
                 "RamInc opening point should match r_cycle from UnifiedBooleanity"
             );
             debug_assert_eq!(
-                rd_inc_point.r.as_slice(),
+                _rd_inc_point.r.as_slice(),
                 r_cycle_from_unified,
                 "RdInc opening point should match r_cycle from UnifiedBooleanity"
             );


### PR DESCRIPTION
Fixes clippy unused variable warnings and removes debug `eprintln` statements from sumcheck.

---
<a href="https://cursor.com/background-agent?bcId=bc-1155ecd7-cbf0-4385-90ec-fa7c2663ba40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1155ecd7-cbf0-4385-90ec-fa7c2663ba40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an unused profiling import, drops a test-only debug print in sumcheck, and prefixes unused variables in the prover to satisfy clippy.
> 
> - **Sumcheck (`jolt-core/src/subprotocols/sumcheck.rs`)**:
>   - Remove test-only debug `eprintln!` block for final `batched_claim`.
> - **Prover (`jolt-core/src/zkvm/prover.rs`)**:
>   - Prefix unused opening points (`_ram_inc_point`, `_rd_inc_point`) and update debug assertions to use them.
> - **Poly Opening Proof (`jolt-core/src/poly/opening_proof.rs`)**:
>   - Remove unused `#[cfg(feature = "allocative")]` import of `print_data_structure_heap_usage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4fc65e7af4f797ff9aadde9161c7c16ea1dea34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->