### PR TITLE
Benchmarking ci performance

### DIFF
--- a/examples/run_ci_benchmarks.sh
+++ b/examples/run_ci_benchmarks.sh
@@ -13,6 +13,9 @@
 
 set -e # Exit on error
 
+# Enable tracing output at INFO level so that "Prover runtime:" logs are visible
+export RUST_LOG=info
+
 # Define the exclude list
 exclusion_list=("collatz" "overflow" "sha3-chain" "verifier" "recursion" "malloc" "hash-bench")
 # JSON file to store results
@@ -95,8 +98,10 @@ for i in "${!test_directories[@]}"; do
     echo "Error running benchmark for $file. Skipping..."
     continue
   fi
-  # Extract 'real' time value using awk
-  exec_time=$(awk '/Prover runtime:/ {print $3}' "$temp_output") # in seconds
+  # Extract 'Prover runtime:' value using awk
+  # The tracing format outputs: "TIMESTAMP  INFO target: Prover runtime: X.XX s"
+  # We need to extract the numeric value after "runtime:"
+  exec_time=$(awk '/Prover runtime:/ { for(i=1; i<=NF; i++) if($i=="runtime:") print $(i+1) }' "$temp_output") # in seconds
   # Extract 'MRS' value using awk
   mem_used=$(awk '/MRS:/ {print $2}' "$temp_output") # in KB
   echo "$output" # Print the output for debugging


### PR DESCRIPTION
Fix CI benchmarking to report runtime data by enabling `RUST_LOG` and correcting the `awk` pattern for extracting runtime values.

The `Prover runtime:` log lines were not appearing in CI output because `RUST_LOG` was not set, causing `info!` macros to be filtered. Additionally, the `awk` pattern used to extract the runtime value was incorrect for the `tracing` output format, which includes a timestamp and log level.

---
<a href="https://cursor.com/background-agent?bcId=bc-bed7df63-ab4b-46a3-9521-4cc4c7b1c638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bed7df63-ab4b-46a3-9521-4cc4c7b1c638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

