### PR TITLE
Dory layout investigation and enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "ark-bn254"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "allocative",
  "ark-ff-asm",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "quote",
  "syn 2.0.110",
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "ark-grumpkin"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "ark-serialize-derive 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-std",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -398,7 +398,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2064,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "jolt-optimizations"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#c5ebe4c975c2243c3ef0fa89261c55ea5f1eb290"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#cc955e90471e5703be8ac54b26a04b6c1f90d9ca"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/examples/merkle-tree/src/main.rs
+++ b/examples/merkle-tree/src/main.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let leaf3 = [7u8; 32];
     let leaf4 = [8u8; 32];
 
-    let (trusted_advice_commitment, _hint) = guest::commit_trusted_advice_merkle_tree(
+    let (trusted_advice_commitment, trusted_advice_hint) = guest::commit_trusted_advice_merkle_tree(
         TrustedAdvice::new(leaf2),
         TrustedAdvice::new(leaf3),
         &prover_preprocessing,
@@ -36,6 +36,7 @@ pub fn main() {
         TrustedAdvice::new(leaf3),
         UntrustedAdvice::new(leaf4),
         trusted_advice_commitment,
+        trusted_advice_hint,
     );
     info!("Prover runtime: {} s", now.elapsed().as_secs_f64());
 

--- a/examples/recursion/src/main.rs
+++ b/examples/recursion/src/main.rs
@@ -338,6 +338,7 @@ fn collect_guest_proofs(guest: GuestProgram, target_dir: &str, use_embed: bool) 
             &[],
             &[],
             None,
+            None,
             &mut output_bytes,
             &guest_prover_preprocessing,
         );
@@ -510,6 +511,7 @@ fn run_recursion_proof(
                 &input_bytes,
                 &[],
                 &[],
+                None,
                 None,
                 &mut output_bytes,
                 &recursion_prover_preprocessing,

--- a/examples/run_ci_benchmarks.sh
+++ b/examples/run_ci_benchmarks.sh
@@ -13,6 +13,9 @@
 
 set -e # Exit on error
 
+# Enable tracing output at INFO level so that "Prover runtime:" logs are visible
+export RUST_LOG=info
+
 # Define the exclude list
 exclusion_list=("collatz" "overflow" "sha3-chain" "verifier" "recursion" "malloc" "hash-bench")
 # JSON file to store results
@@ -95,8 +98,10 @@ for i in "${!test_directories[@]}"; do
     echo "Error running benchmark for $file. Skipping..."
     continue
   fi
-  # Extract 'real' time value using awk
-  exec_time=$(awk '/Prover runtime:/ {print $3}' "$temp_output") # in seconds
+  # Extract 'Prover runtime:' value using awk
+  # The tracing format outputs: "TIMESTAMP  INFO target: Prover runtime: X.XX s"
+  # We need to extract the numeric value after "runtime:"
+  exec_time=$(awk '/Prover runtime:/ { for(i=1; i<=NF; i++) if($i=="runtime:") print $(i+1) }' "$temp_output") # in seconds
   # Extract 'MRS' value using awk
   mem_used=$(awk '/MRS:/ {print $2}' "$temp_output") # in KB
   echo "$output" # Print the output for debugging

--- a/jolt-core/benches/commit.rs
+++ b/jolt-core/benches/commit.rs
@@ -1,6 +1,6 @@
 use criterion::Criterion;
 use jolt_core::poly::commitment::commitment_scheme::CommitmentScheme;
-use jolt_core::poly::commitment::dory::{DoryCommitmentScheme, DoryGlobals};
+use jolt_core::poly::commitment::dory::{DoryCommitmentScheme, DoryContext, DoryGlobals};
 use jolt_core::poly::multilinear_polynomial::MultilinearPolynomial;
 use jolt_core::utils::math::Math;
 use rand::Rng;
@@ -9,7 +9,7 @@ use rand_core::{RngCore, SeedableRng};
 // use rayon::prelude::*;
 
 fn benchmark_dory_dense(c: &mut Criterion, name: &str, k: usize, t: usize) {
-    let globals = DoryGlobals::initialize(k, t);
+    let globals = DoryGlobals::initialize_context(k, t, DoryContext::Main);
     let setup = <DoryCommitmentScheme as CommitmentScheme>::setup_prover(k.log_2() + t.log_2());
     let mut rng = ChaCha20Rng::seed_from_u64(111111u64);
 
@@ -26,7 +26,7 @@ fn benchmark_dory_dense(c: &mut Criterion, name: &str, k: usize, t: usize) {
 }
 
 fn benchmark_dory_one_hot_batch(c: &mut Criterion, name: &str, k: usize, t: usize) {
-    let globals = DoryGlobals::initialize(k, t);
+    let globals = DoryGlobals::initialize_context(k, t, DoryContext::Main);
     let setup = <DoryCommitmentScheme as CommitmentScheme>::setup_prover(k.log_2() + t.log_2());
     let mut rng = ChaCha20Rng::seed_from_u64(111111u64);
 
@@ -52,7 +52,7 @@ fn benchmark_dory_one_hot_batch(c: &mut Criterion, name: &str, k: usize, t: usiz
 }
 
 fn benchmark_dory_mixed_batch(c: &mut Criterion, name: &str, k: usize, t: usize) {
-    let globals = DoryGlobals::initialize(k, t);
+    let globals = DoryGlobals::initialize_context(k, t, DoryContext::Main);
     let setup = <DoryCommitmentScheme as CommitmentScheme>::setup_prover(k.log_2() + t.log_2());
     let mut rng = ChaCha20Rng::seed_from_u64(111111u64);
 

--- a/jolt-core/benches/e2e_profiling.rs
+++ b/jolt-core/benches/e2e_profiling.rs
@@ -211,9 +211,9 @@ fn prove_example(
             bytecode,
             program_io.memory_layout.clone(),
             init_memory_state,
+            padded_trace_len,
         );
-        let preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), padded_trace_len);
+        let preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
 
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -223,6 +223,7 @@ fn prove_example(
             &serialized_input,
             &[],
             &[],
+            None,
             None,
         );
         let program_io = prover.program_io.clone();
@@ -266,9 +267,9 @@ fn prove_example_with_trace(
         bytecode.clone(),
         program_io.memory_layout.clone(),
         init_memory_state,
+        trace.len().next_power_of_two(),
     );
-    let preprocessing =
-        JoltProverPreprocessing::new(shared_preprocessing, trace.len().next_power_of_two());
+    let preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
 
     let elf_contents_opt = program.get_elf_contents();
     let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -280,6 +281,7 @@ fn prove_example_with_trace(
         &serialized_input,
         &[],
         &[],
+        None,
         None,
     );
     let now = Instant::now();

--- a/jolt-core/src/field/challenge/macros.rs
+++ b/jolt-core/src/field/challenge/macros.rs
@@ -272,14 +272,14 @@ macro_rules! impl_field_ops_inline {
     };
 
     (@mul_challenge_field optimized, $f:ty, $lhs:expr, $rhs:expr) => {
-        $rhs.mul_hi_bigint_u128($lhs.value())
+        $rhs.mul_by_hi_2limbs($lhs.low, $lhs.high)
     };
     (@mul_challenge_field standard, $f:ty, $lhs:expr, $rhs:expr) => {
         Into::<$f>::into($lhs) * $rhs
     };
 
     (@mul_field_challenge optimized, $f:ty, $lhs:expr, $rhs:expr) => {
-        $lhs.mul_hi_bigint_u128($rhs.value())
+        $lhs.mul_by_hi_2limbs($rhs.low, $rhs.high)
     };
     (@mul_field_challenge standard, $f:ty, $lhs:expr, $rhs:expr) => {
         $lhs * Into::<$f>::into($rhs)

--- a/jolt-core/src/field/challenge/mont_ark_u128.rs
+++ b/jolt-core/src/field/challenge/mont_ark_u128.rs
@@ -1,7 +1,7 @@
 //! Optimized Challenge field for faster polynomial operations
 //!
 //! This module implements a specialized Challenge type that is a 125-bit subset of JoltField
-//! with the two least significant bits zeroed out. This constraint enables ~1.6x faster
+//! with the top 3 bits zeroed out. This constraint enables ~1.6x faster
 //! multiplication with ark_bn254::Fr elements, resulting in ~1.3x speedup for polynomial
 //! binding operations.
 //!
@@ -9,105 +9,164 @@
 
 use crate::field::OptimizedMul;
 use crate::field::{tracked_ark::TrackedFr, JoltField};
-//use crate::impl_field_ops_inline;
 use allocative::Allocative;
 use ark_ff::{BigInt, PrimeField, UniformRand};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
 use num::{One, Zero};
 use rand::{Rng, RngCore};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::ops::{Add, Mul, Sub};
-#[derive(
-    Copy, Clone, Default, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize, Allocative,
-)]
+
+/// Challenge type storing two u64 limbs (low, high) matching arkworks' internal representation.
+/// Only uses 125 bits (top 3 bits of high limb are always zero).
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, Allocative)]
 pub struct MontU128Challenge<F: JoltField> {
-    value: [u64; 4],
+    /// Low 64 bits of the 125-bit value
+    pub low: u64,
+    /// High 61 bits of the 125-bit value (top 3 bits always zero)
+    pub high: u64,
     _marker: PhantomData<F>,
+}
+
+// Custom serialization: serialize as [u64; 4] for compatibility with field element format
+impl<F: JoltField> Valid for MontU128Challenge<F> {
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+}
+
+impl<F: JoltField> CanonicalSerialize for MontU128Challenge<F> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        // Serialize as [u64; 4] for field element compatibility
+        self.to_bigint_array()
+            .serialize_with_mode(&mut writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        [0u64; 4].serialized_size(compress)
+    }
+}
+
+impl<F: JoltField> CanonicalDeserialize for MontU128Challenge<F> {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let arr = <[u64; 4]>::deserialize_with_mode(reader, compress, validate)?;
+        // arr[0] and arr[1] should be 0, arr[2] is low, arr[3] is high
+        Ok(Self {
+            low: arr[2],
+            high: arr[3],
+            _marker: PhantomData,
+        })
+    }
 }
 
 impl<F: JoltField> Display for MontU128Challenge<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bigint = BigInt::new(self.value);
+        let bigint = BigInt::new(self.to_bigint_array());
         write!(f, "{bigint}")
     }
 }
 
 impl<F: JoltField> Debug for MontU128Challenge<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bigint = BigInt::new(self.value);
+        let bigint = BigInt::new(self.to_bigint_array());
         write!(f, "{bigint}")
     }
 }
 
 impl<F: JoltField> From<u128> for MontU128Challenge<F> {
+    #[inline(always)]
     fn from(value: u128) -> Self {
         Self::new(value)
     }
 }
 
 impl<F: JoltField> MontU128Challenge<F> {
+    /// Creates a new challenge from a u128 value.
+    /// Only the low 125 bits are used (top 3 bits are masked off).
+    #[inline(always)]
     pub fn new(value: u128) -> Self {
-        // MontU128 can always be represented by 125 bits.
-        // This guarantees that the big integer is never greater than the
-        // bn254 modulus
-        let val_masked = value & (u128::MAX >> 3);
-        let low = val_masked as u64;
-        let high = (val_masked >> 64) as u64;
+        // Only mask the high limb - low limb passes through unchanged.
+        // Top 3 bits of high limb are zeroed to ensure value < bn254 modulus.
+        let low = value as u64;
+        let high = ((value >> 64) as u64) & (u64::MAX >> 3);
         Self {
-            value: [0, 0, low, high],
+            low,
+            high,
             _marker: PhantomData,
         }
     }
 
-    pub fn value(&self) -> [u64; 4] {
-        self.value
+    /// Returns the value as a [u64; 4] BigInt array for field conversion.
+    /// Format: [0, 0, low, high] - zeros in lower limbs, value in upper limbs.
+    #[inline(always)]
+    pub fn to_bigint_array(&self) -> [u64; 4] {
+        [0, 0, self.low, self.high]
     }
 
+    #[inline(always)]
     pub fn random<R: Rng + ?Sized>(rng: &mut R) -> Self {
         Self::from(rng.gen::<u128>())
     }
 }
 
 impl<F: JoltField> UniformRand for MontU128Challenge<F> {
+    #[inline(always)]
     fn rand<R: RngCore + ?Sized>(rng: &mut R) -> Self {
         Self::from(rng.gen::<u128>())
     }
 }
 
-impl Into<ark_bn254::Fr> for MontU128Challenge<ark_bn254::Fr> {
+impl From<MontU128Challenge<ark_bn254::Fr>> for ark_bn254::Fr {
     #[inline(always)]
-    fn into(self) -> ark_bn254::Fr {
-        ark_bn254::Fr::from_bigint_unchecked(BigInt::new(self.value())).unwrap()
+    fn from(challenge: MontU128Challenge<ark_bn254::Fr>) -> ark_bn254::Fr {
+        ark_bn254::Fr::from_bigint_unchecked(BigInt::new(challenge.to_bigint_array())).unwrap()
     }
 }
-impl Into<ark_bn254::Fr> for &MontU128Challenge<ark_bn254::Fr> {
+
+impl From<&MontU128Challenge<ark_bn254::Fr>> for ark_bn254::Fr {
     #[inline(always)]
-    fn into(self) -> ark_bn254::Fr {
-        ark_bn254::Fr::from_bigint_unchecked(BigInt::new(self.value())).unwrap()
+    fn from(challenge: &MontU128Challenge<ark_bn254::Fr>) -> ark_bn254::Fr {
+        ark_bn254::Fr::from_bigint_unchecked(BigInt::new(challenge.to_bigint_array())).unwrap()
     }
 }
 
 impl_field_ops_inline!(MontU128Challenge<ark_bn254::Fr>, ark_bn254::Fr, optimized);
 
-impl Into<TrackedFr> for MontU128Challenge<TrackedFr> {
+impl From<MontU128Challenge<TrackedFr>> for TrackedFr {
     #[inline(always)]
-    fn into(self) -> TrackedFr {
-        TrackedFr(ark_bn254::Fr::from_bigint_unchecked(BigInt::new(self.value())).unwrap())
+    fn from(challenge: MontU128Challenge<TrackedFr>) -> TrackedFr {
+        TrackedFr(
+            ark_bn254::Fr::from_bigint_unchecked(BigInt::new(challenge.to_bigint_array())).unwrap(),
+        )
     }
 }
 
-impl Into<TrackedFr> for &MontU128Challenge<TrackedFr> {
+impl From<&MontU128Challenge<TrackedFr>> for TrackedFr {
     #[inline(always)]
-    fn into(self) -> TrackedFr {
-        TrackedFr(ark_bn254::Fr::from_bigint_unchecked(BigInt::new(self.value())).unwrap())
+    fn from(challenge: &MontU128Challenge<TrackedFr>) -> TrackedFr {
+        TrackedFr(
+            ark_bn254::Fr::from_bigint_unchecked(BigInt::new(challenge.to_bigint_array())).unwrap(),
+        )
     }
 }
 
 impl_field_ops_inline!(MontU128Challenge<TrackedFr>, TrackedFr, optimized);
 
 impl OptimizedMul<ark_bn254::Fr, ark_bn254::Fr> for MontU128Challenge<ark_bn254::Fr> {
+    #[inline(always)]
     fn mul_0_optimized(self, other: ark_bn254::Fr) -> Self::Output {
         if other.is_zero() {
             ark_bn254::Fr::zero()
@@ -116,6 +175,7 @@ impl OptimizedMul<ark_bn254::Fr, ark_bn254::Fr> for MontU128Challenge<ark_bn254:
         }
     }
 
+    #[inline(always)]
     fn mul_1_optimized(self, other: ark_bn254::Fr) -> Self::Output {
         if other.is_one() {
             self.into()
@@ -124,6 +184,7 @@ impl OptimizedMul<ark_bn254::Fr, ark_bn254::Fr> for MontU128Challenge<ark_bn254:
         }
     }
 
+    #[inline(always)]
     fn mul_01_optimized(self, other: ark_bn254::Fr) -> Self::Output {
         if other.is_zero() {
             ark_bn254::Fr::zero()
@@ -136,6 +197,7 @@ impl OptimizedMul<ark_bn254::Fr, ark_bn254::Fr> for MontU128Challenge<ark_bn254:
 }
 
 impl OptimizedMul<TrackedFr, TrackedFr> for MontU128Challenge<TrackedFr> {
+    #[inline(always)]
     fn mul_0_optimized(self, other: TrackedFr) -> Self::Output {
         if other.is_zero() {
             TrackedFr::zero()
@@ -144,6 +206,7 @@ impl OptimizedMul<TrackedFr, TrackedFr> for MontU128Challenge<TrackedFr> {
         }
     }
 
+    #[inline(always)]
     fn mul_1_optimized(self, other: TrackedFr) -> Self::Output {
         if other.is_one() {
             self.into()
@@ -152,6 +215,7 @@ impl OptimizedMul<TrackedFr, TrackedFr> for MontU128Challenge<TrackedFr> {
         }
     }
 
+    #[inline(always)]
     fn mul_01_optimized(self, other: TrackedFr) -> Self::Output {
         if other.is_zero() {
             TrackedFr::zero()

--- a/jolt-core/src/field/tracked_ark.rs
+++ b/jolt-core/src/field/tracked_ark.rs
@@ -452,10 +452,10 @@ impl JoltField for TrackedFr {
 }
 
 impl TrackedFr {
-    #[inline]
-    pub fn mul_hi_bigint_u128(&self, n: [u64; 4]) -> Self {
+    #[inline(always)]
+    pub fn mul_by_hi_2limbs(&self, limb_lo: u64, limb_hi: u64) -> Self {
         MUL_U128_COUNT.fetch_add(1, Ordering::Relaxed);
-        TrackedFr(self.0.mul_hi_bigint_u128(n))
+        TrackedFr(self.0.mul_by_hi_2limbs(limb_lo, limb_hi))
     }
 }
 

--- a/jolt-core/src/guest/prover.rs
+++ b/jolt-core/src/guest/prover.rs
@@ -23,11 +23,12 @@ pub fn preprocess(
     let mut memory_config = guest.memory_config;
     memory_config.program_size = Some(program_size);
     let memory_layout = MemoryLayout::new(&memory_config);
-    let shared_preprocessing = JoltSharedPreprocessing::new(bytecode, memory_layout, memory_init);
-    JoltProverPreprocessing::new(shared_preprocessing, max_trace_length)
+    let shared_preprocessing =
+        JoltSharedPreprocessing::new(bytecode, memory_layout, memory_init, max_trace_length);
+    JoltProverPreprocessing::new(shared_preprocessing)
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 #[cfg(feature = "prover")]
 pub fn prove<F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, FS: Transcript>(
     guest: &Program,
@@ -35,6 +36,7 @@ pub fn prove<F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, FS: Transc
     untrusted_advice_bytes: &[u8],
     trusted_advice_bytes: &[u8],
     trusted_advice_commitment: Option<<PCS as CommitmentScheme>::Commitment>,
+    trusted_advice_hint: Option<<PCS as CommitmentScheme>::OpeningProofHint>,
     output_bytes: &mut [u8],
     preprocessing: &JoltProverPreprocessing<F, PCS>,
 ) -> (
@@ -51,6 +53,7 @@ pub fn prove<F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, FS: Transc
         untrusted_advice_bytes,
         trusted_advice_bytes,
         trusted_advice_commitment,
+        trusted_advice_hint,
     );
     let io_device = prover.program_io.clone();
     let (proof, debug_info) = prover.prove();

--- a/jolt-core/src/guest/verifier.rs
+++ b/jolt-core/src/guest/verifier.rs
@@ -15,6 +15,7 @@ use common::jolt_device::MemoryLayout;
 
 pub fn preprocess(
     guest: &Program,
+    max_trace_length: usize,
     verifier_setup: <DoryCommitmentScheme as CommitmentScheme>::VerifierSetup,
 ) -> JoltVerifierPreprocessing<ark_bn254::Fr, DoryCommitmentScheme> {
     let (bytecode, memory_init, program_size) = guest.decode();
@@ -22,7 +23,8 @@ pub fn preprocess(
     let mut memory_config = guest.memory_config;
     memory_config.program_size = Some(program_size);
     let memory_layout = MemoryLayout::new(&memory_config);
-    let shared = JoltSharedPreprocessing::new(bytecode, memory_layout, memory_init);
+    let shared =
+        JoltSharedPreprocessing::new(bytecode, memory_layout, memory_init, max_trace_length);
     JoltVerifierPreprocessing::new(shared, verifier_setup)
 }
 

--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -48,6 +48,11 @@ impl CommitmentScheme for DoryCommitmentScheme {
         let mut rng = ChaCha20Rng::from_seed(seed);
         let setup = ArkworksProverSetup::new_from_urs(&mut rng, max_num_vars);
 
+        // The prepared-point cache in dory-pcs is global and can only be initialized once.
+        // In unit tests, multiple setups with different sizes are created, so initializing the
+        // cache with a small setup can break later tests that need more generators.
+        // We therefore disable cache initialization in `cfg(test)` builds.
+        #[cfg(not(test))]
         DoryGlobals::init_prepared_cache(&setup.g1_vec, &setup.g2_vec);
 
         setup

--- a/jolt-core/src/poly/commitment/dory/dory_globals.rs
+++ b/jolt-core/src/poly/commitment/dory/dory_globals.rs
@@ -58,6 +58,45 @@ impl Drop for DoryContextGuard {
 pub struct DoryGlobals;
 
 impl DoryGlobals {
+    /// Split `total_vars` into a *balanced* pair `(sigma, nu)` where:
+    /// - **sigma** is the number of **column** variables
+    /// - **nu** is the number of **row** variables
+    ///
+    /// Dory matrices are conceptually shaped as `2^nu` rows × `2^sigma` columns (row-major).
+    /// We use the balanced policy `sigma = ceil(total_vars / 2)` and `nu = total_vars - sigma`.
+    #[inline]
+    pub fn balanced_sigma_nu(total_vars: usize) -> (usize, usize) {
+        let sigma = total_vars.div_ceil(2);
+        let nu = total_vars - sigma;
+        (sigma, nu)
+    }
+
+    /// Convenience helper for the main Dory matrix where `total_vars = log_k_chunk + log_t`.
+    #[inline]
+    pub fn main_sigma_nu(log_k_chunk: usize, log_t: usize) -> (usize, usize) {
+        Self::balanced_sigma_nu(log_k_chunk + log_t)
+    }
+
+    /// Computes balanced `(sigma, nu)` dimensions directly from a max advice byte budget.
+    ///
+    /// - `max_advice_size_bytes` is interpreted as bytes of 64-bit words.
+    /// - Rounds word count up to the next power of two (minimum 1) and computes log2 as `advice_vars`.
+    /// - Returns `(sigma, nu)` where `sigma = ⌈advice_vars/2⌉` and `nu = advice_vars - sigma`.
+    #[inline]
+    pub fn advice_sigma_nu_from_max_bytes(max_advice_size_bytes: usize) -> (usize, usize) {
+        let words = max_advice_size_bytes / 8;
+        let len = words.next_power_of_two().max(1);
+        let advice_vars = len.log_2();
+        Self::balanced_sigma_nu(advice_vars)
+    }
+
+    /// How many row variables of the *cycle* segment exist in the unified point:
+    /// `row_cycle_len = max(0, log_t - sigma_main)`.
+    #[inline]
+    pub fn cycle_row_len(log_t: usize, sigma_main: usize) -> usize {
+        log_t.saturating_sub(sigma_main)
+    }
+
     /// Get the current Dory context
     pub fn current_context() -> DoryContext {
         CURRENT_CONTEXT.load(Ordering::SeqCst).into()
@@ -182,46 +221,34 @@ impl DoryGlobals {
             (side, side)
         } else {
             // Odd total vars: almost square (columns = 2*rows)
-            let sigma = total_vars.div_ceil(2);
-            let nu = total_vars - sigma;
+            let (sigma, nu) = Self::balanced_sigma_nu(total_vars);
             (1 << sigma, 1 << nu)
         };
 
         (num_columns, num_rows, T)
     }
 
-    /// Initialize the globals for the main Dory matrix
+    /// Initialize the globals for a specific Dory context
     ///
     /// # Arguments
     /// * `K` - Maximum address space size (K in OneHot polynomials)
     /// * `T` - Maximum trace length (cycle count)
+    /// * `context` - The Dory context to initialize (Main, TrustedAdvice, or UntrustedAdvice)
     ///
     /// The matrix dimensions are calculated to minimize padding:
     /// - If log2(K*T) is even: creates a square matrix
     /// - If log2(K*T) is odd: creates an almost-square matrix (columns = 2*rows)
-    pub fn initialize(K: usize, T: usize) -> Option<()> {
+    pub fn initialize_context(K: usize, T: usize, context: DoryContext) -> Option<()> {
         let (num_columns, num_rows, t) = Self::calculate_dimensions(K, T);
-        Self::set_num_columns_for_context(num_columns, DoryContext::Main);
-        Self::set_T_for_context(t, DoryContext::Main);
-        Self::set_max_num_rows_for_context(num_rows, DoryContext::Main);
-        Some(())
-    }
+        Self::set_num_columns_for_context(num_columns, context);
+        Self::set_T_for_context(t, context);
+        Self::set_max_num_rows_for_context(num_rows, context);
 
-    /// Initialize the globals for trusted advice commitments
-    pub fn initialize_trusted_advice(K: usize, T: usize) -> Option<()> {
-        let (num_columns, num_rows, t) = Self::calculate_dimensions(K, T);
-        Self::set_num_columns_for_context(num_columns, DoryContext::TrustedAdvice);
-        Self::set_T_for_context(t, DoryContext::TrustedAdvice);
-        Self::set_max_num_rows_for_context(num_rows, DoryContext::TrustedAdvice);
-        Some(())
-    }
+        // For Main context, ensure subsequent uses of `get_*` read from it by default
+        if context == DoryContext::Main {
+            CURRENT_CONTEXT.store(DoryContext::Main as u8, Ordering::SeqCst);
+        }
 
-    /// Initialize the globals for untrusted advice commitments
-    pub fn initialize_untrusted_advice(K: usize, T: usize) -> Option<()> {
-        let (num_columns, num_rows, t) = Self::calculate_dimensions(K, T);
-        Self::set_num_columns_for_context(num_columns, DoryContext::UntrustedAdvice);
-        Self::set_T_for_context(t, DoryContext::UntrustedAdvice);
-        Self::set_max_num_rows_for_context(num_rows, DoryContext::UntrustedAdvice);
         Some(())
     }
 

--- a/jolt-core/src/poly/commitment/dory/dory_globals.rs
+++ b/jolt-core/src/poly/commitment/dory/dory_globals.rs
@@ -84,7 +84,13 @@ impl DoryLayout {
     /// * `K` - Total number of addresses
     /// * `T` - Total number of cycles
     #[inline]
-    pub fn address_cycle_to_index(&self, address: usize, cycle: usize, K: usize, T: usize) -> usize {
+    pub fn address_cycle_to_index(
+        &self,
+        address: usize,
+        cycle: usize,
+        K: usize,
+        T: usize,
+    ) -> usize {
         match self {
             DoryLayout::CycleMajor => address * T + cycle,
             DoryLayout::AddressMajor => cycle * K + address,
@@ -118,7 +124,12 @@ impl DoryLayout {
     /// For dense polynomials, this is standard row-major indexing regardless of layout.
     /// The layout distinction primarily affects OneHot polynomial interpretation.
     #[inline]
-    pub fn index_to_position(&self, coeff_idx: usize, _num_rows: usize, num_cols: usize) -> (usize, usize) {
+    pub fn index_to_position(
+        &self,
+        coeff_idx: usize,
+        _num_rows: usize,
+        num_cols: usize,
+    ) -> (usize, usize) {
         // For dense polynomials, both layouts use row-major matrix storage
         let row = coeff_idx / num_cols;
         let col = coeff_idx % num_cols;
@@ -129,7 +140,13 @@ impl DoryLayout {
     ///
     /// For dense polynomials, this is standard row-major indexing regardless of layout.
     #[inline]
-    pub fn position_to_index(&self, row: usize, col: usize, _num_rows: usize, num_cols: usize) -> usize {
+    pub fn position_to_index(
+        &self,
+        row: usize,
+        col: usize,
+        _num_rows: usize,
+        num_cols: usize,
+    ) -> usize {
         // For dense polynomials, both layouts use row-major matrix storage
         row * num_cols + col
     }

--- a/jolt-core/src/poly/commitment/dory/dory_globals.rs
+++ b/jolt-core/src/poly/commitment/dory/dory_globals.rs
@@ -310,6 +310,28 @@ impl DoryGlobals {
         }
     }
 
+    /// Get the matrix dimension for AddressMajor layout.
+    /// For AddressMajor, the matrix is always square with dimension = sqrt(K*T).next_power_of_two()
+    /// This is equivalent to get_num_columns() since we compute square matrices.
+    #[inline]
+    pub fn get_dimension() -> usize {
+        Self::get_num_columns()
+    }
+
+    /// Get the number of cycles per row for the current layout.
+    /// - CycleMajor: cycles_per_row = 1 (each cell is one cycle)
+    /// - AddressMajor: cycles_per_row = T / dimension
+    #[inline]
+    pub fn get_cycles_per_row() -> usize {
+        let T = Self::get_T();
+        let dimension = Self::get_dimension();
+        if T >= dimension {
+            T / dimension
+        } else {
+            1
+        }
+    }
+
     fn set_T_for_context(t: usize, context: DoryContext) {
         #[allow(static_mut_refs)]
         unsafe {

--- a/jolt-core/src/poly/commitment/dory/mod.rs
+++ b/jolt-core/src/poly/commitment/dory/mod.rs
@@ -12,7 +12,7 @@ mod wrappers;
 mod tests;
 
 pub use commitment_scheme::DoryCommitmentScheme;
-pub use dory_globals::{DoryContext, DoryGlobals};
+pub use dory_globals::{DoryContext, DoryGlobals, DoryLayout};
 pub use jolt_dory_routines::{JoltG1Routines, JoltG2Routines};
 pub use wrappers::{
     ArkDoryProof, ArkFr, ArkG1, ArkG2, ArkGT, ArkworksProverSetup, ArkworksVerifierSetup,

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -4,6 +4,7 @@ mod tests {
     use super::super::*;
     use crate::field::JoltField;
     use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+    use crate::poly::commitment::dory::DoryContext;
     use crate::poly::dense_mlpoly::DensePolynomial;
     use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
     use crate::transcripts::{Blake2bTranscript, Transcript};
@@ -64,7 +65,7 @@ mod tests {
 
         let num_coeffs = 1 << num_vars;
         // Dense polynomial: K = 1, T = num_coeffs
-        let _guard = DoryGlobals::initialize(1, num_coeffs);
+        let _guard = DoryGlobals::initialize_context(1, num_coeffs, DoryContext::Main);
 
         let prover_setup = DoryCommitmentScheme::setup_prover(num_vars);
         let verifier_setup = DoryCommitmentScheme::setup_verifier(&prover_setup);
@@ -241,7 +242,7 @@ mod tests {
         let num_coeffs = 1 << num_vars;
 
         // Dense polynomial: K = 1, T = num_coeffs
-        let _guard = DoryGlobals::initialize(1, num_coeffs);
+        let _guard = DoryGlobals::initialize_context(1, num_coeffs, DoryContext::Main);
 
         let mut rng = thread_rng();
         let coeffs: Vec<Fr> = (0..num_coeffs).map(|_| Fr::rand(&mut rng)).collect();
@@ -385,7 +386,7 @@ mod tests {
         let K = 8;
         let T = 8;
 
-        let _guard = DoryGlobals::initialize(K, T);
+        let _guard = DoryGlobals::initialize_context(K, T, DoryContext::Main);
 
         let mut rng = thread_rng();
         let nonzero_indices: Vec<Option<u8>> = (0..T)
@@ -450,7 +451,7 @@ mod tests {
         let num_coeffs = 1 << num_vars;
         let num_polys = 5;
 
-        let _guard = DoryGlobals::initialize(1, num_coeffs);
+        let _guard = DoryGlobals::initialize_context(1, num_coeffs, DoryContext::Main);
 
         let mut rng = thread_rng();
 
@@ -534,7 +535,7 @@ mod tests {
         let num_coeffs = 1 << num_vars;
         let num_polys = 5;
 
-        let _guard = DoryGlobals::initialize(1, num_coeffs);
+        let _guard = DoryGlobals::initialize_context(1, num_coeffs, DoryContext::Main);
 
         let mut rng = thread_rng();
 

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -382,8 +382,9 @@ mod tests {
 
         DoryGlobals::reset();
 
-        let K = 8;
-        let T = 8;
+        // Use K*T = 1024 (num_vars = 10) to match other tests and avoid generator cache mismatch
+        let K = 32;
+        let T = 32;
 
         let _guard = DoryGlobals::initialize(K, T);
 
@@ -446,7 +447,8 @@ mod tests {
     fn test_dory_homomorphic_combination() {
         DoryGlobals::reset();
 
-        let num_vars = 8;
+        // Use num_vars = 10 to match other tests and avoid generator cache mismatch
+        let num_vars = 10;
         let num_coeffs = 1 << num_vars;
         let num_polys = 5;
 
@@ -530,7 +532,8 @@ mod tests {
     fn test_dory_batch_commit_e2e() {
         DoryGlobals::reset();
 
-        let num_vars = 8;
+        // Use num_vars = 10 to match other tests and avoid generator cache mismatch
+        let num_vars = 10;
         let num_coeffs = 1 << num_vars;
         let num_polys = 5;
 
@@ -719,7 +722,8 @@ mod tests {
     fn test_dory_layout_dense_polynomials_same_commitment() {
         DoryGlobals::reset();
 
-        let num_vars = 8;
+        // Use num_vars = 10 to match other tests and avoid generator cache mismatch
+        let num_vars = 10;
         let num_coeffs = 1 << num_vars;
 
         let _guard = DoryGlobals::initialize(1, num_coeffs);
@@ -745,6 +749,9 @@ mod tests {
             commitment_cycle_major, commitment_addr_major,
             "Dense polynomials should produce the same commitment with any layout"
         );
+
+        // Reset layout to default after test
+        DoryGlobals::set_layout(DoryLayout::CycleMajor);
     }
 
     /// Test that the layout enum correctly converts between address/cycle and index.

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -654,11 +654,11 @@ mod tests {
         let cycle_major = DoryLayout::CycleMajor;
 
         // Address 0: indices 0-7, Address 1: indices 8-15, etc.
-        assert_eq!(cycle_major.address_cycle_to_index(0, 0, K, T), 0);  // addr 0, cycle 0
-        assert_eq!(cycle_major.address_cycle_to_index(0, 1, K, T), 1);  // addr 0, cycle 1
-        assert_eq!(cycle_major.address_cycle_to_index(0, 7, K, T), 7);  // addr 0, cycle 7
-        assert_eq!(cycle_major.address_cycle_to_index(1, 0, K, T), 8);  // addr 1, cycle 0
-        assert_eq!(cycle_major.address_cycle_to_index(1, 1, K, T), 9);  // addr 1, cycle 1
+        assert_eq!(cycle_major.address_cycle_to_index(0, 0, K, T), 0); // addr 0, cycle 0
+        assert_eq!(cycle_major.address_cycle_to_index(0, 1, K, T), 1); // addr 0, cycle 1
+        assert_eq!(cycle_major.address_cycle_to_index(0, 7, K, T), 7); // addr 0, cycle 7
+        assert_eq!(cycle_major.address_cycle_to_index(1, 0, K, T), 8); // addr 1, cycle 0
+        assert_eq!(cycle_major.address_cycle_to_index(1, 1, K, T), 9); // addr 1, cycle 1
         assert_eq!(cycle_major.address_cycle_to_index(3, 7, K, T), 31); // addr 3, cycle 7
 
         // Test reverse: index_to_address_cycle
@@ -671,11 +671,11 @@ mod tests {
         let addr_major = DoryLayout::AddressMajor;
 
         // Cycle 0: indices 0-3, Cycle 1: indices 4-7, etc.
-        assert_eq!(addr_major.address_cycle_to_index(0, 0, K, T), 0);  // addr 0, cycle 0
-        assert_eq!(addr_major.address_cycle_to_index(1, 0, K, T), 1);  // addr 1, cycle 0
-        assert_eq!(addr_major.address_cycle_to_index(3, 0, K, T), 3);  // addr 3, cycle 0
-        assert_eq!(addr_major.address_cycle_to_index(0, 1, K, T), 4);  // addr 0, cycle 1
-        assert_eq!(addr_major.address_cycle_to_index(1, 1, K, T), 5);  // addr 1, cycle 1
+        assert_eq!(addr_major.address_cycle_to_index(0, 0, K, T), 0); // addr 0, cycle 0
+        assert_eq!(addr_major.address_cycle_to_index(1, 0, K, T), 1); // addr 1, cycle 0
+        assert_eq!(addr_major.address_cycle_to_index(3, 0, K, T), 3); // addr 3, cycle 0
+        assert_eq!(addr_major.address_cycle_to_index(0, 1, K, T), 4); // addr 0, cycle 1
+        assert_eq!(addr_major.address_cycle_to_index(1, 1, K, T), 5); // addr 1, cycle 1
         assert_eq!(addr_major.address_cycle_to_index(3, 7, K, T), 31); // addr 3, cycle 7
 
         // Test reverse: index_to_address_cycle
@@ -757,7 +757,7 @@ mod tests {
     /// Test that the layout enum correctly converts between address/cycle and index.
     #[test]
     fn test_dory_layout_enum_methods() {
-        let K = 8;  // addresses
+        let K = 8; // addresses
         let T = 16; // cycles
 
         let cycle_major = DoryLayout::CycleMajor;
@@ -780,7 +780,13 @@ mod tests {
         assert_ne!(idx_cycle, idx_addr);
 
         // But both can round-trip back to the same (address, cycle)
-        assert_eq!(cycle_major.index_to_address_cycle(idx_cycle, K, T), (addr, cycle));
-        assert_eq!(addr_major.index_to_address_cycle(idx_addr, K, T), (addr, cycle));
+        assert_eq!(
+            cycle_major.index_to_address_cycle(idx_cycle, K, T),
+            (addr, cycle)
+        );
+        assert_eq!(
+            addr_major.index_to_address_cycle(idx_addr, K, T),
+            (addr, cycle)
+        );
     }
 }

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -727,7 +727,7 @@ mod tests {
         let num_vars = 10;
         let num_coeffs = 1 << num_vars;
 
-        let _guard = DoryGlobals::initialize(1, num_coeffs);
+        let _ = DoryGlobals::initialize_context(1, num_coeffs, DoryContext::Main);
 
         let mut rng = thread_rng();
         let coeffs: Vec<Fr> = (0..num_coeffs).map(|_| Fr::rand(&mut rng)).collect();

--- a/jolt-core/src/poly/commitment/dory/wrappers.rs
+++ b/jolt-core/src/poly/commitment/dory/wrappers.rs
@@ -6,7 +6,7 @@ use crate::{
     poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
     transcripts::{AppendToTranscript, Transcript},
 };
-use ark_bn254::{Fr, G1Affine};
+use ark_bn254::{Fr, G1Affine, G1Projective};
 use ark_ec::CurveGroup;
 use ark_ff::Zero;
 use dory::{
@@ -107,9 +107,11 @@ impl DoryPolynomial<ArkFr> for MultilinearPolynomial<Fr> {
 impl MultilinearLagrange<ArkFr> for MultilinearPolynomial<Fr> {
     fn vector_matrix_product(&self, left_vec: &[ArkFr], nu: usize, sigma: usize) -> Vec<ArkFr> {
         use crate::utils::small_scalar::SmallScalar;
+        use super::dory_globals::DoryGlobals;
 
         let num_cols = 1 << sigma;
         let num_rows = 1 << nu;
+        let layout = DoryGlobals::get_layout();
 
         let wrapped_left_side: Vec<Fr> = left_vec.iter().map(ark_to_jolt).collect();
 
@@ -120,7 +122,7 @@ impl MultilinearLagrange<ArkFr> for MultilinearPolynomial<Fr> {
                     .map(|col_idx| {
                         let mut sum = Fr::zero();
                         for row_idx in 0..num_rows.min(wrapped_left_side.len()) {
-                            let coeff_idx = row_idx * num_cols + col_idx;
+                            let coeff_idx = layout.position_to_index(row_idx, col_idx, num_rows, num_cols);
                             if coeff_idx < $poly.len() {
                                 sum +=
                                     $poly[coeff_idx].$field_mul_method(wrapped_left_side[row_idx]);
@@ -138,7 +140,7 @@ impl MultilinearLagrange<ArkFr> for MultilinearPolynomial<Fr> {
                 .map(|col_idx| {
                     let mut sum = Fr::zero();
                     for row_idx in 0..num_rows.min(wrapped_left_side.len()) {
-                        let coeff_idx = row_idx * num_cols + col_idx;
+                        let coeff_idx = layout.position_to_index(row_idx, col_idx, num_rows, num_cols);
                         if coeff_idx < poly.Z.len() {
                             sum += poly.Z[coeff_idx] * wrapped_left_side[row_idx];
                         }
@@ -196,6 +198,8 @@ where
     E: PairingCurve,
     E::G1: DoryGroup<Scalar = ArkFr>,
 {
+    use super::dory_globals::{DoryGlobals, DoryLayout};
+
     // SAFETY: E::G1 and ArkG1 have the same memory layout when E = BN254.
     let g1_slice = unsafe {
         std::slice::from_raw_parts(g1_generators.as_ptr() as *const ArkG1, g1_generators.len())
@@ -209,7 +213,12 @@ where
         .map(|g| g.0.into_affine())
         .collect();
 
-    macro_rules! compute_msm {
+    let layout = DoryGlobals::get_layout();
+    let num_cols = row_len;
+
+    // For row-major layout, we can use efficient par_chunks.
+    // For column-major layout, we need to gather coefficients per row.
+    macro_rules! compute_msm_row_major {
         ($coeffs:expr, $msm_method:ident) => {
             $coeffs
                 .par_chunks(row_len)
@@ -218,36 +227,133 @@ where
         };
     }
 
-    let result: Vec<ArkG1> = match poly {
-        MultilinearPolynomial::LargeScalars(poly) => {
-            compute_msm!(&poly.Z, msm_field_elements)
-        }
-        MultilinearPolynomial::U8Scalars(poly) => compute_msm!(&poly.coeffs, msm_u8),
-        MultilinearPolynomial::U16Scalars(poly) => compute_msm!(&poly.coeffs, msm_u16),
-        MultilinearPolynomial::U32Scalars(poly) => compute_msm!(&poly.coeffs, msm_u32),
-        MultilinearPolynomial::U64Scalars(poly) => compute_msm!(&poly.coeffs, msm_u64),
-        MultilinearPolynomial::I64Scalars(poly) => compute_msm!(&poly.coeffs, msm_i64),
-        MultilinearPolynomial::I128Scalars(poly) => compute_msm!(&poly.coeffs, msm_i128),
-        MultilinearPolynomial::U128Scalars(poly) => compute_msm!(&poly.coeffs, msm_u128),
-        MultilinearPolynomial::S128Scalars(poly) => compute_msm!(&poly.coeffs, msm_s128),
-        MultilinearPolynomial::BoolScalars(poly) => poly
-            .coeffs
-            .par_chunks(row_len)
-            .map(|row| {
-                let result = row
-                    .iter()
-                    .zip(&bases[..row.len()])
-                    .filter_map(|(&b, base)| if b { Some(*base) } else { None })
-                    .sum();
-                ArkG1(result)
-            })
-            .collect(),
-        MultilinearPolynomial::OneHot(poly) => {
-            poly.commit_rows(&bases).into_iter().map(ArkG1).collect()
-        }
-        MultilinearPolynomial::RLC(poly) => {
-            poly.commit_rows(&bases).into_iter().map(ArkG1).collect()
-        }
+    macro_rules! compute_msm_column_major {
+        ($coeffs:expr, $msm_method:ident, $zero:expr) => {{
+            let num_rows = ($coeffs.len() + num_cols - 1) / num_cols;
+            (0..num_rows)
+                .into_par_iter()
+                .map(|row_idx| {
+                    // Gather coefficients for this row from column-major layout
+                    let row_coeffs: Vec<_> = (0..num_cols)
+                        .map(|col_idx| {
+                            let coeff_idx = col_idx * num_rows + row_idx;
+                            if coeff_idx < $coeffs.len() {
+                                $coeffs[coeff_idx]
+                            } else {
+                                $zero
+                            }
+                        })
+                        .collect();
+                    ArkG1(VariableBaseMSM::$msm_method(&bases, &row_coeffs).unwrap())
+                })
+                .collect()
+        }};
+    }
+
+    let result: Vec<ArkG1> = match layout {
+        DoryLayout::RowMajor => match poly {
+            MultilinearPolynomial::LargeScalars(poly) => {
+                compute_msm_row_major!(&poly.Z, msm_field_elements)
+            }
+            MultilinearPolynomial::U8Scalars(poly) => compute_msm_row_major!(&poly.coeffs, msm_u8),
+            MultilinearPolynomial::U16Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_u16)
+            }
+            MultilinearPolynomial::U32Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_u32)
+            }
+            MultilinearPolynomial::U64Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_u64)
+            }
+            MultilinearPolynomial::I64Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_i64)
+            }
+            MultilinearPolynomial::I128Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_i128)
+            }
+            MultilinearPolynomial::U128Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_u128)
+            }
+            MultilinearPolynomial::S128Scalars(poly) => {
+                compute_msm_row_major!(&poly.coeffs, msm_s128)
+            }
+            MultilinearPolynomial::BoolScalars(poly) => poly
+                .coeffs
+                .par_chunks(row_len)
+                .map(|row| {
+                    let result = row
+                        .iter()
+                        .zip(&bases[..row.len()])
+                        .filter_map(|(&b, base)| if b { Some(*base) } else { None })
+                        .sum();
+                    ArkG1(result)
+                })
+                .collect(),
+            MultilinearPolynomial::OneHot(poly) => {
+                poly.commit_rows(&bases).into_iter().map(ArkG1).collect()
+            }
+            MultilinearPolynomial::RLC(poly) => {
+                poly.commit_rows(&bases).into_iter().map(ArkG1).collect()
+            }
+        },
+        DoryLayout::ColumnMajor => match poly {
+            MultilinearPolynomial::LargeScalars(poly) => {
+                compute_msm_column_major!(&poly.Z, msm_field_elements, Fr::zero())
+            }
+            MultilinearPolynomial::U8Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_u8, 0u8)
+            }
+            MultilinearPolynomial::U16Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_u16, 0u16)
+            }
+            MultilinearPolynomial::U32Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_u32, 0u32)
+            }
+            MultilinearPolynomial::U64Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_u64, 0u64)
+            }
+            MultilinearPolynomial::I64Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_i64, 0i64)
+            }
+            MultilinearPolynomial::I128Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_i128, 0i128)
+            }
+            MultilinearPolynomial::U128Scalars(poly) => {
+                compute_msm_column_major!(&poly.coeffs, msm_u128, 0u128)
+            }
+            MultilinearPolynomial::S128Scalars(poly) => {
+                use ark_ff::biginteger::S128;
+                compute_msm_column_major!(&poly.coeffs, msm_s128, S128::from(0i128))
+            }
+            MultilinearPolynomial::BoolScalars(poly) => {
+                let num_rows = (poly.coeffs.len() + num_cols - 1) / num_cols;
+                (0..num_rows)
+                    .into_par_iter()
+                    .map(|row_idx| {
+                        let result: G1Projective = (0..num_cols)
+                            .filter_map(|col_idx| {
+                                let coeff_idx = col_idx * num_rows + row_idx;
+                                if coeff_idx < poly.coeffs.len() && poly.coeffs[coeff_idx] {
+                                    Some(bases[col_idx])
+                                } else {
+                                    None
+                                }
+                            })
+                            .map(G1Projective::from)
+                            .sum();
+                        ArkG1(result)
+                    })
+                    .collect()
+            }
+            // OneHot and RLC have their own layout handling - they use row-major internally
+            // For column-major layout, they would need separate implementation
+            MultilinearPolynomial::OneHot(poly) => {
+                poly.commit_rows(&bases).into_iter().map(ArkG1).collect()
+            }
+            MultilinearPolynomial::RLC(poly) => {
+                poly.commit_rows(&bases).into_iter().map(ArkG1).collect()
+            }
+        },
     };
 
     // SAFETY: Vec<ArkG1> and Vec<E::G1> have the same memory layout when E = BN254.

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -390,6 +390,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::poly::commitment::dory::DoryContext;
     use ark_bn254::Fr;
     use ark_std::test_rng;
     use rand_core::RngCore;
@@ -398,7 +399,8 @@ mod tests {
     fn evaluate_test<const LOG_K: usize, const LOG_T: usize>() {
         let K: usize = 1 << LOG_K;
         let T: usize = 1 << LOG_T;
-        let _guard = DoryGlobals::initialize(K, T);
+        DoryGlobals::reset();
+        let _guard = DoryGlobals::initialize_context(K, T, DoryContext::Main);
 
         let mut rng = test_rng();
 

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -221,8 +221,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
             .par_chunks_mut(chunk_size)
             .zip(row_indices.par_chunks(chunk_size))
             .for_each(|(result_chunk, indices_chunk)| {
-                let results =
-                    jolt_optimizations::batch_g1_additions_multi(g1_bases, indices_chunk);
+                let results = jolt_optimizations::batch_g1_additions_multi(g1_bases, indices_chunk);
 
                 for (row_result, (indices, batch_result)) in result_chunk
                     .iter_mut()

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     poly::rlc_polynomial::{RLCPolynomial, RLCStreamingData, TraceSource},
-    zkvm::config::OneHotParams,
+    zkvm::{claim_reductions::AdviceKind, config::OneHotParams},
 };
 use allocative::Allocative;
 use num_derive::FromPrimitive;
@@ -17,7 +17,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use super::{
-    commitment::commitment_scheme::CommitmentScheme, multilinear_polynomial::MultilinearPolynomial,
+    commitment::commitment_scheme::CommitmentScheme, eq_poly::EqPolynomial,
+    multilinear_polynomial::MultilinearPolynomial,
 };
 use crate::{
     field::JoltField,
@@ -154,6 +155,8 @@ pub enum SumcheckId {
     RegistersValEvaluation,
     BytecodeReadRaf,
     Booleanity,
+    AdviceClaimReductionPhase1,
+    AdviceClaimReductionPhase2,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
@@ -215,6 +218,12 @@ pub trait OpeningAccumulator<F: JoltField> {
         polynomial: CommittedPolynomial,
         sumcheck: SumcheckId,
     ) -> (OpeningPoint<BIG_ENDIAN, F>, F);
+
+    fn get_advice_opening(
+        &self,
+        kind: AdviceKind,
+        sumcheck: SumcheckId,
+    ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)>;
 }
 
 /// State for Dory batch opening (Stage 8).
@@ -233,6 +242,7 @@ pub struct DoryOpeningState<F: JoltField> {
 impl<F: JoltField> DoryOpeningState<F> {
     /// Build streaming RLC polynomial from this state.
     /// Streams directly from trace - no witness regeneration needed.
+    /// Advice polynomials are passed separately (not streamed from trace).
     #[tracing::instrument(skip_all)]
     pub fn build_streaming_rlc<PCS: CommitmentScheme<Field = F>>(
         &self,
@@ -240,6 +250,7 @@ impl<F: JoltField> DoryOpeningState<F> {
         trace_source: TraceSource,
         rlc_streaming_data: Arc<RLCStreamingData>,
         mut opening_hints: HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
+        advice_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
     ) -> (MultilinearPolynomial<F>, PCS::OpeningProofHint) {
         // Accumulate gamma coefficients per polynomial
         let mut rlc_map = BTreeMap::new();
@@ -256,6 +267,7 @@ impl<F: JoltField> DoryOpeningState<F> {
             trace_source,
             poly_ids.clone(),
             &coeffs,
+            advice_polys,
         ));
 
         let hints: Vec<PCS::OpeningProofHint> = rlc_map
@@ -312,6 +324,19 @@ impl<F: JoltField> OpeningAccumulator<F> for ProverOpeningAccumulator<F> {
             .unwrap_or_else(|| panic!("opening for {sumcheck:?} {polynomial:?} not found"));
         (point.clone(), *claim)
     }
+
+    fn get_advice_opening(
+        &self,
+        kind: AdviceKind,
+        sumcheck_id: SumcheckId,
+    ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)> {
+        let opening_id = match kind {
+            AdviceKind::Trusted => OpeningId::TrustedAdvice(sumcheck_id),
+            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(sumcheck_id),
+        };
+        let (point, claim) = self.openings.get(&opening_id)?;
+        Some((point.clone(), *claim))
+    }
 }
 
 impl<F> ProverOpeningAccumulator<F>
@@ -336,21 +361,16 @@ where
         self.openings.get(&key).unwrap().1
     }
 
-    pub fn get_untrusted_advice_opening(
+    pub fn get_advice_opening(
         &self,
+        kind: AdviceKind,
         sumcheck_id: SumcheckId,
     ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)> {
-        let (point, claim) = self
-            .openings
-            .get(&OpeningId::UntrustedAdvice(sumcheck_id))?;
-        Some((point.clone(), *claim))
-    }
-
-    pub fn get_trusted_advice_opening(
-        &self,
-        sumcheck_id: SumcheckId,
-    ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)> {
-        let (point, claim) = self.openings.get(&OpeningId::TrustedAdvice(sumcheck_id))?;
+        let opening_id = match kind {
+            AdviceKind::Trusted => OpeningId::TrustedAdvice(sumcheck_id),
+            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(sumcheck_id),
+        };
+        let (point, claim) = self.openings.get(&opening_id)?;
         Some((point.clone(), *claim))
     }
 
@@ -489,6 +509,19 @@ impl<F: JoltField> OpeningAccumulator<F> for VerifierOpeningAccumulator<F> {
             .unwrap_or_else(|| panic!("No opening found for {sumcheck:?} {polynomial:?}"));
         (point.clone(), *claim)
     }
+
+    fn get_advice_opening(
+        &self,
+        kind: AdviceKind,
+        sumcheck_id: SumcheckId,
+    ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)> {
+        let opening_id = match kind {
+            AdviceKind::Trusted => OpeningId::TrustedAdvice(sumcheck_id),
+            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(sumcheck_id),
+        };
+        let (point, claim) = self.openings.get(&opening_id)?;
+        Some((point.clone(), *claim))
+    }
 }
 
 impl<F> VerifierOpeningAccumulator<F>
@@ -511,21 +544,16 @@ where
         self.prover_opening_accumulator = Some(prover_openings);
     }
 
-    pub fn get_untrusted_advice_opening(
+    pub fn get_advice_opening(
         &self,
+        kind: AdviceKind,
         sumcheck_id: SumcheckId,
     ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)> {
-        let (point, claim) = self
-            .openings
-            .get(&OpeningId::UntrustedAdvice(sumcheck_id))?;
-        Some((point.clone(), *claim))
-    }
-
-    pub fn get_trusted_advice_opening(
-        &self,
-        sumcheck_id: SumcheckId,
-    ) -> Option<(OpeningPoint<BIG_ENDIAN, F>, F)> {
-        let (point, claim) = self.openings.get(&OpeningId::TrustedAdvice(sumcheck_id))?;
+        let opening_id = match kind {
+            AdviceKind::Trusted => OpeningId::TrustedAdvice(sumcheck_id),
+            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(sumcheck_id),
+        };
+        let (point, claim) = self.openings.get(&opening_id)?;
         Some((point.clone(), *claim))
     }
 
@@ -629,4 +657,50 @@ where
             panic!("Tried to populate opening point for non-existent key: {key:?}");
         }
     }
+}
+
+/// Computes the Lagrange factor for embedding a smaller "advice" polynomial into the top-left
+/// block of the main Dory matrix.
+///
+/// Advice polynomials have fewer variables than main polynomials. To batch them together,
+/// we embed advice in the top-left corner of the larger matrix and multiply by a Lagrange
+/// selector that is 1 on that block and 0 elsewhere:
+///
+/// ```text
+/// Lagrange factor = ∏_{i=nu_a..nu_main} (1 - r_rows[i]) × ∏_{i=sigma_a..sigma_main} (1 - r_cols[i])
+/// ```
+///
+/// # Arguments
+/// - `opening_point_be`: The unified opening point in big-endian order
+/// - `advice_vars`: Number of variables in the advice polynomial
+///
+/// # Returns
+/// The Lagrange factor as a field element
+pub fn compute_advice_lagrange_factor<F: JoltField>(
+    opening_point_be: &[F::Challenge],
+    advice_vars: usize,
+) -> F {
+    // Convert to little-endian (Dory order)
+    let mut r_le: Vec<F::Challenge> = opening_point_be.to_vec();
+    r_le.reverse();
+
+    // Derive main matrix dimensions from the unified point length
+    let total_vars = r_le.len();
+    let (sigma_main, _nu_main) =
+        crate::poly::commitment::dory::DoryGlobals::balanced_sigma_nu(total_vars);
+    let (r_cols, r_rows) = r_le.split_at(sigma_main);
+
+    // Advice dimensions (balanced policy)
+    let (sigma_a, nu_a) =
+        crate::poly::commitment::dory::DoryGlobals::balanced_sigma_nu(advice_vars);
+
+    // Row factor: eq(r_rows[nu_a..], [0, 0, ...]) = ∏(1 - r_rows[i]) for i >= nu_a
+    // This selects the "zero" vertex in the row dimension beyond the advice region
+    let row_factor = EqPolynomial::<F>::zero_selector(&r_rows[nu_a..]);
+
+    // Column factor: eq(r_cols[sigma_a..], [0, 0, ...]) = ∏(1 - r_cols[i]) for i >= sigma_a
+    // This selects the "zero" vertex in the column dimension beyond the advice region
+    let col_factor = EqPolynomial::<F>::zero_selector(&r_cols[sigma_a..]);
+
+    row_factor * col_factor
 }

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -378,7 +378,11 @@ impl<F: JoltField> RLCPolynomial<F> {
     }
 
     /// Vector-matrix product for dense polynomials with AddressMajor layout.
-    fn vector_matrix_product_dense_address_major(&self, left_vec: &[F], num_columns: usize) -> Vec<F> {
+    fn vector_matrix_product_dense_address_major(
+        &self,
+        left_vec: &[F],
+        num_columns: usize,
+    ) -> Vec<F> {
         let T = DoryGlobals::get_T();
         let num_rows = DoryGlobals::get_dimension();
         let row_len = num_columns;

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -23,7 +23,7 @@ use tracing::trace_span;
 
 #[derive(Clone, Debug)]
 pub struct RLCStreamingData {
-    pub bytecode: BytecodePreprocessing,
+    pub bytecode: Arc<BytecodePreprocessing>,
     pub memory_layout: MemoryLayout,
 }
 

--- a/jolt-core/src/subprotocols/sumcheck_prover.rs
+++ b/jolt-core/src/subprotocols/sumcheck_prover.rs
@@ -27,6 +27,15 @@ pub trait SumcheckInstanceProver<F: JoltField, T: Transcript>:
         self.get_params().num_rounds()
     }
 
+    /// Returns the global round offset (0-based) at which this instance becomes active in a
+    /// batched sumcheck of `max_num_rounds` total rounds.
+    ///
+    /// By default we preserve the existing "front-loaded" batching behavior: instances with fewer
+    /// rounds are active only in the **last** `num_rounds()` rounds.
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        max_num_rounds - self.num_rounds()
+    }
+
     /// Returns the initial claim of this sumcheck instance.
     fn input_claim(&self, accumulator: &ProverOpeningAccumulator<F>) -> F {
         self.get_params().input_claim(accumulator)

--- a/jolt-core/src/subprotocols/sumcheck_verifier.rs
+++ b/jolt-core/src/subprotocols/sumcheck_verifier.rs
@@ -21,6 +21,14 @@ pub trait SumcheckInstanceVerifier<F: JoltField, T: Transcript> {
         self.get_params().num_rounds()
     }
 
+    /// Returns the global round offset (0-based) at which this instance becomes active in a
+    /// batched sumcheck of `max_num_rounds` total rounds.
+    ///
+    /// Default preserves existing "front-loaded" batching behavior.
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        max_num_rounds - self.num_rounds()
+    }
+
     /// Returns the initial claim of this sumcheck instance.
     fn input_claim(&self, accumulator: &VerifierOpeningAccumulator<F>) -> F {
         self.get_params().input_claim(accumulator)

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -43,7 +43,7 @@ use common::constants::{REGISTER_COUNT, XLEN};
 use itertools::{zip_eq, Itertools};
 use rayon::prelude::*;
 use strum::{EnumCount, IntoEnumIterator};
-use tracer::instruction::{Cycle, Instruction, NormalizedInstruction};
+use tracer::instruction::{Cycle, Instruction};
 
 /// Number of batched read-checking sumchecks bespokely
 const N_STAGES: usize = 5;
@@ -98,7 +98,7 @@ const N_STAGES: usize = 5;
 /// First log(K) rounds bind address variables in chunks, aggregating per-stage address-only
 /// contributions; last log(T) rounds bind cycle variables via per-stage `GruenSplitEqPolynomial`s.
 #[derive(Allocative)]
-pub struct ReadRafSumcheckProver<F: JoltField> {
+pub struct BytecodeReadRafSumcheckProver<F: JoltField> {
     /// Per-stage address MLEs F_i(k) built from eq(r_cycle_stage_i, (chunk_index, j)),
     /// bound high-to-low during the address-binding phase.
     F: [MultilinearPolynomial<F>; N_STAGES],
@@ -115,17 +115,21 @@ pub struct ReadRafSumcheckProver<F: JoltField> {
     prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
     /// Final sumcheck claims of stage Val polynomials (with RAF Int folded where applicable).
     bound_val_evals: Option<[F; N_STAGES]>,
-    /// Program counter per cycle, used to materialize chunked RA polynomials.
-    pc: Vec<usize>,
-    pub params: ReadRafSumcheckParams<F>,
+    /// Trace for computing PCs on the fly in init_log_t_rounds.
+    #[allocative(skip)]
+    trace: Arc<Vec<Cycle>>,
+    /// Bytecode preprocessing for computing PCs.
+    #[allocative(skip)]
+    bytecode_preprocessing: Arc<BytecodePreprocessing>,
+    pub params: BytecodeReadRafSumcheckParams<F>,
 }
 
-impl<F: JoltField> ReadRafSumcheckProver<F> {
+impl<F: JoltField> BytecodeReadRafSumcheckProver<F> {
     #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckProver::initialize")]
     pub fn initialize(
-        params: ReadRafSumcheckParams<F>,
-        trace: &[Cycle],
-        bytecode_preprocessing: &BytecodePreprocessing,
+        params: BytecodeReadRafSumcheckParams<F>,
+        trace: Arc<Vec<Cycle>>,
+        bytecode_preprocessing: Arc<BytecodePreprocessing>,
     ) -> Self {
         let claim_per_stage = [
             params.rv_claims[0] + params.gamma_powers[5] * params.raf_claim,
@@ -135,45 +139,111 @@ impl<F: JoltField> ReadRafSumcheckProver<F> {
             params.rv_claims[4],
         ];
 
-        // Make each chunk len ~2x bytecode len to prevent allocating too much memory.
-        let chunk_n_vars = params.log_K + 1;
-        let chunk_size = 1 << chunk_n_vars;
-        let prefix_n_vars = params.r_cycles[0].len().saturating_sub(chunk_n_vars);
-        let eq_prefix_evals = params
-            .r_cycles
-            .each_ref()
-            .map(|r_cycle| EqPolynomial::evals(&r_cycle[..prefix_n_vars]));
+        // Two-table split-eq optimization for computing F[stage][k] = Σ_{c: PC(c)=k} eq(r_cycle, c).
+        //
+        // Double summation pattern:
+        //   F[stage][k] = Σ_{c_hi} E_hi[c_hi] × ( Σ_{c_lo : PC(c)=k} E_lo[c_lo] )
+        //
+        // Inner sum (over c_lo): ADDITIONS ONLY - accumulate E_lo contributions by PC
+        // Outer sum (over c_hi): ONE multiplication per touched PC, not per cycle
+        //
+        // This reduces multiplications from O(T × N_STAGES) to O(touched_PCs × out_len × N_STAGES)
+        let T = trace.len();
+        let K = params.K;
+        let log_T = params.log_T;
 
-        let F = trace
+        // Optimal split: sqrt(T) for balanced tables
+        let lo_bits = log_T / 2;
+        let hi_bits = log_T - lo_bits;
+        let in_len: usize = 1 << lo_bits; // E_lo size (inner loop)
+        let out_len: usize = 1 << hi_bits; // E_hi size (outer loop)
+
+        // Pre-compute E_hi[stage][c_hi] and E_lo[stage][c_lo] for all stages in parallel
+        let (E_hi, E_lo): ([Vec<F>; N_STAGES], [Vec<F>; N_STAGES]) = rayon::join(
+            || {
+                params
+                    .r_cycles
+                    .each_ref()
+                    .map(|r_cycle| EqPolynomial::evals(&r_cycle[..hi_bits]))
+            },
+            || {
+                params
+                    .r_cycles
+                    .each_ref()
+                    .map(|r_cycle| EqPolynomial::evals(&r_cycle[hi_bits..]))
+            },
+        );
+
+        // Process by c_hi blocks, distributing work evenly among threads
+        let num_threads = rayon::current_num_threads();
+        let chunk_size = out_len.div_ceil(num_threads);
+
+        // Double summation: outer sum over c_hi, inner sum over c_lo
+        let F: [Vec<F>; N_STAGES] = E_hi[0]
             .par_chunks(chunk_size)
             .enumerate()
-            .map(|(chunk_index, trace_chunk)| {
-                // Generate all eq(r_cycles[stage], (chunk_index, j)).
-                let eq_evals: [_; N_STAGES] = array::from_fn(|i| {
-                    let prefix_eval = Some(eq_prefix_evals[i][chunk_index]);
-                    let r_suffix = &params.r_cycles[i][prefix_n_vars..];
-                    EqPolynomial::evals_serial(r_suffix, prefix_eval)
-                });
+            .map(|(chunk_idx, chunk)| {
+                // Per-thread accumulators for final F
+                let mut partial: [Vec<F>; N_STAGES] =
+                    array::from_fn(|_| unsafe_allocate_zero_vec(K));
 
-                let mut res_per_stage: [_; N_STAGES] =
-                    array::from_fn(|_| unsafe_allocate_zero_vec::<F>(params.K));
+                // Per-c_hi inner accumulators (reused across c_hi iterations)
+                let mut inner: [Vec<F>; N_STAGES] = array::from_fn(|_| unsafe_allocate_zero_vec(K));
 
-                for (j, cycle) in trace_chunk.iter().enumerate() {
-                    let pc = bytecode_preprocessing.get_pc(cycle);
-                    for stage in 0..N_STAGES {
-                        res_per_stage[stage][pc] += eq_evals[stage][j]
+                // Track which PCs were touched in this c_hi block
+                let mut touched = Vec::with_capacity(in_len);
+
+                let chunk_start = chunk_idx * chunk_size;
+                for (local_idx, _) in chunk.iter().enumerate() {
+                    let c_hi = chunk_start + local_idx;
+                    let c_hi_base = c_hi * in_len;
+
+                    // Clear inner accumulators for touched PCs only
+                    for &k in &touched {
+                        for stage in 0..N_STAGES {
+                            inner[stage][k] = F::zero();
+                        }
+                    }
+                    touched.clear();
+
+                    // INNER SUM: accumulate E_lo by PC (ADDITIONS ONLY, no multiplications)
+                    for c_lo in 0..in_len {
+                        let c = c_hi_base + c_lo;
+                        if c >= T {
+                            break;
+                        }
+
+                        let pc = bytecode_preprocessing.get_pc(&trace[c]);
+
+                        // Track touched PCs (avoid duplicates with a simple check)
+                        if inner[0][pc].is_zero() {
+                            touched.push(pc);
+                        }
+
+                        // Accumulate E_lo contributions (addition only!)
+                        for stage in 0..N_STAGES {
+                            inner[stage][pc] += E_lo[stage][c_lo];
+                        }
+                    }
+
+                    // OUTER SUM: multiply by E_hi and add to partial (sparse)
+                    for &k in &touched {
+                        for stage in 0..N_STAGES {
+                            partial[stage][k] += E_hi[stage][c_hi] * inner[stage][k];
+                        }
                     }
                 }
 
-                res_per_stage
+                partial
             })
             .reduce(
-                || array::from_fn(|_| unsafe_allocate_zero_vec(params.K)),
+                || array::from_fn(|_| unsafe_allocate_zero_vec(K)),
                 |mut a, b| {
                     for stage in 0..N_STAGES {
-                        (&mut a[stage], &b[stage])
-                            .into_par_iter()
-                            .for_each(|(a, b)| *a += *b)
+                        a[stage]
+                            .par_iter_mut()
+                            .zip(b[stage].par_iter())
+                            .for_each(|(a, b)| *a += *b);
                     }
                     a
                 },
@@ -209,21 +279,16 @@ impl<F: JoltField> ReadRafSumcheckProver<F> {
             .each_ref()
             .map(|r_cycle| GruenSplitEqPolynomial::new(r_cycle, BindingOrder::LowToHigh));
 
-        let pc = trace
-            .par_iter()
-            .map(|cycle| bytecode_preprocessing.get_pc(cycle))
-            .collect();
-
         Self {
             F,
             ra: Vec::with_capacity(params.d),
             r_address_prime: Vec::with_capacity(params.log_K),
-            // eq_polys,
             gruen_eq_polys,
             prev_round_claims: claim_per_stage,
             prev_round_polys: None,
             bound_val_evals: None,
-            pc,
+            trace,
+            bytecode_preprocessing,
             params,
         }
     }
@@ -259,31 +324,47 @@ impl<F: JoltField> ReadRafSumcheckProver<F> {
         );
 
         // Reverse r_address_prime to get the correct order (it was built low-to-high)
-        let mut r_address = self.r_address_prime.clone();
+        let mut r_address = std::mem::take(&mut self.r_address_prime);
         r_address.reverse();
+
+        // Drop log_K phase data that's no longer needed (val_polys reduced to bound_val_evals)
+        // F polynomials are fully bound and can be dropped
+        self.F = array::from_fn(|_| MultilinearPolynomial::default());
+        // val_polys are reduced to scalars in bound_val_evals
+        self.params.val_polys = array::from_fn(|_| MultilinearPolynomial::default());
+        // int_poly is reduced to a scalar
+        self.params.int_poly = IdentityPolynomial::new(0);
 
         let r_address_chunks = self
             .params
             .one_hot_params
             .compute_r_address_chunks::<F>(&r_address);
 
-        // Use the computed chunks to build RA polynomials
+        // Build RA polynomials by iterating over trace and computing PCs on the fly
         self.ra = r_address_chunks
             .iter()
             .enumerate()
             .map(|(i, r_address_chunk)| {
                 let ra_i: Vec<Option<u8>> = self
-                    .pc
+                    .trace
                     .par_iter()
-                    .map(|pc| Some(self.params.one_hot_params.bytecode_pc_chunk(*pc, i)))
+                    .map(|cycle| {
+                        let pc = self.bytecode_preprocessing.get_pc(cycle);
+                        Some(self.params.one_hot_params.bytecode_pc_chunk(pc, i))
+                    })
                     .collect();
                 RaPolynomial::new(Arc::new(ra_i), EqPolynomial::evals(r_address_chunk))
             })
             .collect();
+
+        // Drop trace and preprocessing - no longer needed after this
+        self.trace = Arc::new(Vec::new());
     }
 }
 
-impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafSumcheckProver<F> {
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for BytecodeReadRafSumcheckProver<F>
+{
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params
     }
@@ -417,7 +498,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafSumche
             // Obtain round poly for each stage and perform RLC.
             for (stage, evals) in evals_per_stage.iter().enumerate() {
                 let claim = self.prev_round_claims[stage];
-                let round_poly = self.gruen_eq_polys[stage].compute_round_poly(evals, claim);
+                let round_poly = self.gruen_eq_polys[stage].gruen_poly_from_evals(evals, claim);
                 agg_round_poly += &(&round_poly * self.params.gamma_powers[stage]);
                 round_polys[stage] = round_poly;
             }
@@ -492,11 +573,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafSumche
     }
 }
 
-pub struct ReadRafSumcheckVerifier<F: JoltField> {
-    params: ReadRafSumcheckParams<F>,
+pub struct BytecodeReadRafSumcheckVerifier<F: JoltField> {
+    params: BytecodeReadRafSumcheckParams<F>,
 }
 
-impl<F: JoltField> ReadRafSumcheckVerifier<F> {
+impl<F: JoltField> BytecodeReadRafSumcheckVerifier<F> {
     pub fn gen(
         bytecode_preprocessing: &BytecodePreprocessing,
         n_cycle_vars: usize,
@@ -505,7 +586,7 @@ impl<F: JoltField> ReadRafSumcheckVerifier<F> {
         transcript: &mut impl Transcript,
     ) -> Self {
         Self {
-            params: ReadRafSumcheckParams::gen(
+            params: BytecodeReadRafSumcheckParams::gen(
                 bytecode_preprocessing,
                 n_cycle_vars,
                 one_hot_params,
@@ -516,7 +597,9 @@ impl<F: JoltField> ReadRafSumcheckVerifier<F> {
     }
 }
 
-impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReadRafSumcheckVerifier<F> {
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
+    for BytecodeReadRafSumcheckVerifier<F>
+{
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params
     }
@@ -602,7 +685,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T> for ReadRafSumc
 }
 
 #[derive(Allocative, Clone)]
-pub struct ReadRafSumcheckParams<F: JoltField> {
+pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
     /// Index `i` stores `gamma^i`.
     pub gamma_powers: Vec<F>,
     /// RLC of stage rv_claims and RAF claims (per Stage1/Stage3) used as the sumcheck LHS.
@@ -627,7 +710,8 @@ pub struct ReadRafSumcheckParams<F: JoltField> {
     pub r_cycles: [Vec<F::Challenge>; N_STAGES],
 }
 
-impl<F: JoltField> ReadRafSumcheckParams<F> {
+impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
+    #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckParams::gen")]
     pub fn gen(
         bytecode_preprocessing: &BytecodePreprocessing,
         n_cycle_vars: usize,
@@ -638,46 +722,56 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
         let gamma_powers = transcript.challenge_scalar_powers(7);
 
         let bytecode = &bytecode_preprocessing.bytecode;
-        let (val_1, rv_claim_1) = Self::compute_val_rv(
-            bytecode,
-            opening_accumulator,
-            ReadCheckingValType::Stage1,
-            transcript,
-        );
-        let (val_2, rv_claim_2) = Self::compute_val_rv(
-            bytecode,
-            opening_accumulator,
-            ReadCheckingValType::Stage2,
-            transcript,
-        );
-        let (val_3, rv_claim_3) = Self::compute_val_rv(
-            bytecode,
-            opening_accumulator,
-            ReadCheckingValType::Stage3,
-            transcript,
-        );
-        let (val_4, rv_claim_4) = Self::compute_val_rv(
-            bytecode,
-            opening_accumulator,
-            ReadCheckingValType::Stage4,
-            transcript,
-        );
-        let (val_5, rv_claim_5) = Self::compute_val_rv(
-            bytecode,
-            opening_accumulator,
-            ReadCheckingValType::Stage5,
-            transcript,
-        );
-        let rv_claims = [rv_claim_1, rv_claim_2, rv_claim_3, rv_claim_4, rv_claim_5];
-        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_k.log_2());
 
-        let val_polys = [
-            MultilinearPolynomial::from(val_1),
-            MultilinearPolynomial::from(val_2),
-            MultilinearPolynomial::from(val_3),
-            MultilinearPolynomial::from(val_4),
-            MultilinearPolynomial::from(val_5),
-        ];
+        // Generate all stage-specific gamma powers upfront (order must match verifier)
+        let stage1_gammas: Vec<F> = transcript.challenge_scalar_powers(2 + NUM_CIRCUIT_FLAGS);
+        let stage2_gammas: Vec<F> = transcript.challenge_scalar_powers(4);
+        let stage3_gammas: Vec<F> = transcript.challenge_scalar_powers(9);
+        let stage4_gammas: Vec<F> = transcript.challenge_scalar_powers(3);
+        let stage5_gammas: Vec<F> = transcript.challenge_scalar_powers(2 + NUM_LOOKUP_TABLES);
+
+        // Compute rv_claims (these don't iterate bytecode, just query opening accumulator)
+        let rv_claim_1 = Self::compute_rv_claim_1(opening_accumulator, &stage1_gammas);
+        let rv_claim_2 = Self::compute_rv_claim_2(opening_accumulator, &stage2_gammas);
+        let rv_claim_3 = Self::compute_rv_claim_3(opening_accumulator, &stage3_gammas);
+        let rv_claim_4 = Self::compute_rv_claim_4(opening_accumulator, &stage4_gammas);
+        let rv_claim_5 = Self::compute_rv_claim_5(opening_accumulator, &stage5_gammas);
+        let rv_claims = [rv_claim_1, rv_claim_2, rv_claim_3, rv_claim_4, rv_claim_5];
+
+        // Pre-compute eq_r_register for stages 4 and 5 (they use different r_register points)
+        let r_register_4 = opening_accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::RdWa,
+                SumcheckId::RegistersReadWriteChecking,
+            )
+            .0
+            .r;
+        let eq_r_register_4 =
+            EqPolynomial::<F>::evals(&r_register_4[..(REGISTER_COUNT as usize).log_2()]);
+
+        let r_register_5 = opening_accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::RdWa,
+                SumcheckId::RegistersValEvaluation,
+            )
+            .0
+            .r;
+        let eq_r_register_5 =
+            EqPolynomial::<F>::evals(&r_register_5[..(REGISTER_COUNT as usize).log_2()]);
+
+        // Fused pass: compute all val polynomials in a single parallel iteration
+        let val_polys = Self::compute_val_polys(
+            bytecode,
+            &eq_r_register_4,
+            &eq_r_register_5,
+            &stage1_gammas,
+            &stage2_gammas,
+            &stage3_gammas,
+            &stage4_gammas,
+            &stage5_gammas,
+        );
+
+        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_k.log_2());
 
         let (_, raf_claim) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::PC, SumcheckId::SpartanOuter);
@@ -744,83 +838,166 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
         }
     }
 
-    fn compute_val_rv(
+    /// Fused computation of all Val polynomials in a single parallel pass over bytecode.
+    ///
+    /// This computes all 5 stage-specific Val(k) polynomials simultaneously, avoiding
+    /// 5 separate passes through the bytecode. Each stage has its own gamma powers
+    /// and formula for Val(k).
+    #[allow(clippy::too_many_arguments)]
+    fn compute_val_polys(
         bytecode: &[Instruction],
-        opening_accumulator: &dyn OpeningAccumulator<F>,
-        val_type: ReadCheckingValType,
-        transcript: &mut impl Transcript,
-    ) -> (Vec<F>, F) {
-        match val_type {
-            ReadCheckingValType::Stage1 => {
-                let gamma_powers = transcript.challenge_scalar_powers(2 + NUM_CIRCUIT_FLAGS);
-                (
-                    Self::compute_val_1(bytecode, &gamma_powers),
-                    Self::compute_rv_claim_1(opening_accumulator, &gamma_powers),
-                )
-            }
-            ReadCheckingValType::Stage2 => {
-                let gamma_powers = transcript.challenge_scalar_powers(4);
-                (
-                    Self::compute_val_2(bytecode, &gamma_powers),
-                    Self::compute_rv_claim_2(opening_accumulator, &gamma_powers),
-                )
-            }
-            ReadCheckingValType::Stage3 => {
-                let gamma_powers = transcript.challenge_scalar_powers(9);
-                (
-                    Self::compute_val_3(bytecode, &gamma_powers),
-                    Self::compute_rv_claim_3(opening_accumulator, &gamma_powers),
-                )
-            }
-            ReadCheckingValType::Stage4 => {
-                let gamma_powers = transcript.challenge_scalar_powers(3);
-                (
-                    Self::compute_val_4(bytecode, opening_accumulator, &gamma_powers),
-                    Self::compute_rv_claim_4(opening_accumulator, &gamma_powers),
-                )
-            }
-            ReadCheckingValType::Stage5 => {
-                let gamma_powers = transcript.challenge_scalar_powers(2 + NUM_LOOKUP_TABLES);
-                (
-                    Self::compute_val_5(bytecode, opening_accumulator, &gamma_powers),
-                    Self::compute_rv_claim_5(opening_accumulator, &gamma_powers),
-                )
-            }
-        }
-    }
+        eq_r_register_4: &[F],
+        eq_r_register_5: &[F],
+        stage1_gammas: &[F],
+        stage2_gammas: &[F],
+        stage3_gammas: &[F],
+        stage4_gammas: &[F],
+        stage5_gammas: &[F],
+    ) -> [MultilinearPolynomial<F>; N_STAGES] {
+        let K = bytecode.len();
 
-    /// Returns a vec of evaluations:
-    ///    Val(k) = unexpanded_pc(k) + gamma * imm(k)
-    ///             + gamma^2 * circuit_flags[0](k) + gamma^3 * circuit_flags[1](k) + ...
-    /// This particular Val virtualizes claims output by Spartan's "outer" sumcheck
-    fn compute_val_1(bytecode: &[Instruction], gamma_powers: &[F]) -> Vec<F> {
+        // Pre-allocate output vectors for each stage
+        let mut vals: [Vec<F>; N_STAGES] = array::from_fn(|_| unsafe_allocate_zero_vec(K));
+        let [v0, v1, v2, v3, v4] = &mut vals;
+
+        // Fused parallel iteration: compute all 5 val entries for each instruction
         bytecode
             .par_iter()
-            .map(|instruction| {
-                let NormalizedInstruction {
-                    address: unexpanded_pc,
-                    operands,
-                    ..
-                } = instruction.normalize();
+            .zip(v0.par_iter_mut())
+            .zip(v1.par_iter_mut())
+            .zip(v2.par_iter_mut())
+            .zip(v3.par_iter_mut())
+            .zip(v4.par_iter_mut())
+            .for_each(|(((((instruction, o0), o1), o2), o3), o4)| {
+                let instr = instruction.normalize();
+                let circuit_flags = instruction.circuit_flags();
+                let instr_flags = instruction.instruction_flags();
 
-                let mut linear_combination = F::zero();
-                linear_combination += F::from_u64(unexpanded_pc as u64);
-                linear_combination += operands.imm.field_mul(gamma_powers[1]);
-                let flags = instruction.circuit_flags();
-                // sanity check
-                assert!(
-                    !flags[CircuitFlags::IsCompressed]
-                        || !flags[CircuitFlags::DoNotUpdateUnexpandedPC]
-                );
-                for (flag, gamma_power) in flags.iter().zip(gamma_powers[2..].iter()) {
-                    if *flag {
-                        linear_combination += *gamma_power;
+                // ===== Stage 1 (Spartan outer sumcheck) =====
+                // Val(k) = unexpanded_pc(k) + γ·imm(k)
+                //          + γ²·circuit_flags[0](k) + γ³·circuit_flags[1](k) + ...
+                // This virtualizes claims output by Spartan's "outer" sumcheck.
+                {
+                    let mut lc = F::from_u64(instr.address as u64);
+                    lc += instr.operands.imm.field_mul(stage1_gammas[1]);
+                    // sanity check
+                    debug_assert!(
+                        !circuit_flags[CircuitFlags::IsCompressed]
+                            || !circuit_flags[CircuitFlags::DoNotUpdateUnexpandedPC]
+                    );
+                    for (flag, gamma_power) in circuit_flags.iter().zip(stage1_gammas[2..].iter()) {
+                        if *flag {
+                            lc += *gamma_power;
+                        }
                     }
+                    *o0 = lc;
                 }
 
-                linear_combination
-            })
-            .collect()
+                // ===== Stage 2 (product virtualization, de-duplicated factors) =====
+                // Val(k) = jump_flag(k) + γ·branch_flag(k)
+                //          + γ²·is_rd_not_zero_flag(k) + γ³·write_lookup_output_to_rd_flag(k)
+                // where jump_flag(k) = 1 if instruction k is a jump, 0 otherwise;
+                //       branch_flag(k) = 1 if instruction k is a branch, 0 otherwise;
+                //       is_rd_not_zero_flag(k) = 1 if instruction k has rd != 0;
+                //       write_lookup_output_to_rd_flag(k) = 1 if instruction k writes lookup output to rd.
+                // This Val matches the fused product sumcheck.
+                {
+                    let mut lc = F::zero();
+                    if circuit_flags[CircuitFlags::Jump] {
+                        lc += stage2_gammas[0];
+                    }
+                    if instr_flags[InstructionFlags::Branch] {
+                        lc += stage2_gammas[1];
+                    }
+                    if instr_flags[InstructionFlags::IsRdNotZero] {
+                        lc += stage2_gammas[2];
+                    }
+                    if circuit_flags[CircuitFlags::WriteLookupOutputToRD] {
+                        lc += stage2_gammas[3];
+                    }
+                    *o1 = lc;
+                }
+
+                // ===== Stage 3 (Shift sumcheck) =====
+                // Val(k) = imm(k) + γ·unexpanded_pc(k)
+                //          + γ²·left_operand_is_rs1_value(k) + γ³·left_operand_is_pc(k)
+                //          + γ⁴·right_operand_is_rs2_value(k) + γ⁵·right_operand_is_imm(k)
+                //          + γ⁶·is_noop(k) + γ⁷·virtual_instruction(k) + γ⁸·is_first_in_sequence(k)
+                // This virtualizes claims output by the ShiftSumcheck.
+                {
+                    let mut lc = F::from_i128(instr.operands.imm);
+                    lc += stage3_gammas[1].mul_u64(instr.address as u64);
+                    if instr_flags[InstructionFlags::LeftOperandIsRs1Value] {
+                        lc += stage3_gammas[2];
+                    }
+                    if instr_flags[InstructionFlags::LeftOperandIsPC] {
+                        lc += stage3_gammas[3];
+                    }
+                    if instr_flags[InstructionFlags::RightOperandIsRs2Value] {
+                        lc += stage3_gammas[4];
+                    }
+                    if instr_flags[InstructionFlags::RightOperandIsImm] {
+                        lc += stage3_gammas[5];
+                    }
+                    if instr_flags[InstructionFlags::IsNoop] {
+                        lc += stage3_gammas[6];
+                    }
+                    if circuit_flags[CircuitFlags::VirtualInstruction] {
+                        lc += stage3_gammas[7];
+                    }
+                    if circuit_flags[CircuitFlags::IsFirstInSequence] {
+                        lc += stage3_gammas[8];
+                    }
+                    *o2 = lc;
+                }
+
+                // ===== Stage 4 (registers read/write checking sumcheck) =====
+                // Val(k) = eq(rd(k), r_register) + γ·eq(rs1(k), r_register) + γ²·eq(rs2(k), r_register)
+                // where rd(k, r) = 1 if the k'th instruction in the bytecode has rd = r,
+                // and analogously for rs1(k, r) and rs2(k, r).
+                // This virtualizes claims output by the registers read/write checking sumcheck.
+                {
+                    let rd_eq = instr
+                        .operands
+                        .rd
+                        .map_or(F::zero(), |r| eq_r_register_4[r as usize]);
+                    let rs1_eq = instr
+                        .operands
+                        .rs1
+                        .map_or(F::zero(), |r| eq_r_register_4[r as usize]);
+                    let rs2_eq = instr
+                        .operands
+                        .rs2
+                        .map_or(F::zero(), |r| eq_r_register_4[r as usize]);
+                    *o3 = rd_eq * stage4_gammas[0]
+                        + rs1_eq * stage4_gammas[1]
+                        + rs2_eq * stage4_gammas[2];
+                }
+
+                // ===== Stage 5 (registers val-evaluation + instruction lookups sumcheck) =====
+                // Val(k) = eq(rd(k), r_register) + γ·raf_flag(k)
+                //          + γ²·lookup_table_flag[0](k) + γ³·lookup_table_flag[1](k) + ...
+                // where rd(k, r) = 1 if the k'th instruction in the bytecode has rd = r,
+                // and raf_flag(k) = 1 if instruction k is NOT interleaved operands.
+                // This virtualizes the claim output by the registers val-evaluation sumcheck
+                // and the instruction lookups sumcheck.
+                {
+                    let mut lc = instr
+                        .operands
+                        .rd
+                        .map_or(F::zero(), |r| eq_r_register_5[r as usize]);
+                    if !circuit_flags.is_interleaved_operands() {
+                        lc += stage5_gammas[1];
+                    }
+                    if let Some(table) = instruction.lookup_table() {
+                        let table_index = LookupTables::enum_index(&table);
+                        lc += stage5_gammas[2 + table_index];
+                    }
+                    *o4 = lc;
+                }
+            });
+
+        vals.map(MultilinearPolynomial::from)
     }
 
     fn compute_rv_claim_1(
@@ -851,42 +1028,6 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
             .zip_eq(gamma_powers)
             .map(|(claim, gamma)| claim * gamma)
             .sum()
-    }
-
-    /// Returns a vec of evaluations (de-duplicated factors after product virtualization):
-    ///    Val(k) = jump_flag(k)
-    ///             + gamma * branch_flag(k)
-    ///             + gamma^2 * is_rd_not_zero_flag(k)
-    ///             + gamma^3 * write_lookup_output_to_rd_flag(k)
-    /// where jump_flag(k) = 1 if instruction k is a jump, 0 otherwise;
-    ///       branch_flag(k) = 1 if instruction k is a branch, 0 otherwise;
-    ///       rd_addr(k) is the rd address for instruction k;
-    ///       write_lookup_output_to_rd_flag(k) = 1 if instruction k writes lookup output to rd, 0 otherwise.
-    /// This Val matches the fused product sumcheck.
-    fn compute_val_2(bytecode: &[Instruction], gamma_powers: &[F]) -> Vec<F> {
-        bytecode
-            .par_iter()
-            .map(|instruction| {
-                let flags = instruction.circuit_flags();
-                let instr_flags = instruction.instruction_flags();
-                let mut linear_combination = F::zero();
-
-                if flags[CircuitFlags::Jump] {
-                    linear_combination += gamma_powers[0];
-                }
-                if instr_flags[InstructionFlags::Branch] {
-                    linear_combination += gamma_powers[1];
-                }
-                if instr_flags[InstructionFlags::IsRdNotZero] {
-                    linear_combination += gamma_powers[2];
-                }
-                if flags[CircuitFlags::WriteLookupOutputToRD] {
-                    linear_combination += gamma_powers[3];
-                }
-
-                linear_combination
-            })
-            .collect()
     }
 
     fn compute_rv_claim_2(
@@ -921,51 +1062,6 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
         .zip_eq(gamma_powers)
         .map(|(claim, gamma)| claim * gamma)
         .sum()
-    }
-
-    /// Returns a vec of evaluations:
-    ///    Val(k) = imm(k) + gamma * unexpanded_pc(k)
-    ///             + gamma^2 * left_operand_is_rs1_value(k)
-    ///             + gamma^3 * left_operand_is_pc(k) + ...
-    /// This particular Val virtualizes claims output by the ShiftSumcheck.
-    fn compute_val_3(bytecode: &[Instruction], gamma_powers: &[F]) -> Vec<F> {
-        bytecode
-            .par_iter()
-            .map(|instruction| {
-                let instr = instruction.normalize();
-                let instr_flags = instruction.instruction_flags();
-                let circuit_flags = instruction.circuit_flags();
-                let unexpanded_pc = instr.address;
-                let imm = instr.operands.imm;
-
-                let mut linear_combination: F = F::from_i128(imm);
-                linear_combination += gamma_powers[1].mul_u64(unexpanded_pc as u64);
-
-                if instr_flags[InstructionFlags::LeftOperandIsRs1Value] {
-                    linear_combination += gamma_powers[2];
-                }
-                if instr_flags[InstructionFlags::LeftOperandIsPC] {
-                    linear_combination += gamma_powers[3];
-                }
-                if instr_flags[InstructionFlags::RightOperandIsRs2Value] {
-                    linear_combination += gamma_powers[4];
-                }
-                if instr_flags[InstructionFlags::RightOperandIsImm] {
-                    linear_combination += gamma_powers[5];
-                }
-                if instr_flags[InstructionFlags::IsNoop] {
-                    linear_combination += gamma_powers[6];
-                }
-                if circuit_flags[CircuitFlags::VirtualInstruction] {
-                    linear_combination += gamma_powers[7];
-                }
-                if circuit_flags[CircuitFlags::IsFirstInSequence] {
-                    linear_combination += gamma_powers[8];
-                }
-
-                linear_combination
-            })
-            .collect()
     }
 
     fn compute_rv_claim_3(
@@ -1039,50 +1135,6 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
         .sum()
     }
 
-    /// Returns a vec of evaluations:
-    ///    Val(k) = rd(k, r_register) + gamma * rs1(k, r_register) + gamma^2 * rs2(k, r_register)
-    /// where rd(k, k') = 1 if the k'th instruction in the bytecode has rd = k'
-    /// and analogously for rs1(k, k') and rs2(k, k').
-    /// This particular Val virtualizes claims output by the registers read/write checking sumcheck.
-    fn compute_val_4(
-        bytecode: &[Instruction],
-        opening_accumulator: &dyn OpeningAccumulator<F>,
-        gamma_powers: &[F],
-    ) -> Vec<F> {
-        let r_register = opening_accumulator
-            .get_virtual_polynomial_opening(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersReadWriteChecking,
-            )
-            .0
-            .r;
-        let r_register = &r_register[..(REGISTER_COUNT as usize).log_2()];
-        let eq_r_register = EqPolynomial::<F>::evals(r_register);
-        debug_assert_eq!(eq_r_register.len(), REGISTER_COUNT as usize);
-
-        bytecode
-            .par_iter()
-            .map(|instruction| {
-                let instr = instruction.normalize();
-
-                std::iter::empty()
-                    .chain(once(instr.operands.rd))
-                    .chain(once(instr.operands.rs1))
-                    .chain(once(instr.operands.rs2))
-                    .map(|r| {
-                        if let Some(r) = r {
-                            eq_r_register[r as usize]
-                        } else {
-                            F::zero()
-                        }
-                    })
-                    .zip(gamma_powers)
-                    .map(|(claim, gamma)| claim * gamma)
-                    .sum::<F>()
-            })
-            .collect()
-    }
-
     fn compute_rv_claim_4(
         opening_accumulator: &dyn OpeningAccumulator<F>,
         gamma_powers: &[F],
@@ -1099,53 +1151,6 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
             .zip(gamma_powers)
             .map(|(claim, gamma)| claim * gamma)
             .sum::<F>()
-    }
-
-    /// Returns a vec of evaluations:
-    ///    Val(k) = rd(k, r_register) + gamma * raf_flag(k)
-    ///             + gamma^2 * lookup_table_flag[0](k) + gamma^3 * lookup_table_flag[1](k) + ...
-    /// where rd(k, k') = 1 if the k'th instruction in the bytecode has rd = k'
-    /// and raf_flag(k) = 1 if instruction k is NOT interleaved operands
-    /// This particular Val virtualizes the claim output by the registers val-evaluation sumcheck
-    /// and the instruction lookups sumcheck.
-    fn compute_val_5(
-        bytecode: &[Instruction],
-        opening_accumulator: &dyn OpeningAccumulator<F>,
-        gamma_powers: &[F],
-    ) -> Vec<F> {
-        let r_register = opening_accumulator
-            .get_virtual_polynomial_opening(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersValEvaluation,
-            )
-            .0
-            .r;
-        let r_register: Vec<_> = r_register[..(REGISTER_COUNT as usize).log_2()].to_vec();
-        let eq_r_register = EqPolynomial::evals(&r_register);
-        debug_assert_eq!(eq_r_register.len(), REGISTER_COUNT as usize);
-
-        bytecode
-            .par_iter()
-            .map(|instruction| {
-                let instr = instruction.normalize();
-                let flags = instruction.circuit_flags();
-                let mut linear_combination = F::zero();
-                if let Some(rd) = instr.operands.rd {
-                    linear_combination += eq_r_register[rd as usize];
-                }
-
-                if !flags.is_interleaved_operands() {
-                    linear_combination += gamma_powers[1];
-                }
-
-                if let Some(table) = instruction.lookup_table() {
-                    let table_index = LookupTables::enum_index(&table);
-                    linear_combination += gamma_powers[2 + table_index];
-                }
-
-                linear_combination
-            })
-            .collect()
     }
 
     fn compute_rv_claim_5(
@@ -1178,7 +1183,7 @@ impl<F: JoltField> ReadRafSumcheckParams<F> {
     }
 }
 
-impl<F: JoltField> SumcheckInstanceParams<F> for ReadRafSumcheckParams<F> {
+impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafSumcheckParams<F> {
     fn degree(&self) -> usize {
         self.d + 1
     }
@@ -1199,52 +1204,5 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ReadRafSumcheckParams<F> {
         r[0..self.log_K].reverse();
         r[self.log_K..].reverse();
         OpeningPoint::new(r)
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum ReadCheckingValType {
-    /// Spartan outer sumcheck
-    Stage1,
-    /// Jump flag from SpartanProductVirtualization
-    Stage2,
-    /// ShiftSumcheck
-    Stage3,
-    /// Registers from read-write sumcheck (rd, rs1, rs2)
-    Stage4,
-    /// Registers val evaluation sumcheck and Instruction Lookups
-    Stage5,
-}
-
-impl<F: JoltField> GruenSplitEqPolynomial<F> {
-    // TODO: Consider moving to split_eq_poly.rs if gets used elsewhere.
-    /// Compute the sumcheck round polynomial `s(X) = l(X) * q(X)`, where `l(X)` is
-    /// the current (linear) eq polynomial and we are given the following:
-    /// - `evals` equal to `[q(1), q(2), ..., q(deg(q) - 1), q(inf)]`
-    /// - the previous round claim `s(0) + s(1)`.
-    fn compute_round_poly(&self, q_evals: &[F], s_0_plus_s_1: F) -> UniPoly<F> {
-        let r_round = match self.binding_order {
-            BindingOrder::LowToHigh => self.w[self.current_index - 1],
-            BindingOrder::HighToLow => self.w[self.current_index],
-        };
-
-        // Interpolate q.
-        let l_at_0 = self.current_scalar * EqPolynomial::mle(&[F::zero()], &[r_round]);
-        let l_at_1 = self.current_scalar * EqPolynomial::mle(&[F::one()], &[r_round]);
-        let q_at_0 = (s_0_plus_s_1 - l_at_1 * q_evals[0]) / l_at_0;
-        let mut q_evals = q_evals.to_vec();
-        q_evals.insert(0, q_at_0);
-        let q = UniPoly::from_evals_toom(&q_evals);
-
-        // Multiply q by l(X) = c0 + Xc1.
-        let l_c0 = l_at_0;
-        let l_c1 = l_at_1 - l_at_0;
-        let mut s_coeffs = vec![F::zero(); q.coeffs.len() + 1];
-        for (i, q_ci) in q.coeffs.into_iter().enumerate() {
-            s_coeffs[i] += q_ci * l_c0;
-            s_coeffs[i + 1] += q_ci * l_c1;
-        }
-
-        UniPoly::from_coeff(s_coeffs)
     }
 }

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -1,0 +1,931 @@
+//! Two-phase advice claim reduction (Stage 6 cycle → Stage 7 address)
+//!
+//! This module generalizes the previous single-phase `AdviceClaimReduction` so that trusted and
+//! untrusted advice can be committed as an arbitrary Dory matrix `2^{nu_a} x 2^{sigma_a}` (balanced
+//! by default), while still keeping a **single Stage 8 Dory opening** at the unified Dory point.
+//!
+//! ## Variable order (Dory order)
+//! Dory evaluates at:
+//! - `point_dory = reverse(opening_point_be) = [cycle6_le || addr7_le]`
+//! - `col_coords = point_dory[0..sigma_main]`
+//! - `row_coords = point_dory[sigma_main..]`
+//!
+//! For an advice matrix embedded as the **top-left block** `2^{nu_a} x 2^{sigma_a}`, the *native*
+//! advice evaluation point (in Dory order, LSB-first) is:
+//! - `advice_cols = col_coords[0..sigma_a]`
+//! - `advice_rows = row_coords[0..nu_a]`
+//! - `advice_point = [advice_cols || advice_rows]`
+//!
+//! In our current pipeline, `cycle` coordinates come from Stage 6 and `addr` coordinates come from
+//! Stage 7. When `row_coords[0..nu_a]` crosses into the address segment, we must consume
+//! coordinates from *both* stages; hence the 2-phase reduction:
+//! - **Phase 1 (Stage 6)**: bind the cycle-derived advice coordinates and output an intermediate
+//!   scalar claim `C_mid`.
+//! - **Phase 2 (Stage 7)**: resume from `C_mid`, bind the address-derived advice coordinates, and
+//!   cache the final advice opening `AdviceMLE(advice_point)` for batching into Stage 8.
+//!
+//! ## Dummy-gap scaling (within Stage 6)
+//! When `nu_a > 0`, the advice row bits that come from `cycle6_le` start at `cycle6_le[sigma_main]`,
+//! while the advice column bits are `cycle6_le[0..sigma_a]`. If `sigma_a < sigma_main`, Phase 1
+//! must *pass through* the intervening cycle coordinates `cycle6_le[sigma_a .. sigma_main)` that
+//! are **not** advice variables (they are handled by the Stage 7 embedding selector).
+//!
+//! We handle this without modifying the generic batched sumcheck by treating those intervening
+//! rounds as **dummy internal rounds** (constant univariates), and maintaining a running scaling
+//! factor `2^{-dummy_done}` so the per-round univariates remain consistent.
+//!
+//! Trusted and untrusted advice run as **separate** sumcheck instances (each may have different
+//! dimensions).
+//!
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+use crate::poly::opening_proof::{
+    OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+    VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::config::OneHotConfig;
+use crate::zkvm::witness::CommittedPolynomial;
+use allocative::Allocative;
+use common::jolt_device::MemoryLayout;
+use rayon::prelude::*;
+
+const DEGREE_BOUND: usize = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative)]
+pub enum AdviceKind {
+    Trusted,
+    Untrusted,
+}
+
+#[derive(Clone, Allocative)]
+pub struct AdviceClaimReductionPhase1Params<F: JoltField> {
+    pub kind: AdviceKind,
+    pub gamma: F,
+    pub advice_vars: usize,
+    pub sigma_a: usize, // number of advice columns
+    pub nu_a: usize,    // number of advice rows
+    pub single_opening: bool,
+    pub log_k_chunk: usize,
+    pub log_t: usize,
+    pub sigma_main: usize, // number of main columns
+    pub nu_a_cycle: usize, // number of advice rows that come from the cycle variables
+    pub nu_a_addr: usize,  // number of advice rows that come from the address variables
+    /// Dummy rounds are `[dummy_start, dummy_end)` within the Phase 1 local round index space.
+    pub dummy_start: usize,
+    pub dummy_end: usize,
+    pub r_val_eval: OpeningPoint<BIG_ENDIAN, F>,
+    pub r_val_final: Option<OpeningPoint<BIG_ENDIAN, F>>,
+}
+
+impl<F: JoltField> AdviceClaimReductionPhase1Params<F> {
+    pub fn new(
+        kind: AdviceKind,
+        memory_layout: &MemoryLayout,
+        trace_len: usize,
+        accumulator: &dyn OpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+        single_opening: bool,
+    ) -> Option<Self> {
+        let max_advice_size_bytes = match kind {
+            AdviceKind::Trusted => memory_layout.max_trusted_advice_size as usize,
+            AdviceKind::Untrusted => memory_layout.max_untrusted_advice_size as usize,
+        };
+
+        let log_t = trace_len.log_2();
+        let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
+        let (sigma_main, _nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
+
+        let r_val_eval = accumulator
+            .get_advice_opening(kind, SumcheckId::RamValEvaluation)
+            .map(|(p, _)| p)?;
+        let r_val_final = if single_opening {
+            None
+        } else {
+            accumulator
+                .get_advice_opening(kind, SumcheckId::RamValFinalEvaluation)
+                .map(|(p, _)| p)
+        };
+        let (r_val_eval, r_val_final) = (r_val_eval, r_val_final);
+
+        let gamma: F = transcript.challenge_scalar();
+
+        let (sigma_a, nu_a) = DoryGlobals::advice_sigma_nu_from_max_bytes(max_advice_size_bytes);
+        let advice_vars = sigma_a + nu_a;
+
+        let row_cycle = DoryGlobals::cycle_row_len(log_t, sigma_main);
+        let nu_a_cycle = std::cmp::min(nu_a, row_cycle);
+        let nu_a_addr = nu_a - nu_a_cycle;
+
+        // Phase 1 only needs to traverse the cycle gap if we actually need cycle-derived row bits.
+        let (dummy_start, dummy_end) = if nu_a_cycle == 0 {
+            (0, 0)
+        } else {
+            (sigma_a, sigma_main)
+        };
+
+        Some(Self {
+            kind,
+            gamma,
+            advice_vars,
+            sigma_a,
+            nu_a,
+            single_opening,
+            log_k_chunk,
+            log_t,
+            sigma_main,
+            nu_a_cycle,
+            nu_a_addr,
+            dummy_start,
+            dummy_end,
+            r_val_eval,
+            r_val_final,
+        })
+    }
+
+    #[inline]
+    fn is_dummy_round(&self, local_round: usize) -> bool {
+        self.dummy_start < self.dummy_end
+            && local_round >= self.dummy_start
+            && local_round < self.dummy_end
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionPhase1Params<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        let mut claim = F::zero();
+        if let Some((_, eval)) =
+            accumulator.get_advice_opening(self.kind, SumcheckId::RamValEvaluation)
+        {
+            claim += eval;
+        }
+        if !self.single_opening {
+            if let Some((_, final_eval)) =
+                accumulator.get_advice_opening(self.kind, SumcheckId::RamValFinalEvaluation)
+            {
+                claim += self.gamma * final_eval;
+            }
+        }
+        claim
+    }
+
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        if self.nu_a_cycle == 0 {
+            // Only need the low column bits; no need to traverse the cycle gap.
+            self.sigma_a
+        } else {
+            // Need to reach cycle row bits at index sigma_main.
+            self.sigma_main + self.nu_a_cycle
+        }
+    }
+
+    fn normalize_opening_point(
+        &self,
+        challenges: &[<F as JoltField>::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        // Instance-local rounds are interpreted as little-endian in time order.
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+}
+
+#[derive(Allocative)]
+pub struct AdviceClaimReductionPhase1Prover<F: JoltField> {
+    params: AdviceClaimReductionPhase1Params<F>,
+    advice_poly: MultilinearPolynomial<F>,
+    eq_poly: MultilinearPolynomial<F>,
+    /// Maintains the running internal scaling factor 2^{-dummy_done}.
+    scale: F,
+    inv_scale: F,
+    /// Constant scaling for trailing dummy rounds *after* the active window in the batched Stage 6
+    /// sumcheck (i.e., dummy cycle variables beyond this instance's `num_rounds()`).
+    after_scale: F,
+    after_inv_scale: F,
+    two_inv: F,
+}
+
+impl<F: JoltField> AdviceClaimReductionPhase1Prover<F> {
+    pub fn initialize(
+        params: AdviceClaimReductionPhase1Params<F>,
+        advice_poly: MultilinearPolynomial<F>,
+    ) -> Self {
+        let gamma = params.gamma;
+        let eq_eval = EqPolynomial::evals(&params.r_val_eval.r);
+        let eq_poly = if params.single_opening {
+            MultilinearPolynomial::from(eq_eval)
+        } else {
+            let r_final = params
+                .r_val_final
+                .as_ref()
+                .expect("r_val_final must exist when !single_opening");
+            let eq_final = EqPolynomial::evals_with_scaling(&r_final.r, Some(gamma));
+            let combined: Vec<F> = eq_eval
+                .par_iter()
+                .zip(eq_final.par_iter())
+                .map(|(e1, e2)| *e1 + e2)
+                .collect();
+            MultilinearPolynomial::from(combined)
+        };
+
+        let two_inv = F::from_u64(2).inverse().unwrap();
+        let dummy_after = params.log_t.saturating_sub(params.num_rounds());
+        let after_scale = F::one().mul_pow_2(dummy_after);
+        let after_inv_scale = after_scale.inverse().unwrap();
+        Self {
+            params,
+            advice_poly,
+            eq_poly,
+            scale: F::one(),
+            inv_scale: F::one(),
+            after_scale,
+            after_inv_scale,
+            two_inv,
+        }
+    }
+
+    fn compute_message_unscaled(&mut self, previous_claim_unscaled: F) -> UniPoly<F> {
+        let half = self.advice_poly.len() / 2;
+        let evals: [F; DEGREE_BOUND] = (0..half)
+            .into_par_iter()
+            .map(|j| {
+                let a_evals = self
+                    .advice_poly
+                    .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                let eq_evals = self
+                    .eq_poly
+                    .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+
+                let mut out = [F::zero(); DEGREE_BOUND];
+                for i in 0..DEGREE_BOUND {
+                    out[i] = a_evals[i] * eq_evals[i];
+                }
+                out
+            })
+            .reduce(
+                || [F::zero(); DEGREE_BOUND],
+                |mut acc, arr| {
+                    acc.par_iter_mut()
+                        .zip(arr.par_iter())
+                        .for_each(|(a, b)| *a += *b);
+                    acc
+                },
+            );
+        UniPoly::from_evals_and_hint(previous_claim_unscaled, &evals)
+    }
+
+    fn bind_real_var(&mut self, r_j: F::Challenge) {
+        self.advice_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+    }
+
+    fn step_dummy(&mut self) {
+        // Each dummy internal round halves the running claim; equivalently, we multiply the
+        // scaling factor by 1/2.
+        self.scale *= self.two_inv;
+        self.inv_scale *= F::from_u64(2);
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for AdviceClaimReductionPhase1Prover<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        if self.params.is_dummy_round(round) {
+            // Dummy internal variable: constant univariate with H(0)=H(1)=previous_claim/2.
+            UniPoly::from_coeff(vec![previous_claim * self.two_inv])
+        } else {
+            // Account for (1) internal dummy rounds already traversed (scale/inv_scale) and
+            // (2) trailing dummy rounds after this instance's active window in the batched sumcheck.
+            let prev_unscaled = previous_claim * self.inv_scale * self.after_inv_scale;
+            let poly_unscaled = self.compute_message_unscaled(prev_unscaled);
+            poly_unscaled * self.scale * self.after_scale
+        }
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        if self.params.is_dummy_round(round) {
+            self.step_dummy();
+        } else {
+            self.bind_real_var(r_j);
+        }
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        // Compute the intermediate claim C_mid = (2^{-gap}) * Σ_y advice(y) * eq(y),
+        // where y are the remaining (address-derived) advice row variables.
+        let len = self.advice_poly.len();
+        debug_assert_eq!(len, self.eq_poly.len());
+
+        let mut sum = F::zero();
+        for i in 0..len {
+            sum += self.advice_poly.get_bound_coeff(i) * self.eq_poly.get_bound_coeff(i);
+        }
+        let c_mid = sum * self.scale;
+
+        let opening_point = SumcheckInstanceProver::<F, T>::get_params(self)
+            .normalize_opening_point(sumcheck_challenges);
+
+        // Append C_mid to transcript for explicit Fiat-Shamir binding (defensive).
+        // While C_mid is already implicitly determined by the sumcheck univariates,
+        // explicit transcript binding makes the security argument clearer.
+        match self.params.kind {
+            AdviceKind::Trusted => accumulator.append_trusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase1,
+                opening_point,
+                c_mid,
+            ),
+            AdviceKind::Untrusted => accumulator.append_untrusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase1,
+                opening_point,
+                c_mid,
+            ),
+        }
+
+        // If there is no Phase 2 (all advice row bits come from cycle), cache the final advice opening
+        // directly here under `SumcheckId::AdviceClaimReduction` so Stage 7 can scale/embed it.
+        if self.params.nu_a_addr == 0 {
+            let mut advice_le: Vec<F::Challenge> = Vec::with_capacity(self.params.advice_vars);
+            // col bits are the first sigma_a cycle coords
+            advice_le.extend_from_slice(&sumcheck_challenges[0..self.params.sigma_a]);
+            // row bits (from cycle) start at sigma_main
+            if self.params.nu_a_cycle > 0 {
+                advice_le.extend_from_slice(
+                    &sumcheck_challenges
+                        [self.params.sigma_main..self.params.sigma_main + self.params.nu_a_cycle],
+                );
+            }
+            let advice_point: OpeningPoint<BIG_ENDIAN, F> =
+                OpeningPoint::<LITTLE_ENDIAN, F>::new(advice_le).match_endianness();
+            let advice_claim = self.advice_poly.final_sumcheck_claim();
+
+            match self.params.kind {
+                AdviceKind::Trusted => accumulator.append_trusted_advice(
+                    transcript,
+                    SumcheckId::AdviceClaimReductionPhase2,
+                    advice_point,
+                    advice_claim,
+                ),
+                AdviceKind::Untrusted => accumulator.append_untrusted_advice(
+                    transcript,
+                    SumcheckId::AdviceClaimReductionPhase2,
+                    advice_point,
+                    advice_claim,
+                ),
+            }
+        }
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        // Align Phase 1 to the *start* of Booleanity's cycle segment, so local rounds correspond
+        // to low Dory column bits in the unified point ordering.
+        let booleanity_rounds = self.params.log_k_chunk + self.params.log_t;
+        let booleanity_offset = max_num_rounds - booleanity_rounds;
+        booleanity_offset + self.params.log_k_chunk
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct AdviceClaimReductionPhase1Verifier<F: JoltField> {
+    params: AdviceClaimReductionPhase1Params<F>,
+}
+
+impl<F: JoltField> AdviceClaimReductionPhase1Verifier<F> {
+    pub fn new(
+        kind: AdviceKind,
+        memory_layout: &MemoryLayout,
+        trace_len: usize,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+        single_opening: bool,
+    ) -> Option<Self> {
+        let params = AdviceClaimReductionPhase1Params::new(
+            kind,
+            memory_layout,
+            trace_len,
+            accumulator,
+            transcript,
+            single_opening,
+        )?;
+        Some(Self { params })
+    }
+
+    pub fn gamma(&self) -> F {
+        self.params.gamma
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
+    for AdviceClaimReductionPhase1Verifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        _sumcheck_challenges: &[F::Challenge],
+    ) -> F {
+        let (key, label) = match self.params.kind {
+            AdviceKind::Trusted => (
+                SumcheckId::AdviceClaimReductionPhase1,
+                "Trusted Phase1 intermediate claim",
+            ),
+            AdviceKind::Untrusted => (
+                SumcheckId::AdviceClaimReductionPhase1,
+                "Untrusted Phase1 intermediate claim",
+            ),
+        };
+
+        accumulator
+            .get_advice_opening(self.params.kind, key)
+            .unwrap_or_else(|| panic!("{label} not found"))
+            .1
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let opening_point = SumcheckInstanceVerifier::<F, T>::get_params(self)
+            .normalize_opening_point(sumcheck_challenges);
+
+        // Append C_mid to transcript for explicit Fiat-Shamir binding (defensive).
+        match self.params.kind {
+            AdviceKind::Trusted => accumulator.append_trusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase1,
+                opening_point,
+            ),
+            AdviceKind::Untrusted => accumulator.append_untrusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase1,
+                opening_point,
+            ),
+        }
+
+        // If Phase 2 is absent (nu_a_addr == 0), Phase 1 cached the final advice opening in Stage 6.
+        // Populate its opening point now so downstream stages can extract it.
+        if self.params.nu_a_addr == 0 {
+            let mut advice_le: Vec<F::Challenge> = Vec::with_capacity(self.params.advice_vars);
+            advice_le.extend_from_slice(&sumcheck_challenges[0..self.params.sigma_a]);
+            if self.params.nu_a_cycle > 0 {
+                advice_le.extend_from_slice(
+                    &sumcheck_challenges
+                        [self.params.sigma_main..self.params.sigma_main + self.params.nu_a_cycle],
+                );
+            }
+            let advice_point: OpeningPoint<BIG_ENDIAN, F> =
+                OpeningPoint::<LITTLE_ENDIAN, F>::new(advice_le).match_endianness();
+            match self.params.kind {
+                AdviceKind::Trusted => accumulator.append_trusted_advice(
+                    transcript,
+                    SumcheckId::AdviceClaimReductionPhase2,
+                    advice_point,
+                ),
+                AdviceKind::Untrusted => accumulator.append_untrusted_advice(
+                    transcript,
+                    SumcheckId::AdviceClaimReductionPhase2,
+                    advice_point,
+                ),
+            }
+        }
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        let booleanity_rounds = self.params.log_k_chunk + self.params.log_t;
+        let booleanity_offset = max_num_rounds - booleanity_rounds;
+        booleanity_offset + self.params.log_k_chunk
+    }
+}
+
+#[derive(Clone, Allocative)]
+pub struct AdviceClaimReductionPhase2Params<F: JoltField> {
+    pub kind: AdviceKind,
+    pub gamma: F,
+    pub advice_vars: usize,
+    pub sigma_a: usize, // number of advice columns
+    pub nu_a: usize,    // number of advice rows
+    pub single_opening: bool,
+    pub log_k_chunk: usize,
+    pub log_t: usize,
+    pub sigma_main: usize, // number of main columns
+    pub nu_a_cycle: usize, // number of advice rows that come from the cycle variables
+    pub nu_a_addr: usize,  // number of advice rows that come from the address variables
+    /// Constant scaling factor carried from Phase 1 (equals 2^{-gap_len}).
+    pub scale: F,
+    pub inv_scale: F,
+    /// Cycle-derived prefix (Dory order) used to pre-bind advice vars in Phase 2:
+    /// `[col_bits (sigma_a) || row_cycle_bits (nu_a_cycle)]` (little-endian).
+    pub cycle_bind_le: Vec<F::Challenge>,
+    pub r_val_eval: OpeningPoint<BIG_ENDIAN, F>,
+    pub r_val_final: Option<OpeningPoint<BIG_ENDIAN, F>>,
+}
+
+impl<F: JoltField> AdviceClaimReductionPhase2Params<F> {
+    pub fn new(
+        kind: AdviceKind,
+        memory_layout: &MemoryLayout,
+        trace_len: usize,
+        gamma: F,
+        accumulator: &dyn OpeningAccumulator<F>,
+        single_opening: bool,
+    ) -> Option<Self> {
+        let max_advice_size_bytes = match kind {
+            AdviceKind::Trusted => memory_layout.max_trusted_advice_size as usize,
+            AdviceKind::Untrusted => memory_layout.max_untrusted_advice_size as usize,
+        };
+        let log_t = trace_len.log_2();
+        let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
+        let (sigma_main, _nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
+
+        let r_val_eval = accumulator
+            .get_advice_opening(kind, SumcheckId::RamValEvaluation)
+            .map(|(p, _)| p)?;
+        let r_val_final = if single_opening {
+            None
+        } else {
+            accumulator
+                .get_advice_opening(kind, SumcheckId::RamValFinalEvaluation)
+                .map(|(p, _)| p)
+        };
+        let (r_val_eval, r_val_final) = (r_val_eval, r_val_final);
+
+        let (sigma_a, nu_a) = DoryGlobals::advice_sigma_nu_from_max_bytes(max_advice_size_bytes);
+        let advice_vars = sigma_a + nu_a;
+
+        let row_cycle = DoryGlobals::cycle_row_len(log_t, sigma_main);
+        let nu_a_cycle = std::cmp::min(nu_a, row_cycle);
+        let nu_a_addr = nu_a - nu_a_cycle;
+
+        // If no address-derived advice vars, Phase 2 is not needed.
+        if nu_a_addr == 0 {
+            return None;
+        }
+
+        // Gap dummy rounds exist only if Phase 1 had to traverse from sigma_a to sigma_main.
+        let gap_len = if nu_a_cycle == 0 {
+            0
+        } else {
+            sigma_main.saturating_sub(sigma_a)
+        };
+
+        let two_inv = F::from_u64(2).inverse().unwrap();
+        let scale = (0..gap_len).fold(F::one(), |acc, _| acc * two_inv);
+        let inv_scale = (0..gap_len).fold(F::one(), |acc, _| acc * F::from_u64(2));
+
+        // Extract cycle6_le from Booleanity's unified opening point in the accumulator.
+        let (unified_point, _) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::InstructionRa(0),
+            SumcheckId::Booleanity,
+        );
+        let r_cycle_be = &unified_point.r[log_k_chunk..];
+        let mut cycle_le = r_cycle_be.to_vec();
+        cycle_le.reverse();
+
+        let mut cycle_bind_le = Vec::with_capacity(sigma_a + nu_a_cycle);
+        // col bits: cycle_le[0..sigma_a]
+        cycle_bind_le.extend_from_slice(&cycle_le[0..sigma_a]);
+        // row cycle bits: cycle_le[sigma_main .. sigma_main+nu_a_cycle]
+        if nu_a_cycle > 0 {
+            cycle_bind_le.extend_from_slice(&cycle_le[sigma_main..sigma_main + nu_a_cycle]);
+        }
+
+        Some(Self {
+            kind,
+            gamma,
+            advice_vars,
+            sigma_a,
+            nu_a,
+            single_opening,
+            log_k_chunk,
+            log_t,
+            sigma_main,
+            nu_a_cycle,
+            nu_a_addr,
+            scale,
+            inv_scale,
+            cycle_bind_le,
+            r_val_eval,
+            r_val_final,
+        })
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionPhase2Params<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        // Phase 2 starts from the Phase 1 intermediate claim.
+        accumulator
+            .get_advice_opening(self.kind, SumcheckId::AdviceClaimReductionPhase1)
+            .expect("Phase1 intermediate claim not found")
+            .1
+    }
+
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.nu_a_addr
+    }
+
+    fn normalize_opening_point(
+        &self,
+        challenges: &[<F as JoltField>::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        OpeningPoint::<LITTLE_ENDIAN, F>::new(challenges.to_vec()).match_endianness()
+    }
+}
+
+#[derive(Allocative)]
+pub struct AdviceClaimReductionPhase2Prover<F: JoltField> {
+    params: AdviceClaimReductionPhase2Params<F>,
+    advice_poly: MultilinearPolynomial<F>,
+    eq_poly: MultilinearPolynomial<F>,
+    /// Constant scaling for trailing dummy rounds after the active window in Stage 7 batching
+    /// (remaining address bits not consumed by advice).
+    after_scale: F,
+    after_inv_scale: F,
+    two_inv: F,
+}
+
+impl<F: JoltField> AdviceClaimReductionPhase2Prover<F> {
+    pub fn initialize(
+        params: AdviceClaimReductionPhase2Params<F>,
+        mut advice_poly: MultilinearPolynomial<F>,
+    ) -> Self {
+        let gamma = params.gamma;
+        let eq_eval = EqPolynomial::evals(&params.r_val_eval.r);
+        let mut eq_poly = if params.single_opening {
+            MultilinearPolynomial::from(eq_eval)
+        } else {
+            let r_final = params
+                .r_val_final
+                .as_ref()
+                .expect("r_val_final must exist when !single_opening");
+            let eq_final = EqPolynomial::evals_with_scaling(&r_final.r, Some(gamma));
+            let combined: Vec<F> = eq_eval
+                .par_iter()
+                .zip(eq_final.par_iter())
+                .map(|(e1, e2)| *e1 + e2)
+                .collect();
+            MultilinearPolynomial::from(combined)
+        };
+
+        // Pre-bind cycle-derived advice variables in Dory order:
+        // [col_bits || row_cycle_bits].
+        for &r in params.cycle_bind_le.iter() {
+            advice_poly.bind_parallel(r, BindingOrder::LowToHigh);
+            eq_poly.bind_parallel(r, BindingOrder::LowToHigh);
+        }
+
+        let two_inv = F::from_u64(2).inverse().unwrap();
+        let dummy_after = params.log_k_chunk.saturating_sub(params.nu_a_addr);
+        let after_scale = F::one().mul_pow_2(dummy_after);
+        let after_inv_scale = after_scale.inverse().unwrap();
+        Self {
+            params,
+            advice_poly,
+            eq_poly,
+            after_scale,
+            after_inv_scale,
+            two_inv,
+        }
+    }
+
+    fn compute_message_unscaled(&mut self, previous_claim_unscaled: F) -> UniPoly<F> {
+        let half = self.advice_poly.len() / 2;
+
+        let evals: [F; DEGREE_BOUND] = (0..half)
+            .into_par_iter()
+            .map(|j| {
+                let a_evals = self
+                    .advice_poly
+                    .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                let eq_evals = self
+                    .eq_poly
+                    .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+
+                let mut out = [F::zero(); DEGREE_BOUND];
+                for i in 0..DEGREE_BOUND {
+                    out[i] = a_evals[i] * eq_evals[i];
+                }
+                out
+            })
+            .reduce(
+                || [F::zero(); DEGREE_BOUND],
+                |mut acc, arr| {
+                    acc.par_iter_mut()
+                        .zip(arr.par_iter())
+                        .for_each(|(a, b)| *a += *b);
+                    acc
+                },
+            );
+
+        UniPoly::from_evals_and_hint(previous_claim_unscaled, &evals)
+    }
+
+    fn bind_real_var(&mut self, r_j: F::Challenge) {
+        self.advice_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for AdviceClaimReductionPhase2Prover<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        // Account for (1) constant scale from Phase 1's internal dummy-gap traversal and
+        // (2) trailing dummy rounds after this instance's active window in Stage 7 batching.
+        let prev_unscaled = previous_claim * self.params.inv_scale * self.after_inv_scale;
+        let poly_unscaled = self.compute_message_unscaled(prev_unscaled);
+        poly_unscaled * self.params.scale * self.after_scale
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        self.bind_real_var(r_j);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        // Build full advice opening point (little-endian Dory order):
+        // [col_bits (sigma_a) || row_cycle_bits (nu_a_cycle) || row_addr_bits (nu_a_addr)]
+        debug_assert_eq!(sumcheck_challenges.len(), self.params.nu_a_addr);
+        debug_assert_eq!(
+            self.params.cycle_bind_le.len(),
+            self.params.sigma_a + self.params.nu_a_cycle
+        );
+
+        let mut advice_le: Vec<F::Challenge> = Vec::with_capacity(self.params.advice_vars);
+        advice_le.extend_from_slice(&self.params.cycle_bind_le[0..self.params.sigma_a]);
+        advice_le.extend_from_slice(&self.params.cycle_bind_le[self.params.sigma_a..]);
+        advice_le.extend_from_slice(sumcheck_challenges);
+
+        let opening_point: OpeningPoint<BIG_ENDIAN, F> =
+            OpeningPoint::<LITTLE_ENDIAN, F>::new(advice_le).match_endianness();
+
+        let claim = self.advice_poly.final_sumcheck_claim();
+
+        match self.params.kind {
+            AdviceKind::Trusted => accumulator.append_trusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase2,
+                opening_point,
+                claim,
+            ),
+            AdviceKind::Untrusted => accumulator.append_untrusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase2,
+                opening_point,
+                claim,
+            ),
+        }
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        // Stage 7 rounds are the address bits `addr7_le = [b0..b_{log_k_chunk-1}]`.
+        // We need the prefix `b0..b_{nu_a_addr-1}`, so we start at offset 0.
+        0
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct AdviceClaimReductionPhase2Verifier<F: JoltField> {
+    params: AdviceClaimReductionPhase2Params<F>,
+}
+
+impl<F: JoltField> AdviceClaimReductionPhase2Verifier<F> {
+    pub fn new(
+        kind: AdviceKind,
+        memory_layout: &MemoryLayout,
+        trace_len: usize,
+        gamma: F,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        single_opening: bool,
+    ) -> Option<Self> {
+        let params = AdviceClaimReductionPhase2Params::new(
+            kind,
+            memory_layout,
+            trace_len,
+            gamma,
+            accumulator,
+            single_opening,
+        )?;
+        Some(Self { params })
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
+    for AdviceClaimReductionPhase2Verifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F {
+        // Build the full advice opening point in BIG_ENDIAN for eq computations.
+        debug_assert_eq!(sumcheck_challenges.len(), self.params.nu_a_addr);
+        let mut advice_le: Vec<F::Challenge> = Vec::with_capacity(self.params.advice_vars);
+        advice_le.extend_from_slice(&self.params.cycle_bind_le[0..self.params.sigma_a]);
+        advice_le.extend_from_slice(&self.params.cycle_bind_le[self.params.sigma_a..]);
+        advice_le.extend_from_slice(sumcheck_challenges);
+        let opening_point: OpeningPoint<BIG_ENDIAN, F> =
+            OpeningPoint::<LITTLE_ENDIAN, F>::new(advice_le).match_endianness();
+
+        let advice_claim = accumulator
+            .get_advice_opening(self.params.kind, SumcheckId::AdviceClaimReductionPhase2)
+            .expect("Final advice claim not found")
+            .1;
+
+        let eq_eval = EqPolynomial::mle(&opening_point.r, &self.params.r_val_eval.r);
+        let eq_combined = if self.params.single_opening {
+            eq_eval
+        } else {
+            let r_final = self
+                .params
+                .r_val_final
+                .as_ref()
+                .expect("r_val_final must exist when !single_opening");
+            let eq_final = EqPolynomial::mle(&opening_point.r, &r_final.r);
+            eq_eval + self.params.gamma * eq_final
+        };
+
+        // Account for Phase 1's internal dummy-gap traversal via constant scaling.
+        advice_claim * eq_combined * self.params.scale
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        transcript: &mut T,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        debug_assert_eq!(sumcheck_challenges.len(), self.params.nu_a_addr);
+        let mut advice_le: Vec<F::Challenge> = Vec::with_capacity(self.params.advice_vars);
+        advice_le.extend_from_slice(&self.params.cycle_bind_le[0..self.params.sigma_a]);
+        advice_le.extend_from_slice(&self.params.cycle_bind_le[self.params.sigma_a..]);
+        advice_le.extend_from_slice(sumcheck_challenges);
+        let opening_point: OpeningPoint<BIG_ENDIAN, F> =
+            OpeningPoint::<LITTLE_ENDIAN, F>::new(advice_le).match_endianness();
+
+        match self.params.kind {
+            AdviceKind::Trusted => accumulator.append_trusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase2,
+                opening_point,
+            ),
+            AdviceKind::Untrusted => accumulator.append_untrusted_advice(
+                transcript,
+                SumcheckId::AdviceClaimReductionPhase2,
+                opening_point,
+            ),
+        }
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+}

--- a/jolt-core/src/zkvm/claim_reductions/increments.rs
+++ b/jolt-core/src/zkvm/claim_reductions/increments.rs
@@ -11,7 +11,7 @@
 //!    - `RamReadWriteChecking` (Stage 2): opened at `r_cycle_stage2`
 //!    - `RamValEvaluation` (Stage 4): opened at `r_cycle_stage4`
 //!    - `RamValFinalEvaluation` (Stage 4): opened at `r_cycle_stage4` (same as RamValEvaluation)
-//!
+//!    
 //!    Note: ValEvaluation and ValFinal share the same opening point because they're
 //!    in the same batched sumcheck and both normalize using the same sumcheck challenges.
 //!    So effectively RamInc has **2 distinct opening points**.
@@ -19,7 +19,7 @@
 //! 2. **RdInc**: Claims are emitted from:
 //!    - `RegistersReadWriteChecking` (Stage 4): opened at `s_cycle_stage4`
 //!    - `RegistersValEvaluation` (Stage 5): opened at `s_cycle_stage5`
-//!
+//!    
 //!    So RdInc has **2 distinct opening points**.
 //!
 //! ## Sumcheck Relation
@@ -27,7 +27,7 @@
 //! Let:
 //!   - v_1 = RamInc(r_cycle_stage2)     from RamReadWriteChecking
 //!   - v_2 = RamInc(r_cycle_stage4)     from RamValEvaluation (and RamValFinal)
-//!   - w_1 = RdInc(s_cycle_stage4)      from RegistersReadWriteChecking
+//!   - w_1 = RdInc(s_cycle_stage4)      from RegistersReadWriteChecking  
 //!   - w_2 = RdInc(s_cycle_stage5)      from RegistersValEvaluation
 //!
 //! Input claim:

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -1,9 +1,15 @@
+pub mod advice;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction_lookups;
 pub mod ram_ra;
 pub mod registers;
 
+pub use advice::{
+    AdviceClaimReductionPhase1Params, AdviceClaimReductionPhase1Prover,
+    AdviceClaimReductionPhase1Verifier, AdviceClaimReductionPhase2Params,
+    AdviceClaimReductionPhase2Prover, AdviceClaimReductionPhase2Verifier, AdviceKind,
+};
 pub use hamming_weight::{
     HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
     HammingWeightClaimReductionVerifier,

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -221,10 +221,9 @@ pub struct ReadRafSumcheckProver<F: JoltField> {
     /// Prefix-suffix decomposition for the instruction-identity path (RAF flag path).
     identity_ps: PrefixSuffixDecomposition<F, 2>,
 
-    /// Materialized Val_j(k) over (address, cycle) after phase transitions.
+    /// Materialized Val_j(k) + γ · RafVal_j(k) over (address, cycle) for final log T rounds.
+    /// Combines lookup table values with γ-weighted RAF operand contributions.
     combined_val_polynomial: Option<MultilinearPolynomial<F>>,
-    /// Materialized RafVal_j(k) (with γ-weights folded into prefixes) over (address, cycle).
-    combined_raf_val_polynomial: Option<MultilinearPolynomial<F>>,
 
     phases: usize,
     pub params: ReadRafSumcheckParams<F>,
@@ -387,7 +386,6 @@ impl<F: JoltField> ReadRafSumcheckProver<F> {
             eq_r_reduction: eq_poly_r_reduction,
             prefix_registry: PrefixRegistry::new(),
             combined_val_polynomial: None,
-            combined_raf_val_polynomial: None,
             params,
             phases,
         };
@@ -588,14 +586,24 @@ impl<F: JoltField> ReadRafSumcheckProver<F> {
             .into_iter()
             .map(|checkpoint| checkpoint.unwrap())
             .collect();
+        // Materialize combined_val_poly = Val_j(k) + γ·RafVal_j(k)
+        // combining lookup table values with RAF operand contributions in a single pass.
         let mut combined_val_poly: Vec<F> = unsafe_allocate_zero_vec(self.lookup_indices.len());
         {
             let span = tracing::span!(tracing::Level::INFO, "Materialize combined_val_poly");
             let _guard = span.enter();
+            let gamma_left_prefix =
+                gamma * self.prefix_registry.checkpoints[Prefix::LeftOperand].unwrap();
+            let gamma_sqr_right_prefix =
+                gamma_sqr * self.prefix_registry.checkpoints[Prefix::RightOperand].unwrap();
+            let gamma_sqr_identity_prefix =
+                gamma_sqr * self.prefix_registry.checkpoints[Prefix::Identity].unwrap();
             combined_val_poly
                 .par_iter_mut()
                 .zip(std::mem::take(&mut self.lookup_tables))
-                .for_each(|(val, table)| {
+                .zip(std::mem::take(&mut self.is_interleaved_operands))
+                .for_each(|((val, table), is_interleaved_operands)| {
+                    // Add lookup table value (Val_j(k))
                     if let Some(table) = table {
                         let suffixes: Vec<_> = table
                             .suffixes()
@@ -606,31 +614,16 @@ impl<F: JoltField> ReadRafSumcheckProver<F> {
                             .collect();
                         *val += table.combine(&prefixes, &suffixes);
                     }
-                });
-        }
-
-        let mut combined_raf_val_poly: Vec<F> = unsafe_allocate_zero_vec(self.lookup_indices.len());
-        {
-            let span = tracing::span!(tracing::Level::INFO, "Materialize combined_raf_val_poly");
-            let _guard = span.enter();
-            combined_raf_val_poly
-                .par_iter_mut()
-                .zip(std::mem::take(&mut self.is_interleaved_operands))
-                .for_each(|(val, is_interleaved_operands)| {
+                    // Add RAF operand contribution (γ·RafVal_j(k))
                     if is_interleaved_operands {
-                        *val += gamma
-                            * self.prefix_registry.checkpoints[Prefix::LeftOperand].unwrap()
-                            + gamma_sqr
-                                * self.prefix_registry.checkpoints[Prefix::RightOperand].unwrap();
+                        *val += gamma_left_prefix + gamma_sqr_right_prefix;
                     } else {
-                        *val +=
-                            gamma_sqr * self.prefix_registry.checkpoints[Prefix::Identity].unwrap();
+                        *val += gamma_sqr_identity_prefix;
                     }
                 });
         }
 
         self.combined_val_polynomial = Some(MultilinearPolynomial::from(combined_val_poly));
-        self.combined_raf_val_polynomial = Some(MultilinearPolynomial::from(combined_raf_val_poly));
         self.ra_polys = Some(ra_polys);
     }
 }
@@ -652,8 +645,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafSumche
             self.compute_prefix_suffix_prover_message(round, previous_claim)
         } else {
             let ra_polys = self.ra_polys.as_ref().unwrap();
-            let val = self.combined_val_polynomial.as_ref().unwrap();
-            let raf_val = self.combined_raf_val_polynomial.as_ref().unwrap();
+            let combined_val = self.combined_val_polynomial.as_ref().unwrap();
             let n_evals = ra_polys.len() + 1;
 
             let mut sum_evals = self
@@ -673,14 +665,9 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafSumche
                             unreachable!()
                         };
 
-                        let val_at_j_0 = val.get_bound_coeff(2 * j);
-                        let val_at_j_1 = val.get_bound_coeff(2 * j + 1);
-                        let raf_val_at_j_0 = raf_val.get_bound_coeff(2 * j);
-                        let raf_val_at_j_1 = raf_val.get_bound_coeff(2 * j + 1);
-                        // v = val + raf_val
-                        let v_at_0 = val_at_j_0 + raf_val_at_j_0;
-                        let v_at_1 = val_at_j_1 + raf_val_at_j_1;
-                        // Load linear poly: eq * (val + raf_val).
+                        let v_at_0 = combined_val.get_bound_coeff(2 * j);
+                        let v_at_1 = combined_val.get_bound_coeff(2 * j + 1);
+                        // Load linear poly: eq * combined_val.
                         *val_pair = (*e_in * v_at_0, *e_in * v_at_1);
                         // Load ra polys.
                         zip(ra_pairs, ra_polys).for_each(|(pair, ra_poly)| {
@@ -764,14 +751,10 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for ReadRafSumche
             // log(T) rounds
 
             self.eq_r_reduction.bind(r_j);
-            [
-                self.combined_val_polynomial.as_mut().unwrap(),
-                self.combined_raf_val_polynomial.as_mut().unwrap(),
-            ]
-            .iter_mut()
-            .for_each(|poly| {
-                poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-            });
+            self.combined_val_polynomial
+                .as_mut()
+                .unwrap()
+                .bind_parallel(r_j, BindingOrder::LowToHigh);
 
             self.ra_polys
                 .as_mut()

--- a/jolt-core/src/zkvm/lookup_table/suffixes/mod.rs
+++ b/jolt-core/src/zkvm/lookup_table/suffixes/mod.rs
@@ -136,6 +136,29 @@ pub enum Suffixes {
 pub type SuffixEval<F: JoltField> = F;
 
 impl Suffixes {
+    /// Returns true iff this suffix's `suffix_mle` output is guaranteed to be in {0, 1}.
+    ///
+    /// This is used for micro-optimizations that avoid calling `mul_u64_unreduced(1)`
+    /// and instead directly add the unreduced field element when the suffix evaluates to 1.
+    #[inline(always)]
+    pub fn is_01_valued(&self) -> bool {
+        matches!(
+            self,
+            Suffixes::One
+                | Suffixes::Eq
+                | Suffixes::LessThan
+                | Suffixes::GreaterThan
+                | Suffixes::LeftOperandIsZero
+                | Suffixes::RightOperandIsZero
+                | Suffixes::Lsb
+                | Suffixes::TwoLsb
+                | Suffixes::DivByZero
+                | Suffixes::OverflowBitsZero
+                | Suffixes::ChangeDivisor
+                | Suffixes::ChangeDivisorW
+        )
+    }
+
     /// Evaluates the MLE for this suffix on the bitvector `b`, where
     /// `b` represents `b.len()` variables, each assuming a Boolean value.
     pub fn suffix_mle<const XLEN: usize>(&self, b: LookupBits) -> u64 {

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2285,14 +2285,15 @@ mod tests {
         let inputs = postcard::to_stdvec(&50u32).unwrap(); // Smaller input for faster test
         let (bytecode, init_memory_state, _) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
+        let max_padded_trace_length = 1 << 16;
         let shared_preprocessing = JoltSharedPreprocessing::new(
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            max_padded_trace_length,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2301,6 +2302,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -2349,14 +2351,15 @@ mod tests {
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
+        let max_padded_trace_length = 1 << 16;
         let shared_preprocessing = JoltSharedPreprocessing::new(
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            max_padded_trace_length,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2365,6 +2368,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -2421,14 +2425,15 @@ mod tests {
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
+        let max_padded_trace_length = 1 << 16;
         let shared_preprocessing = JoltSharedPreprocessing::new(
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            max_padded_trace_length,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -2437,6 +2442,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -42,7 +42,7 @@ use crate::{
     transcripts::Transcript,
     utils::{math::Math, thread::drop_in_background_thread},
     zkvm::{
-        bytecode::read_raf_checking::ReadRafSumcheckParams as BytecodeReadRafParams,
+        bytecode::read_raf_checking::BytecodeReadRafSumcheckParams,
         claim_reductions::{
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
@@ -54,7 +54,7 @@ use crate::{
         config::OneHotParams,
         instruction_lookups::{
             ra_virtual::InstructionRaSumcheckParams,
-            read_raf_checking::ReadRafSumcheckParams as InstructionReadRafParams,
+            read_raf_checking::InstructionReadRafSumcheckParams,
         },
         ram::{
             hamming_booleanity::HammingBooleanitySumcheckParams,
@@ -88,11 +88,11 @@ use crate::{
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
     zkvm::{
-        bytecode::read_raf_checking::ReadRafSumcheckProver as BytecodeReadRafSumcheckProver,
+        bytecode::read_raf_checking::BytecodeReadRafSumcheckProver,
         fiat_shamir_preamble,
         instruction_lookups::{
             ra_virtual::InstructionRaSumcheckProver as LookupsRaSumcheckProver,
-            read_raf_checking::ReadRafSumcheckProver as LookupsReadRafSumcheckProver,
+            read_raf_checking::InstructionReadRafSumcheckProver,
         },
         proof_serialization::{Claims, JoltProof},
         r1cs::key::UniformSpartanKey,
@@ -852,7 +852,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             &self.opening_accumulator,
             &mut self.transcript,
         );
-        let lookups_read_raf_params = InstructionReadRafParams::new(
+        let lookups_read_raf_params = InstructionReadRafSumcheckParams::new(
             self.trace.len().log_2(),
             &self.one_hot_params,
             &self.opening_accumulator,
@@ -872,7 +872,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             &self.one_hot_params,
         );
         let lookups_read_raf =
-            LookupsReadRafSumcheckProver::initialize(lookups_read_raf_params, &self.trace);
+            InstructionReadRafSumcheckProver::initialize(lookups_read_raf_params, &self.trace);
 
         #[cfg(feature = "allocative")]
         {
@@ -881,7 +881,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
                 &registers_val_evaluation,
             );
             print_data_structure_heap_usage("RamRaClaimReductionSumcheckProver", &ram_ra_reduction);
-            print_data_structure_heap_usage("LookupsReadRafSumcheckProver", &lookups_read_raf);
+            print_data_structure_heap_usage("InstructionReadRafSumcheckProver", &lookups_read_raf);
         }
 
         let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
@@ -910,7 +910,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         #[cfg(not(target_arch = "wasm32"))]
         print_current_memory_usage("Stage 6 baseline");
 
-        let bytecode_read_raf_params = BytecodeReadRafParams::gen(
+        let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::gen(
             &self.preprocessing.shared.bytecode,
             self.trace.len().log_2(),
             &self.one_hot_params,
@@ -946,8 +946,8 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
 
         let bytecode_read_raf = BytecodeReadRafSumcheckProver::initialize(
             bytecode_read_raf_params,
-            &self.trace,
-            &self.preprocessing.shared.bytecode,
+            Arc::clone(&self.trace),
+            Arc::clone(&self.preprocessing.shared.bytecode),
         );
         let ram_hamming_booleanity =
             HammingBooleanitySumcheckProver::initialize(ram_hamming_booleanity_params, &self.trace);
@@ -1234,7 +1234,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         };
 
         let streaming_data = Arc::new(RLCStreamingData {
-            bytecode: self.preprocessing.shared.bytecode.clone(),
+            bytecode: Arc::clone(&self.preprocessing.shared.bytecode),
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1,4 +1,4 @@
-use crate::subprotocols::streaming_schedule::LinearOnlySchedule;
+use crate::{subprotocols::streaming_schedule::LinearOnlySchedule, zkvm::config::OneHotConfig};
 use std::{
     collections::HashMap,
     fs::File,
@@ -8,6 +8,7 @@ use std::{
     time::Instant,
 };
 
+use crate::poly::commitment::dory::DoryContext;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::zkvm::config::ReadWriteConfig;
@@ -22,13 +23,11 @@ use crate::{
     field::JoltField,
     guest,
     poly::{
-        commitment::{
-            commitment_scheme::StreamingCommitmentScheme,
-            dory::{DoryContext, DoryGlobals},
-        },
+        commitment::{commitment_scheme::StreamingCommitmentScheme, dory::DoryGlobals},
         multilinear_polynomial::MultilinearPolynomial,
         opening_proof::{
-            DoryOpeningState, OpeningAccumulator, ProverOpeningAccumulator, SumcheckId,
+            compute_advice_lagrange_factor, DoryOpeningState, OpeningAccumulator,
+            ProverOpeningAccumulator, SumcheckId,
         },
         rlc_polynomial::{RLCStreamingData, TraceSource},
     },
@@ -44,6 +43,8 @@ use crate::{
     zkvm::{
         bytecode::read_raf_checking::BytecodeReadRafSumcheckParams,
         claim_reductions::{
+            AdviceClaimReductionPhase1Params, AdviceClaimReductionPhase1Prover,
+            AdviceClaimReductionPhase2Params, AdviceClaimReductionPhase2Prover, AdviceKind,
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
@@ -139,6 +140,10 @@ pub struct JoltCpuProver<
     pub lazy_trace: LazyTraceIterator,
     pub trace: Arc<Vec<Cycle>>,
     pub advice: JoltAdvice<F, PCS>,
+    /// Phase-bridge randomness for two-phase advice claim reduction.
+    /// Stored after Stage 6 initialization and reused in Stage 7.
+    advice_reduction_gamma_trusted: Option<F>,
+    advice_reduction_gamma_untrusted: Option<F>,
     pub unpadded_trace_len: usize,
     pub padded_trace_len: usize,
     pub transcript: ProofTranscript,
@@ -159,6 +164,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         untrusted_advice: &[u8],
         trusted_advice: &[u8],
         trusted_advice_commitment: Option<PCS::Commitment>,
+        trusted_advice_hint: Option<PCS::OpeningProofHint>,
     ) -> Self {
         let memory_config = MemoryConfig {
             max_untrusted_advice_size: preprocessing.shared.memory_layout.max_untrusted_advice_size,
@@ -210,8 +216,86 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             trace,
             program_io,
             trusted_advice_commitment,
+            trusted_advice_hint,
             final_memory_state,
         )
+    }
+
+    /// Adjusts the padded trace length to ensure the main Dory matrix is large enough
+    /// to embed advice polynomials as the top-left block.
+    ///
+    /// Returns the adjusted padded_trace_len that satisfies:
+    /// - `sigma_main >= max_sigma_a`
+    /// - `nu_main >= max_nu_a`
+    ///
+    /// Panics if `max_padded_trace_length` is too small for the configured advice sizes.
+    fn adjust_trace_length_for_advice(
+        mut padded_trace_len: usize,
+        max_padded_trace_length: usize,
+        max_trusted_advice_size: u64,
+        max_untrusted_advice_size: u64,
+        has_trusted_advice: bool,
+        has_untrusted_advice: bool,
+    ) -> usize {
+        // Canonical advice shape policy (balanced):
+        // - advice_vars = log2(advice_len)
+        // - sigma_a = ceil(advice_vars/2)
+        // - nu_a    = advice_vars - sigma_a
+        let mut max_sigma_a = 0usize;
+        let mut max_nu_a = 0usize;
+
+        if has_trusted_advice {
+            let (sigma_a, nu_a) =
+                DoryGlobals::advice_sigma_nu_from_max_bytes(max_trusted_advice_size as usize);
+            max_sigma_a = max_sigma_a.max(sigma_a);
+            max_nu_a = max_nu_a.max(nu_a);
+        }
+        if has_untrusted_advice {
+            let (sigma_a, nu_a) =
+                DoryGlobals::advice_sigma_nu_from_max_bytes(max_untrusted_advice_size as usize);
+            max_sigma_a = max_sigma_a.max(sigma_a);
+            max_nu_a = max_nu_a.max(nu_a);
+        }
+
+        if max_sigma_a == 0 && max_nu_a == 0 {
+            return padded_trace_len;
+        }
+
+        // Require main matrix dimensions to be large enough to embed advice as the top-left
+        // block: sigma_main >= sigma_a and nu_main >= nu_a.
+        //
+        // This loop doubles padded_trace_len until the main Dory matrix is large enough.
+        // Each doubling increases log_t by 1, which increases total_vars by 1 (since
+        // log_k_chunk stays constant for a given log_t range), increasing both sigma_main
+        // and nu_main by roughly 0.5 each iteration.
+        while {
+            let log_t = padded_trace_len.log_2();
+            let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
+            let (sigma_main, nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
+            sigma_main < max_sigma_a || nu_main < max_nu_a
+        } {
+            if padded_trace_len >= max_padded_trace_length {
+                // This is a configuration error: the preprocessing was set up with
+                // max_padded_trace_length too small for the configured advice sizes.
+                // Cannot recover at runtime - user must fix their configuration.
+                let log_t = padded_trace_len.log_2();
+                let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
+                let total_vars = log_k_chunk + log_t;
+                let (sigma_main, nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
+                panic!(
+                    "Configuration error: trace too small to embed advice into Dory batch opening.\n\
+                    Current: (sigma_main={sigma_main}, nu_main={nu_main}) from total_vars={total_vars} (log_t={log_t}, log_k_chunk={log_k_chunk})\n\
+                    Required: (sigma_a={max_sigma_a}, nu_a={max_nu_a}) for advice embedding\n\
+                    Solutions:\n\
+                    1. Increase max_trace_length in preprocessing (currently {max_padded_trace_length})\n\
+                    2. Reduce max_trusted_advice_size or max_untrusted_advice_size\n\
+                    3. Run a program with more cycles"
+                );
+            }
+            padded_trace_len = (padded_trace_len * 2).min(max_padded_trace_length);
+        }
+
+        padded_trace_len
     }
 
     pub fn gen_from_trace(
@@ -220,8 +304,14 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         mut trace: Vec<Cycle>,
         mut program_io: JoltDevice,
         trusted_advice_commitment: Option<PCS::Commitment>,
+        trusted_advice_hint: Option<PCS::OpeningProofHint>,
         final_memory_state: Memory,
     ) -> Self {
+        // Dory globals are process-wide (OnceCell). In tests we run many end-to-end proofs with
+        // different trace lengths in a single process, so reset before each prover construction.
+        #[cfg(test)]
+        crate::poly::commitment::dory::DoryGlobals::reset();
+
         // truncate trailing zeros on device outputs
         program_io.outputs.truncate(
             program_io
@@ -238,6 +328,20 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         } else {
             (trace.len() + 1).next_power_of_two()
         };
+        // We may need extra padding so the main Dory matrix has enough (row, col) variables
+        // to embed advice commitments committed in their own preprocessing-only contexts.
+        let has_trusted_advice = !program_io.trusted_advice.is_empty();
+        let has_untrusted_advice = !program_io.untrusted_advice.is_empty();
+
+        let padded_trace_len = Self::adjust_trace_length_for_advice(
+            padded_trace_len,
+            preprocessing.shared.max_padded_trace_length,
+            preprocessing.shared.memory_layout.max_trusted_advice_size,
+            preprocessing.shared.memory_layout.max_untrusted_advice_size,
+            has_trusted_advice,
+            has_untrusted_advice,
+        );
+
         trace.resize(padded_trace_len, Cycle::NoOp);
 
         // Calculate K for DoryGlobals initialization
@@ -289,7 +393,11 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
                 untrusted_advice_polynomial: None,
                 trusted_advice_commitment,
                 trusted_advice_polynomial: None,
+                untrusted_advice_hint: None,
+                trusted_advice_hint,
             },
+            advice_reduction_gamma_trusted: None,
+            advice_reduction_gamma_untrusted: None,
             unpadded_trace_len,
             padded_trace_len,
             transcript,
@@ -325,20 +433,26 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             self.preprocessing.shared.bytecode.code_size
         );
 
-        let (commitments, opening_proof_hints) = self.generate_and_commit_witness_polynomials();
+        let (commitments, mut opening_proof_hints) = self.generate_and_commit_witness_polynomials();
         let untrusted_advice_commitment = self.generate_and_commit_untrusted_advice();
         self.generate_and_commit_trusted_advice();
+
+        // Add advice hints for batched Stage 8 opening
+        if let Some(hint) = self.advice.trusted_advice_hint.take() {
+            opening_proof_hints.insert(CommittedPolynomial::TrustedAdvice, hint);
+        }
+        if let Some(hint) = self.advice.untrusted_advice_hint.take() {
+            opening_proof_hints.insert(CommittedPolynomial::UntrustedAdvice, hint);
+        }
+
         let (stage1_uni_skip_first_round_proof, stage1_sumcheck_proof) = self.prove_stage1();
         let (stage2_uni_skip_first_round_proof, stage2_sumcheck_proof) = self.prove_stage2();
         let stage3_sumcheck_proof = self.prove_stage3();
         let stage4_sumcheck_proof = self.prove_stage4();
         let stage5_sumcheck_proof = self.prove_stage5();
         let stage6_sumcheck_proof = self.prove_stage6();
-        let (trusted_advice_val_evaluation_proof, trusted_advice_val_final_proof) =
-            self.prove_trusted_advice();
-        let (untrusted_advice_val_evaluation_proof, untrusted_advice_val_final_proof) =
-            self.prove_untrusted_advice();
         let stage7_sumcheck_proof = self.prove_stage7();
+
         let joint_opening_proof = self.prove_stage8(opening_proof_hints);
 
         #[cfg(test)]
@@ -372,10 +486,6 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             stage4_sumcheck_proof,
             stage5_sumcheck_proof,
             stage6_sumcheck_proof,
-            trusted_advice_val_evaluation_proof,
-            trusted_advice_val_final_proof,
-            untrusted_advice_val_evaluation_proof,
-            untrusted_advice_val_final_proof,
             stage7_sumcheck_proof,
             joint_opening_proof,
             trace_length: self.trace.len(),
@@ -404,8 +514,11 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         Vec<PCS::Commitment>,
         HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
     ) {
-        let _guard =
-            DoryGlobals::initialize(1 << self.one_hot_params.log_k_chunk, self.padded_trace_len);
+        let _guard = DoryGlobals::initialize_context(
+            1 << self.one_hot_params.log_k_chunk,
+            self.padded_trace_len,
+            DoryContext::Main,
+        );
         // Generate and commit to all witness polynomials using streaming tier1/tier2 pattern
         let T = DoryGlobals::get_T();
         let polys = all_committed_polynomials(&self.one_hot_params);
@@ -480,11 +593,8 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             return None;
         }
 
-        DoryGlobals::initialize_untrusted_advice(
-            1,
-            self.program_io.memory_layout.max_untrusted_advice_size as usize / 8,
-        );
-        let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+        // Commit untrusted advice in its dedicated Dory context, using a preprocessing-only
+        // matrix shape derived deterministically from the advice length (balanced dims).
 
         let mut untrusted_advice_vec =
             vec![0; self.program_io.memory_layout.max_untrusted_advice_size as usize / 8];
@@ -497,10 +607,15 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         );
 
         let poly = MultilinearPolynomial::from(untrusted_advice_vec);
-        let (commitment, _hint) = PCS::commit(&poly, &self.preprocessing.generators);
+        let advice_len = poly.len().next_power_of_two().max(1);
+
+        let _guard = DoryGlobals::initialize_context(1, advice_len, DoryContext::UntrustedAdvice);
+        let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+        let (commitment, hint) = PCS::commit(&poly, &self.preprocessing.generators);
         self.transcript.append_serializable(&commitment);
 
         self.advice.untrusted_advice_polynomial = Some(poly);
+        self.advice.untrusted_advice_hint = Some(hint);
 
         Some(commitment)
     }
@@ -946,6 +1061,26 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             &mut self.transcript,
         );
 
+        // Advice claim reduction (Phase 1 in Stage 6): trusted and untrusted are separate instances.
+        let trusted_advice_phase1_params = AdviceClaimReductionPhase1Params::new(
+            AdviceKind::Trusted,
+            &self.program_io.memory_layout,
+            self.trace.len(),
+            &self.opening_accumulator,
+            &mut self.transcript,
+            self.rw_config
+                .needs_single_advice_opening(self.trace.len().log_2()),
+        );
+        let untrusted_advice_phase1_params = AdviceClaimReductionPhase1Params::new(
+            AdviceKind::Untrusted,
+            &self.program_io.memory_layout,
+            self.trace.len(),
+            &self.opening_accumulator,
+            &mut self.transcript,
+            self.rw_config
+                .needs_single_advice_opening(self.trace.len().log_2()),
+        );
+
         let bytecode_read_raf = BytecodeReadRafSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
@@ -972,6 +1107,31 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         let inc_reduction =
             IncClaimReductionSumcheckProver::initialize(inc_reduction_params, self.trace.clone());
 
+        // Initialize Phase 1 provers (Stage 6) if advice is present.
+        // Note: We clone the advice polynomial here because:
+        // 1. Phase1 (Stage 6) destructively binds cycle variables
+        // 2. Phase2 (Stage 7) needs a fresh copy to bind address variables
+        // 3. Stage 8 RLC needs the original polynomial
+        // A future optimization could use Arc<MultilinearPolynomial> with copy-on-write.
+        let trusted_advice_phase1 = trusted_advice_phase1_params.map(|params| {
+            self.advice_reduction_gamma_trusted = Some(params.gamma);
+            let poly = self
+                .advice
+                .trusted_advice_polynomial
+                .clone()
+                .expect("trusted advice params exist but polynomial is missing");
+            AdviceClaimReductionPhase1Prover::initialize(params, poly)
+        });
+        let untrusted_advice_phase1 = untrusted_advice_phase1_params.map(|params| {
+            self.advice_reduction_gamma_untrusted = Some(params.gamma);
+            let poly = self
+                .advice
+                .untrusted_advice_polynomial
+                .clone()
+                .expect("untrusted advice params exist but polynomial is missing");
+            AdviceClaimReductionPhase1Prover::initialize(params, poly)
+        });
+
         #[cfg(feature = "allocative")]
         {
             print_data_structure_heap_usage("BytecodeReadRafSumcheckProver", &bytecode_read_raf);
@@ -983,6 +1143,18 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             print_data_structure_heap_usage("RamRaSumcheckProver", &ram_ra_virtual);
             print_data_structure_heap_usage("LookupsRaSumcheckProver", &lookups_ra_virtual);
             print_data_structure_heap_usage("IncClaimReductionSumcheckProver", &inc_reduction);
+            if let Some(ref advice) = trusted_advice_phase1 {
+                print_data_structure_heap_usage(
+                    "AdviceClaimReductionPhase1Prover(trusted)",
+                    advice,
+                );
+            }
+            if let Some(ref advice) = untrusted_advice_phase1 {
+                print_data_structure_heap_usage(
+                    "AdviceClaimReductionPhase1Prover(untrusted)",
+                    advice,
+                );
+            }
         }
 
         let mut instances: Vec<Box<dyn SumcheckInstanceProver<_, _>>> = vec![
@@ -993,6 +1165,12 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             Box::new(lookups_ra_virtual),
             Box::new(inc_reduction),
         ];
+        if let Some(advice) = trusted_advice_phase1 {
+            instances.push(Box::new(advice));
+        }
+        if let Some(advice) = untrusted_advice_phase1 {
+            instances.push(Box::new(advice));
+        }
 
         #[cfg(feature = "allocative")]
         write_instance_flamegraph_svg(&instances, "stage6_start_flamechart.svg");
@@ -1007,96 +1185,6 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         drop_in_background_thread(instances);
 
         sumcheck_proof
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn prove_trusted_advice(&mut self) -> (Option<PCS::Proof>, Option<PCS::Proof>) {
-        use crate::poly::opening_proof::SumcheckId;
-        let poly = match &self.advice.trusted_advice_polynomial {
-            Some(p) => p,
-            None => return (None, None),
-        };
-        let _ctx = DoryGlobals::with_context(DoryContext::TrustedAdvice);
-
-        // Prove at RamValEvaluation point
-        let (point_val, _) = self
-            .opening_accumulator
-            .get_trusted_advice_opening(SumcheckId::RamValEvaluation)
-            .unwrap();
-        let proof_val = PCS::prove(
-            &self.preprocessing.generators,
-            poly,
-            &point_val.r,
-            None,
-            &mut self.transcript,
-        );
-
-        // Prove at RamValFinalEvaluation point - only if different from ValEvaluation
-        let proof_val_final = if self
-            .rw_config
-            .needs_single_advice_opening(self.trace.len().log_2())
-        {
-            None
-        } else {
-            let (point_val_final, _) = self
-                .opening_accumulator
-                .get_trusted_advice_opening(SumcheckId::RamValFinalEvaluation)
-                .unwrap();
-            Some(PCS::prove(
-                &self.preprocessing.generators,
-                poly,
-                &point_val_final.r,
-                None,
-                &mut self.transcript,
-            ))
-        };
-
-        (Some(proof_val), proof_val_final)
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn prove_untrusted_advice(&mut self) -> (Option<PCS::Proof>, Option<PCS::Proof>) {
-        use crate::poly::opening_proof::SumcheckId;
-        let poly = match &self.advice.untrusted_advice_polynomial {
-            Some(p) => p,
-            None => return (None, None),
-        };
-        let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
-
-        // Prove at RamValEvaluation point
-        let (point_val, _) = self
-            .opening_accumulator
-            .get_untrusted_advice_opening(SumcheckId::RamValEvaluation)
-            .unwrap();
-        let proof_val = PCS::prove(
-            &self.preprocessing.generators,
-            poly,
-            &point_val.r,
-            None,
-            &mut self.transcript,
-        );
-
-        // Prove at RamValFinalEvaluation point - only if different from ValEvaluation
-        let proof_val_final = if self
-            .rw_config
-            .needs_single_advice_opening(self.trace.len().log_2())
-        {
-            None
-        } else {
-            let (point_val_final, _) = self
-                .opening_accumulator
-                .get_untrusted_advice_opening(SumcheckId::RamValFinalEvaluation)
-                .unwrap();
-            Some(PCS::prove(
-                &self.preprocessing.generators,
-                poly,
-                &point_val_final.r,
-                None,
-                &mut self.transcript,
-            ))
-        };
-
-        (Some(proof_val), proof_val_final)
     }
 
     /// Stage 7: HammingWeight + ClaimReduction sumcheck (only log_k_chunk rounds).
@@ -1119,9 +1207,51 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
         #[cfg(feature = "allocative")]
         print_data_structure_heap_usage("HammingWeightClaimReductionProver", &hw_prover);
 
-        // Run sumcheck (only log_k_chunk rounds!)
+        // 3. Run Stage 7 batched sumcheck (address rounds only).
+        // Includes HammingWeightClaimReduction plus Phase 2 advice reduction instances (if needed).
         let mut instances: Vec<Box<dyn SumcheckInstanceProver<F, ProofTranscript>>> =
             vec![Box::new(hw_prover)];
+
+        if let Some(gamma) = self.advice_reduction_gamma_trusted {
+            if let Some(params) = AdviceClaimReductionPhase2Params::new(
+                AdviceKind::Trusted,
+                &self.program_io.memory_layout,
+                self.trace.len(),
+                gamma,
+                &self.opening_accumulator,
+                self.rw_config
+                    .needs_single_advice_opening(self.trace.len().log_2()),
+            ) {
+                let poly = self
+                    .advice
+                    .trusted_advice_polynomial
+                    .clone()
+                    .expect("trusted advice phase2 params exist but polynomial is missing");
+                instances.push(Box::new(AdviceClaimReductionPhase2Prover::initialize(
+                    params, poly,
+                )));
+            }
+        }
+        if let Some(gamma) = self.advice_reduction_gamma_untrusted {
+            if let Some(params) = AdviceClaimReductionPhase2Params::new(
+                AdviceKind::Untrusted,
+                &self.program_io.memory_layout,
+                self.trace.len(),
+                gamma,
+                &self.opening_accumulator,
+                self.rw_config
+                    .needs_single_advice_opening(self.trace.len().log_2()),
+            ) {
+                let poly = self
+                    .advice
+                    .untrusted_advice_polynomial
+                    .clone()
+                    .expect("untrusted advice phase2 params exist but polynomial is missing");
+                instances.push(Box::new(AdviceClaimReductionPhase2Prover::initialize(
+                    params, poly,
+                )));
+            }
+        }
 
         #[cfg(feature = "allocative")]
         write_instance_flamegraph_svg(&instances, "stage7_start_flamechart.svg");
@@ -1147,7 +1277,11 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
-        let _guard = DoryGlobals::initialize(self.one_hot_params.k_chunk, self.padded_trace_len);
+        let _guard = DoryGlobals::initialize_context(
+            self.one_hot_params.k_chunk,
+            self.padded_trace_len,
+            DoryContext::Main,
+        );
 
         // Get the unified opening point from HammingWeightClaimReduction
         // This contains (r_address_stage7 || r_cycle_stage6) in big-endian
@@ -1223,6 +1357,33 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             polynomial_claims.push((CommittedPolynomial::RamRa(i), claim));
         }
 
+        // Advice polynomials: TrustedAdvice and UntrustedAdvice (from AdviceClaimReduction in Stage 6)
+        // These are committed with smaller dimensions, so we apply Lagrange factors to embed
+        // them in the top-left block of the main Dory matrix.
+        if let Some((advice_point, advice_claim)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReductionPhase2)
+        {
+            let lagrange_factor =
+                compute_advice_lagrange_factor::<F>(&opening_point.r, advice_point.len());
+            polynomial_claims.push((
+                CommittedPolynomial::TrustedAdvice,
+                advice_claim * lagrange_factor,
+            ));
+        }
+
+        if let Some((advice_point, advice_claim)) = self.opening_accumulator.get_advice_opening(
+            AdviceKind::Untrusted,
+            SumcheckId::AdviceClaimReductionPhase2,
+        ) {
+            let lagrange_factor =
+                compute_advice_lagrange_factor::<F>(&opening_point.r, advice_point.len());
+            polynomial_claims.push((
+                CommittedPolynomial::UntrustedAdvice,
+                advice_claim * lagrange_factor,
+            ));
+        }
+
         // 2. Sample gamma and compute powers for RLC
         let claims: Vec<F> = polynomial_claims.iter().map(|(_, c)| *c).collect();
         self.transcript.append_scalars(&claims);
@@ -1240,6 +1401,15 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 
+        // Build advice polynomials map for RLC
+        let mut advice_polys = HashMap::new();
+        if let Some(poly) = self.advice.trusted_advice_polynomial.take() {
+            advice_polys.insert(CommittedPolynomial::TrustedAdvice, poly);
+        }
+        if let Some(poly) = self.advice.untrusted_advice_polynomial.take() {
+            advice_polys.insert(CommittedPolynomial::UntrustedAdvice, poly);
+        }
+
         // Build streaming RLC polynomial directly (no witness poly regeneration!)
         // Use materialized trace (default, single pass) instead of lazy trace
         let (joint_poly, hint) = state.build_streaming_rlc::<PCS>(
@@ -1247,6 +1417,7 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             TraceSource::Materialized(Arc::clone(&self.trace)),
             streaming_data,
             opening_proof_hints,
+            advice_polys,
         );
 
         // Dory opening proof at the unified point
@@ -1264,6 +1435,10 @@ pub struct JoltAdvice<F: JoltField, PCS: CommitmentScheme<Field = F>> {
     pub untrusted_advice_polynomial: Option<MultilinearPolynomial<F>>,
     pub trusted_advice_commitment: Option<PCS::Commitment>,
     pub trusted_advice_polynomial: Option<MultilinearPolynomial<F>>,
+    /// Hint for untrusted advice (for batched Dory opening)
+    pub untrusted_advice_hint: Option<PCS::OpeningProofHint>,
+    /// Hint for trusted advice (for batched Dory opening)
+    pub trusted_advice_hint: Option<PCS::OpeningProofHint>,
 }
 
 #[cfg(feature = "allocative")]
@@ -1292,10 +1467,10 @@ where
     #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::gen")]
     pub fn new(
         shared: JoltSharedPreprocessing,
-        max_trace_length: usize,
+        // max_trace_length: usize,
     ) -> JoltProverPreprocessing<F, PCS> {
         use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
-        let max_T: usize = max_trace_length.next_power_of_two();
+        let max_T: usize = shared.max_padded_trace_length.next_power_of_two();
         let max_log_T = max_T.log_2();
         // Use the maximum possible log_k_chunk for generator setup
         let max_log_k_chunk = if max_log_T < ONEHOT_CHUNK_THRESHOLD_LOG_T {
@@ -1332,11 +1507,54 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> Serializable
 
 #[cfg(test)]
 mod tests {
-    use crate::host;
-    use crate::zkvm::prover::JoltProverPreprocessing;
-    use crate::zkvm::verifier::{JoltSharedPreprocessing, JoltVerifier, JoltVerifierPreprocessing};
-    use crate::zkvm::{RV64IMACProver, RV64IMACVerifier};
+    use ark_bn254::Fr;
     use serial_test::serial;
+
+    use crate::host;
+    use crate::poly::{
+        commitment::{
+            commitment_scheme::CommitmentScheme,
+            dory::{DoryCommitmentScheme, DoryContext, DoryGlobals},
+        },
+        multilinear_polynomial::MultilinearPolynomial,
+        opening_proof::{OpeningAccumulator, SumcheckId},
+    };
+    use crate::zkvm::claim_reductions::AdviceKind;
+    use crate::zkvm::verifier::JoltSharedPreprocessing;
+    use crate::zkvm::witness::CommittedPolynomial;
+    use crate::zkvm::{
+        prover::JoltProverPreprocessing,
+        ram::populate_memory_states,
+        verifier::{JoltVerifier, JoltVerifierPreprocessing},
+        RV64IMACProver, RV64IMACVerifier,
+    };
+
+    fn commit_trusted_advice_preprocessing_only(
+        preprocessing: &JoltProverPreprocessing<Fr, DoryCommitmentScheme>,
+        trusted_advice_bytes: &[u8],
+    ) -> (
+        <DoryCommitmentScheme as CommitmentScheme>::Commitment,
+        <DoryCommitmentScheme as CommitmentScheme>::OpeningProofHint,
+    ) {
+        let max_trusted_advice_size = preprocessing.shared.memory_layout.max_trusted_advice_size;
+        let mut trusted_advice_words = vec![0u64; (max_trusted_advice_size as usize) / 8];
+        populate_memory_states(
+            0,
+            trusted_advice_bytes,
+            Some(&mut trusted_advice_words),
+            None,
+        );
+
+        let poly = MultilinearPolynomial::<Fr>::from(trusted_advice_words);
+        let advice_len = poly.len().next_power_of_two().max(1);
+
+        let _guard = DoryGlobals::initialize_context(1, advice_len, DoryContext::TrustedAdvice);
+        let (commitment, hint) = {
+            let _ctx = DoryGlobals::with_context(DoryContext::TrustedAdvice);
+            DoryCommitmentScheme::commit(&poly, &preprocessing.generators)
+        };
+        (commitment, hint)
+    }
 
     #[test]
     #[serial]
@@ -1349,10 +1567,10 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -1361,6 +1579,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -1393,9 +1612,10 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            256,
         );
 
-        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone(), 256);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let log_chunk = 8; // Use default log_chunk for tests
@@ -1405,6 +1625,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
 
@@ -1451,10 +1672,10 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -1463,6 +1684,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -1511,10 +1733,10 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -1523,6 +1745,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -1555,23 +1778,16 @@ mod tests {
 
     #[test]
     #[serial]
-    fn advice_e2e_dory() {
-        use crate::poly::{
-            commitment::commitment_scheme::CommitmentScheme,
-            multilinear_polynomial::MultilinearPolynomial,
-        };
-        use crate::zkvm::ram::populate_memory_states;
-
-        let mut program = host::Program::new("merkle-tree-guest");
+    fn sha2_e2e_dory_with_unused_advice() {
+        // SHA2 guest does not consume advice, but providing both trusted and untrusted advice
+        // should still work correctly through the full pipeline:
+        // - Trusted: commit in preprocessing-only context, reduce in Stage 6, batch in Stage 8
+        // - Untrusted: commit at prove time, reduce in Stage 6, batch in Stage 8
+        let mut program = host::Program::new("sha2-guest");
         let (bytecode, init_memory_state, _) = program.decode();
-        let leaf1: [u8; 32] = [5u8; 32];
-        let leaf2: [u8; 32] = [6u8; 32];
-        let leaf3: [u8; 32] = [7u8; 32];
-        let leaf4: [u8; 32] = [8u8; 32];
-        let inputs = postcard::to_stdvec(&leaf1.as_slice()).unwrap();
-        let untrusted_advice = postcard::to_stdvec(&leaf4).unwrap();
-        let mut trusted_advice = postcard::to_stdvec(&leaf2).unwrap();
-        trusted_advice.extend(postcard::to_stdvec(&leaf3).unwrap());
+        let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
+        let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
+        let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
@@ -1579,80 +1795,262 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
-        let elf_contents_opt = program.get_elf_contents();
-        let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
-
-        let max_trusted_advice_size = prover_preprocessing
-            .shared
-            .memory_layout
-            .max_trusted_advice_size;
-        let mut trusted_advice_words = vec![0u64; (max_trusted_advice_size as usize) / 8];
-        populate_memory_states(0, &trusted_advice, Some(&mut trusted_advice_words), None);
-        let trusted_advice_commitment = {
-            crate::poly::commitment::dory::DoryGlobals::initialize_trusted_advice(
-                1,
-                (max_trusted_advice_size as usize) / 8,
-            );
-            let _ctx = crate::poly::commitment::dory::DoryGlobals::with_context(
-                crate::poly::commitment::dory::DoryContext::TrustedAdvice,
-            );
-            let poly = MultilinearPolynomial::<ark_bn254::Fr>::from(trusted_advice_words);
-            let (trusted_advice_commitment, _hint) =
-                <crate::poly::commitment::dory::DoryCommitmentScheme as CommitmentScheme>::commit(
-                    &poly,
-                    &prover_preprocessing.generators,
-                );
-            trusted_advice_commitment
-        };
+        let (trusted_commitment, trusted_hint) =
+            commit_trusted_advice_preprocessing_only(&prover_preprocessing, &trusted_advice);
 
         let prover = RV64IMACProver::gen_from_elf(
             &prover_preprocessing,
-            elf_contents,
+            &elf_contents,
             &inputs,
             &untrusted_advice,
             &trusted_advice,
-            Some(trusted_advice_commitment),
+            Some(trusted_commitment),
+            Some(trusted_hint),
         );
         let io_device = prover.program_io.clone();
         let (jolt_proof, debug_info) = prover.prove();
 
-        let verifier_preprocessing = JoltVerifierPreprocessing::new(
-            prover_preprocessing.shared.clone(),
-            prover_preprocessing.generators.to_verifier_setup(),
-        );
-        let verifier = RV64IMACVerifier::new(
+        let verifier_preprocessing = JoltVerifierPreprocessing::from(&prover_preprocessing);
+        RV64IMACVerifier::new(
             &verifier_preprocessing,
             jolt_proof,
             io_device.clone(),
-            Some(trusted_advice_commitment),
+            Some(trusted_commitment),
             debug_info,
         )
-        .unwrap();
-        let verification_result = verifier.verify();
-        assert!(
-            verification_result.is_ok(),
-            "Verification failed with error: {:?}",
-            verification_result.err()
+        .expect("Failed to create verifier")
+        .verify()
+        .expect("Failed to verify proof");
+
+        // Verify output is correct (advice should not affect sha2 output)
+        let expected_output = &[
+            0x28, 0x9b, 0xdf, 0x82, 0x9b, 0x4a, 0x30, 0x26, 0x7, 0x9a, 0x3e, 0xa0, 0x89, 0x73,
+            0xb1, 0x97, 0x2d, 0x12, 0x4e, 0x7e, 0xaf, 0x22, 0x33, 0xc6, 0x3, 0x14, 0x3d, 0xc6,
+            0x3b, 0x50, 0xd2, 0x57,
+        ];
+        assert_eq!(io_device.outputs, expected_output);
+    }
+
+    #[test]
+    #[serial]
+    fn max_advice_with_small_trace() {
+        // Tests that max-sized advice (4KB = 512 words) works with a minimal trace.
+        // With balanced dims (sigma_a=5, nu_a=4 for 512 words), the minimum padded trace
+        // (256 cycles -> total_vars=12) is sufficient to embed advice.
+        let mut program = host::Program::new("fibonacci-guest");
+        let inputs = postcard::to_stdvec(&5u32).unwrap();
+        let trusted_advice = vec![7u8; 4096];
+        let untrusted_advice = vec![9u8; 4096];
+
+        let (bytecode, init_memory_state, _) = program.decode();
+        let (lazy_trace, trace, final_memory_state, io_device) =
+            program.trace(&inputs, &untrusted_advice, &trusted_advice);
+
+        let shared_preprocessing = JoltSharedPreprocessing::new(
+            bytecode.clone(),
+            io_device.memory_layout.clone(),
+            init_memory_state,
+            256,
         );
-        assert_eq!(
-            io_device.inputs, inputs,
-            "Inputs mismatch: expected {:?}, got {:?}",
-            inputs, io_device.inputs
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        tracing::info!(
+            "preprocessing.memory_layout.max_trusted_advice_size: {}",
+            shared_preprocessing.memory_layout.max_trusted_advice_size
         );
+
+        let (trusted_commitment, trusted_hint) =
+            commit_trusted_advice_preprocessing_only(&prover_preprocessing, &trusted_advice);
+
+        let prover = RV64IMACProver::gen_from_trace(
+            &prover_preprocessing,
+            lazy_trace,
+            trace,
+            io_device,
+            Some(trusted_commitment),
+            Some(trusted_hint),
+            final_memory_state,
+        );
+
+        // Trace is tiny but advice is max-sized
+        assert!(prover.unpadded_trace_len < 512);
+        assert_eq!(prover.padded_trace_len, 256);
+
+        let io_device = prover.program_io.clone();
+        let (jolt_proof, debug_info) = prover.prove();
+
+        let verifier_preprocessing = JoltVerifierPreprocessing::from(&prover_preprocessing);
+        RV64IMACVerifier::new(
+            &verifier_preprocessing,
+            jolt_proof,
+            io_device,
+            Some(trusted_commitment),
+            debug_info,
+        )
+        .expect("Failed to create verifier")
+        .verify()
+        .expect("Verification failed");
+    }
+
+    #[test]
+    #[serial]
+    fn advice_e2e_dory() {
+        // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
+        let mut program = host::Program::new("merkle-tree-guest");
+        let (bytecode, init_memory_state, _) = program.decode();
+
+        // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4
+        let inputs = postcard::to_stdvec(&[5u8; 32].as_slice()).unwrap();
+        let untrusted_advice = postcard::to_stdvec(&[8u8; 32]).unwrap();
+        let mut trusted_advice = postcard::to_stdvec(&[6u8; 32]).unwrap();
+        trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
+
+        let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
+        let shared_preprocessing = JoltSharedPreprocessing::new(
+            bytecode.clone(),
+            io_device.memory_layout.clone(),
+            init_memory_state,
+            1 << 16,
+        );
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        let elf_contents = program.get_elf_contents().expect("elf contents is None");
+
+        let (trusted_commitment, trusted_hint) =
+            commit_trusted_advice_preprocessing_only(&prover_preprocessing, &trusted_advice);
+
+        let prover = RV64IMACProver::gen_from_elf(
+            &prover_preprocessing,
+            &elf_contents,
+            &inputs,
+            &untrusted_advice,
+            &trusted_advice,
+            Some(trusted_commitment),
+            Some(trusted_hint),
+        );
+        let io_device = prover.program_io.clone();
+        let (jolt_proof, debug_info) = prover.prove();
+
+        let verifier_preprocessing = JoltVerifierPreprocessing::from(&prover_preprocessing);
+        RV64IMACVerifier::new(
+            &verifier_preprocessing,
+            jolt_proof,
+            io_device.clone(),
+            Some(trusted_commitment),
+            debug_info,
+        )
+        .expect("Failed to create verifier")
+        .verify()
+        .expect("Verification failed");
+
+        // Expected merkle root for leaves [5;32], [6;32], [7;32], [8;32]
         let expected_output = &[
             0xb4, 0x37, 0x0f, 0x3a, 0xb, 0x3d, 0x38, 0xa8, 0x7a, 0x6c, 0x4c, 0x46, 0x9, 0xe7, 0x83,
             0xb3, 0xcc, 0xb7, 0x1c, 0x30, 0x1f, 0xf8, 0x54, 0xd, 0xf7, 0xdd, 0xc8, 0x42, 0x32,
             0xbb, 0x16, 0xd7,
         ];
-        assert_eq!(
-            io_device.outputs, expected_output,
-            "Outputs mismatch: expected {:?}, got {:?}",
-            expected_output, io_device.outputs
+        assert_eq!(io_device.outputs, expected_output);
+    }
+
+    #[test]
+    #[serial]
+    fn advice_opening_point_derives_from_unified_point() {
+        // Tests that advice opening points are correctly derived from the unified main opening
+        // point using Dory's balanced dimension policy.
+        //
+        // For a small trace (256 cycles), the advice row coordinates span both Stage 6 (cycle)
+        // and Stage 7 (address) challenges, verifying the two-phase reduction works correctly.
+        let mut program = host::Program::new("fibonacci-guest");
+        let inputs = postcard::to_stdvec(&5u32).unwrap();
+        let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
+        let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
+
+        let (bytecode, init_memory_state, _) = program.decode();
+        let (lazy_trace, trace, final_memory_state, io_device) =
+            program.trace(&inputs, &untrusted_advice, &trusted_advice);
+
+        let shared_preprocessing = JoltSharedPreprocessing::new(
+            bytecode.clone(),
+            io_device.memory_layout.clone(),
+            init_memory_state,
+            1 << 16,
         );
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        let (trusted_commitment, trusted_hint) =
+            commit_trusted_advice_preprocessing_only(&prover_preprocessing, &trusted_advice);
+
+        let prover = RV64IMACProver::gen_from_trace(
+            &prover_preprocessing,
+            lazy_trace,
+            trace,
+            io_device,
+            Some(trusted_commitment),
+            Some(trusted_hint),
+            final_memory_state,
+        );
+
+        assert_eq!(prover.padded_trace_len, 256, "test expects small trace");
+
+        let io_device = prover.program_io.clone();
+        let (jolt_proof, debug_info) = prover.prove();
+        let debug_info = debug_info.expect("expected debug_info in tests");
+
+        // Get unified opening point and derive expected advice point
+        let (opening_point, _) = debug_info
+            .opening_accumulator
+            .get_committed_polynomial_opening(
+                CommittedPolynomial::InstructionRa(0),
+                SumcheckId::HammingWeightClaimReduction,
+            );
+        let mut point_dory_le = opening_point.r.clone();
+        point_dory_le.reverse();
+
+        let total_vars = point_dory_le.len();
+        let (sigma_main, _nu_main) = DoryGlobals::balanced_sigma_nu(total_vars);
+        let (sigma_a, nu_a) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+            prover_preprocessing
+                .shared
+                .memory_layout
+                .max_trusted_advice_size as usize,
+        );
+
+        // Build expected advice point: [col_bits[0..sigma_a] || row_bits[0..nu_a]]
+        let mut expected_advice_le: Vec<_> = point_dory_le[0..sigma_a].to_vec();
+        expected_advice_le.extend_from_slice(&point_dory_le[sigma_main..sigma_main + nu_a]);
+
+        // Verify both advice types derive the same opening point
+        for (name, kind) in [
+            ("trusted", AdviceKind::Trusted),
+            ("untrusted", AdviceKind::Untrusted),
+        ] {
+            let get_fn = debug_info
+                .opening_accumulator
+                .get_advice_opening(kind, SumcheckId::AdviceClaimReductionPhase2);
+            assert!(
+                get_fn.is_some(),
+                "{name} advice opening missing for AdviceClaimReductionPhase2"
+            );
+            let (point_be, _) = get_fn.unwrap();
+            let mut point_le = point_be.r.clone();
+            point_le.reverse();
+            assert_eq!(point_le, expected_advice_le, "{name} advice point mismatch");
+        }
+
+        // Verify end-to-end
+        let verifier_preprocessing = JoltVerifierPreprocessing::from(&prover_preprocessing);
+        RV64IMACVerifier::new(
+            &verifier_preprocessing,
+            jolt_proof,
+            io_device,
+            Some(trusted_commitment),
+            Some(debug_info),
+        )
+        .expect("Failed to create verifier")
+        .verify()
+        .expect("Verification failed");
     }
 
     #[test]
@@ -1666,14 +2064,21 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
-        let prover =
-            RV64IMACProver::gen_from_elf(&prover_preprocessing, elf_contents, &[], &[], &[], None);
+        let prover = RV64IMACProver::gen_from_elf(
+            &prover_preprocessing,
+            elf_contents,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+        );
         let io_device = prover.program_io.clone();
         let (jolt_proof, debug_info) = prover.prove();
 
@@ -1704,10 +2109,10 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -1716,6 +2121,7 @@ mod tests {
             &inputs,
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -1748,10 +2154,10 @@ mod tests {
             bytecode.clone(),
             io_device.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -1760,6 +2166,7 @@ mod tests {
             &[50],
             &[],
             &[],
+            None,
             None,
         );
         let io_device = prover.program_io.clone();
@@ -1796,16 +2203,17 @@ mod tests {
             bytecode.clone(),
             program_io.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
 
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
 
         let prover = RV64IMACProver::gen_from_trace(
             &prover_preprocessing,
             lazy_trace,
             trace,
             program_io.clone(),
+            None,
             None,
             final_memory_state,
         );
@@ -1836,9 +2244,9 @@ mod tests {
             bytecode.clone(),
             program_io.memory_layout.clone(),
             init_memory_state,
+            1 << 16,
         );
-        let prover_preprocessing =
-            JoltProverPreprocessing::new(shared_preprocessing.clone(), 1 << 16);
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
 
         // change memory address of output & termination bit to the same address as input
         // changes here should not be able to spoof the verifier result
@@ -1851,6 +2259,7 @@ mod tests {
             lazy_trace,
             trace,
             program_io.clone(),
+            None,
             None,
             final_memory_state,
         );

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -871,8 +871,10 @@ impl<'a, F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, ProofTranscrip
             &self.program_io.memory_layout,
             &self.one_hot_params,
         );
-        let lookups_read_raf =
-            InstructionReadRafSumcheckProver::initialize(lookups_read_raf_params, &self.trace);
+        let lookups_read_raf = InstructionReadRafSumcheckProver::initialize(
+            lookups_read_raf_params,
+            Arc::clone(&self.trace),
+        );
 
         #[cfg(feature = "allocative")]
         {

--- a/jolt-core/src/zkvm/ram/val_evaluation.rs
+++ b/jolt-core/src/zkvm/ram/val_evaluation.rs
@@ -26,6 +26,7 @@ use crate::{
     utils::math::Math,
     zkvm::{
         bytecode::BytecodePreprocessing,
+        claim_reductions::AdviceKind,
         config::OneHotParams,
         ram::remap_address,
         witness::{CommittedPolynomial, VirtualPolynomial},
@@ -109,7 +110,8 @@ impl<F: JoltField> ValEvaluationSumcheckParams<F> {
 
         // Calculate untrusted advice contribution
         let untrusted_contribution = super::calculate_advice_memory_evaluation(
-            opening_accumulator.get_untrusted_advice_opening(SumcheckId::RamValEvaluation),
+            opening_accumulator
+                .get_advice_opening(AdviceKind::Untrusted, SumcheckId::RamValEvaluation),
             (program_io.memory_layout.max_untrusted_advice_size as usize / 8)
                 .next_power_of_two()
                 .log_2(),
@@ -121,7 +123,8 @@ impl<F: JoltField> ValEvaluationSumcheckParams<F> {
 
         // Calculate trusted advice contribution
         let trusted_contribution = super::calculate_advice_memory_evaluation(
-            opening_accumulator.get_trusted_advice_opening(SumcheckId::RamValEvaluation),
+            opening_accumulator
+                .get_advice_opening(AdviceKind::Trusted, SumcheckId::RamValEvaluation),
             (program_io.memory_layout.max_trusted_advice_size as usize / 8)
                 .next_power_of_two()
                 .log_2(),

--- a/jolt-core/src/zkvm/ram/val_final.rs
+++ b/jolt-core/src/zkvm/ram/val_final.rs
@@ -21,6 +21,7 @@ use crate::{
     utils::math::Math,
     zkvm::{
         bytecode::BytecodePreprocessing,
+        claim_reductions::AdviceKind,
         ram::remap_address,
         witness::{CommittedPolynomial, VirtualPolynomial},
     },
@@ -87,7 +88,7 @@ impl<F: JoltField> ValFinalSumcheckParams<F> {
         };
 
         let untrusted_advice_contribution = super::calculate_advice_memory_evaluation(
-            opening_accumulator.get_untrusted_advice_opening(advice_sumcheck_id),
+            opening_accumulator.get_advice_opening(AdviceKind::Untrusted, advice_sumcheck_id),
             (program_io.memory_layout.max_untrusted_advice_size as usize / 8)
                 .next_power_of_two()
                 .log_2(),
@@ -98,7 +99,7 @@ impl<F: JoltField> ValFinalSumcheckParams<F> {
         );
 
         let trusted_advice_contribution = super::calculate_advice_memory_evaluation(
-            opening_accumulator.get_trusted_advice_opening(advice_sumcheck_id),
+            opening_accumulator.get_advice_opening(AdviceKind::Trusted, advice_sumcheck_id),
             (program_io.memory_layout.max_trusted_advice_size as usize / 8)
                 .next_power_of_two()
                 .log_2(),

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -18,6 +18,7 @@ use crate::zkvm::Serializable;
 use crate::zkvm::{
     bytecode::read_raf_checking::BytecodeReadRafSumcheckVerifier,
     claim_reductions::{
+        AdviceClaimReductionPhase1Verifier, AdviceClaimReductionPhase2Verifier, AdviceKind,
         HammingWeightClaimReductionVerifier, IncClaimReductionSumcheckVerifier,
         InstructionLookupsClaimReductionSumcheckVerifier, RamRaClaimReductionSumcheckVerifier,
     },
@@ -50,7 +51,8 @@ use crate::zkvm::{
 use crate::{
     field::JoltField,
     poly::opening_proof::{
-        DoryOpeningState, OpeningAccumulator, OpeningPoint, SumcheckId, VerifierOpeningAccumulator,
+        compute_advice_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningPoint,
+        SumcheckId, VerifierOpeningAccumulator,
     },
     pprof_scope,
     subprotocols::{
@@ -80,6 +82,9 @@ pub struct JoltVerifier<
     pub preprocessing: &'a JoltVerifierPreprocessing<F, PCS>,
     pub transcript: ProofTranscript,
     pub opening_accumulator: VerifierOpeningAccumulator<F>,
+    /// Phase-bridge randomness for two-phase advice claim reduction.
+    advice_reduction_gamma_trusted: Option<F>,
+    advice_reduction_gamma_untrusted: Option<F>,
     pub spartan_key: UniformSpartanKey<F>,
     pub one_hot_params: OneHotParams,
 }
@@ -159,6 +164,8 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
             preprocessing,
             transcript,
             opening_accumulator,
+            advice_reduction_gamma_trusted: None,
+            advice_reduction_gamma_untrusted: None,
             spartan_key,
             one_hot_params,
         })
@@ -197,8 +204,6 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
         self.verify_stage4()?;
         self.verify_stage5()?;
         self.verify_stage6()?;
-        self.verify_trusted_advice_opening_proofs()?;
-        self.verify_untrusted_advice_opening_proofs()?;
         self.verify_stage7()?;
         self.verify_stage8()?;
 
@@ -433,16 +438,52 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
             &mut self.transcript,
         );
 
+        // Advice claim reduction (Phase 1 in Stage 6): trusted and untrusted are separate instances.
+        let trusted_advice_phase1 = AdviceClaimReductionPhase1Verifier::new(
+            AdviceKind::Trusted,
+            &self.program_io.memory_layout,
+            self.proof.trace_length,
+            &self.opening_accumulator,
+            &mut self.transcript,
+            self.proof
+                .rw_config
+                .needs_single_advice_opening(self.proof.trace_length.log_2()),
+        );
+        if let Some(ref v) = trusted_advice_phase1 {
+            self.advice_reduction_gamma_trusted = Some(v.gamma());
+        }
+        let untrusted_advice_phase1 = AdviceClaimReductionPhase1Verifier::new(
+            AdviceKind::Untrusted,
+            &self.program_io.memory_layout,
+            self.proof.trace_length,
+            &self.opening_accumulator,
+            &mut self.transcript,
+            self.proof
+                .rw_config
+                .needs_single_advice_opening(self.proof.trace_length.log_2()),
+        );
+        if let Some(ref v) = untrusted_advice_phase1 {
+            self.advice_reduction_gamma_untrusted = Some(v.gamma());
+        }
+
+        let mut instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript>> = vec![
+            &bytecode_read_raf,
+            &ram_hamming_booleanity,
+            &booleanity,
+            &ram_ra_virtual,
+            &lookups_ra_virtual,
+            &inc_reduction,
+        ];
+        if let Some(ref advice) = trusted_advice_phase1 {
+            instances.push(advice);
+        }
+        if let Some(ref advice) = untrusted_advice_phase1 {
+            instances.push(advice);
+        }
+
         let _r_stage6 = BatchedSumcheck::verify(
             &self.proof.stage6_sumcheck_proof,
-            vec![
-                &bytecode_read_raf as &dyn SumcheckInstanceVerifier<F, ProofTranscript>,
-                &ram_hamming_booleanity,
-                &booleanity,
-                &ram_ra_virtual,
-                &lookups_ra_virtual,
-                &inc_reduction,
-            ],
+            instances,
             &mut self.opening_accumulator,
             &mut self.transcript,
         )
@@ -461,8 +502,41 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
             &mut self.transcript,
         );
 
-        // Verify sumcheck (only log_k_chunk rounds)
-        let instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript>> = vec![&hw_verifier];
+        // 3. Verify Stage 7 batched sumcheck (address rounds only).
+        // Includes HammingWeightClaimReduction plus Phase 2 advice reduction instances (if needed).
+        let trusted_advice_phase2 = self.advice_reduction_gamma_trusted.and_then(|gamma| {
+            AdviceClaimReductionPhase2Verifier::new(
+                AdviceKind::Trusted,
+                &self.program_io.memory_layout,
+                self.proof.trace_length,
+                gamma,
+                &self.opening_accumulator,
+                self.proof
+                    .rw_config
+                    .needs_single_advice_opening(self.proof.trace_length.log_2()),
+            )
+        });
+        let untrusted_advice_phase2 = self.advice_reduction_gamma_untrusted.and_then(|gamma| {
+            AdviceClaimReductionPhase2Verifier::new(
+                AdviceKind::Untrusted,
+                &self.program_io.memory_layout,
+                self.proof.trace_length,
+                gamma,
+                &self.opening_accumulator,
+                self.proof
+                    .rw_config
+                    .needs_single_advice_opening(self.proof.trace_length.log_2()),
+            )
+        });
+
+        let mut instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript>> =
+            vec![&hw_verifier];
+        if let Some(ref v) = trusted_advice_phase2 {
+            instances.push(v);
+        }
+        if let Some(ref v) = untrusted_advice_phase2 {
+            instances.push(v);
+        }
         let _r_address_stage7 = BatchedSumcheck::verify(
             &self.proof.stage7_sumcheck_proof,
             instances,
@@ -528,6 +602,33 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
             polynomial_claims.push((CommittedPolynomial::RamRa(i), claim));
         }
 
+        // Advice polynomials: TrustedAdvice and UntrustedAdvice (from AdviceClaimReduction in Stage 6)
+        // These are committed with smaller dimensions, so we apply Lagrange factors to embed
+        // them in the top-left block of the main Dory matrix.
+        if let Some((advice_point, advice_claim)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReductionPhase2)
+        {
+            let lagrange_factor =
+                compute_advice_lagrange_factor::<F>(&opening_point.r, advice_point.len());
+            polynomial_claims.push((
+                CommittedPolynomial::TrustedAdvice,
+                advice_claim * lagrange_factor,
+            ));
+        }
+
+        if let Some((advice_point, advice_claim)) = self.opening_accumulator.get_advice_opening(
+            AdviceKind::Untrusted,
+            SumcheckId::AdviceClaimReductionPhase2,
+        ) {
+            let lagrange_factor =
+                compute_advice_lagrange_factor::<F>(&opening_point.r, advice_point.len());
+            polynomial_claims.push((
+                CommittedPolynomial::UntrustedAdvice,
+                advice_claim * lagrange_factor,
+            ));
+        }
+
         // 2. Sample gamma and compute powers for RLC
         let claims: Vec<F> = polynomial_claims.iter().map(|(_, c)| *c).collect();
         self.transcript.append_scalars(&claims);
@@ -547,6 +648,26 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
             .zip_eq(&self.proof.commitments)
         {
             commitments_map.insert(polynomial, commitment.clone());
+        }
+
+        // Add advice commitments if they're part of the batch
+        if let Some(ref commitment) = self.trusted_advice_commitment {
+            if state
+                .polynomial_claims
+                .iter()
+                .any(|(p, _)| *p == CommittedPolynomial::TrustedAdvice)
+            {
+                commitments_map.insert(CommittedPolynomial::TrustedAdvice, commitment.clone());
+            }
+        }
+        if let Some(ref commitment) = self.proof.untrusted_advice_commitment {
+            if state
+                .polynomial_claims
+                .iter()
+                .any(|(p, _)| *p == CommittedPolynomial::UntrustedAdvice)
+            {
+                commitments_map.insert(CommittedPolynomial::UntrustedAdvice, commitment.clone());
+            }
         }
 
         // Compute joint commitment: Σ γ_i · C_i
@@ -594,133 +715,6 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
 
         PCS::combine_commitments(&commitments, &coeffs)
     }
-
-    fn verify_trusted_advice_opening_proofs(&mut self) -> Result<(), anyhow::Error> {
-        if let Some(ref commitment) = self.trusted_advice_commitment {
-            // Verify at RamValEvaluation point
-            let Some(ref proof) = self.proof.trusted_advice_val_evaluation_proof else {
-                return Err(anyhow::anyhow!(
-                    "Trusted advice val evaluation proof not found"
-                ));
-            };
-            let Some((point, eval)) = self
-                .opening_accumulator
-                .get_trusted_advice_opening(SumcheckId::RamValEvaluation)
-            else {
-                return Err(anyhow::anyhow!("Trusted advice opening not found"));
-            };
-            PCS::verify(
-                proof,
-                &self.preprocessing.generators,
-                &mut self.transcript,
-                &point.r,
-                &eval,
-                commitment,
-            )
-            .map_err(|e| {
-                anyhow::anyhow!("Trusted advice opening proof verification failed: {e:?}")
-            })?;
-
-            // Verify at RamValFinalEvaluation point - only if different from ValEvaluation
-            if !self
-                .proof
-                .rw_config
-                .needs_single_advice_opening(self.proof.trace_length.log_2())
-            {
-                let Some(ref proof_val_final) = self.proof.trusted_advice_val_final_proof else {
-                    return Err(anyhow::anyhow!("Trusted advice val final proof not found"));
-                };
-                let Some((point_val_final, eval_val_final)) = self
-                    .opening_accumulator
-                    .get_trusted_advice_opening(SumcheckId::RamValFinalEvaluation)
-                else {
-                    return Err(anyhow::anyhow!(
-                        "Trusted advice val final opening not found"
-                    ));
-                };
-                PCS::verify(
-                    proof_val_final,
-                    &self.preprocessing.generators,
-                    &mut self.transcript,
-                    &point_val_final.r,
-                    &eval_val_final,
-                    commitment,
-                )
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Trusted advice val final opening proof verification failed: {e:?}"
-                    )
-                })?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn verify_untrusted_advice_opening_proofs(&mut self) -> Result<(), anyhow::Error> {
-        use crate::poly::opening_proof::SumcheckId;
-        if let Some(ref commitment) = self.proof.untrusted_advice_commitment {
-            // Verify at RamValEvaluation point
-            let Some(ref proof) = self.proof.untrusted_advice_val_evaluation_proof else {
-                return Err(anyhow::anyhow!(
-                    "Untrusted advice val evaluation proof not found"
-                ));
-            };
-            let Some((point, eval)) = self
-                .opening_accumulator
-                .get_untrusted_advice_opening(SumcheckId::RamValEvaluation)
-            else {
-                return Err(anyhow::anyhow!("Untrusted advice opening not found"));
-            };
-            PCS::verify(
-                proof,
-                &self.preprocessing.generators,
-                &mut self.transcript,
-                &point.r,
-                &eval,
-                commitment,
-            )
-            .map_err(|e| {
-                anyhow::anyhow!("Untrusted advice opening proof verification failed: {e:?}")
-            })?;
-
-            // Verify at RamValFinalEvaluation point - only if different from ValEvaluation
-            if !self
-                .proof
-                .rw_config
-                .needs_single_advice_opening(self.proof.trace_length.log_2())
-            {
-                let Some(ref proof_val_final) = self.proof.untrusted_advice_val_final_proof else {
-                    return Err(anyhow::anyhow!(
-                        "Untrusted advice val final proof not found"
-                    ));
-                };
-                let Some((point_val_final, eval_val_final)) = self
-                    .opening_accumulator
-                    .get_untrusted_advice_opening(SumcheckId::RamValFinalEvaluation)
-                else {
-                    return Err(anyhow::anyhow!(
-                        "Untrusted advice val final opening not found"
-                    ));
-                };
-                PCS::verify(
-                    proof_val_final,
-                    &self.preprocessing.generators,
-                    &mut self.transcript,
-                    &point_val_final.r,
-                    &eval_val_final,
-                    commitment,
-                )
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Untrusted advice val final opening proof verification failed: {e:?}"
-                    )
-                })?;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -728,6 +722,7 @@ pub struct JoltSharedPreprocessing {
     pub bytecode: Arc<BytecodePreprocessing>,
     pub ram: RAMPreprocessing,
     pub memory_layout: MemoryLayout,
+    pub max_padded_trace_length: usize,
 }
 
 impl CanonicalSerialize for JoltSharedPreprocessing {
@@ -743,6 +738,8 @@ impl CanonicalSerialize for JoltSharedPreprocessing {
         self.ram.serialize_with_mode(&mut writer, compress)?;
         self.memory_layout
             .serialize_with_mode(&mut writer, compress)?;
+        self.max_padded_trace_length
+            .serialize_with_mode(&mut writer, compress)?;
         Ok(())
     }
 
@@ -750,6 +747,7 @@ impl CanonicalSerialize for JoltSharedPreprocessing {
         self.bytecode.serialized_size(compress)
             + self.ram.serialized_size(compress)
             + self.memory_layout.serialized_size(compress)
+            + self.max_padded_trace_length.serialized_size(compress)
     }
 }
 
@@ -763,10 +761,13 @@ impl CanonicalDeserialize for JoltSharedPreprocessing {
             BytecodePreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
         let ram = RAMPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
         let memory_layout = MemoryLayout::deserialize_with_mode(&mut reader, compress, validate)?;
+        let max_padded_trace_length =
+            usize::deserialize_with_mode(&mut reader, compress, validate)?;
         Ok(Self {
             bytecode: Arc::new(bytecode),
             ram,
             memory_layout,
+            max_padded_trace_length,
         })
     }
 }
@@ -785,6 +786,7 @@ impl JoltSharedPreprocessing {
         bytecode: Vec<Instruction>,
         memory_layout: MemoryLayout,
         memory_init: Vec<(u64, u8)>,
+        max_padded_trace_length: usize,
     ) -> JoltSharedPreprocessing {
         let bytecode = Arc::new(BytecodePreprocessing::preprocess(bytecode));
         let ram = RAMPreprocessing::preprocess(memory_init);
@@ -792,6 +794,7 @@ impl JoltSharedPreprocessing {
             bytecode,
             ram,
             memory_layout,
+            max_padded_trace_length,
         }
     }
 }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -4,6 +4,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::DoryGlobals;
 use crate::subprotocols::sumcheck::BatchedSumcheck;
 use crate::zkvm::bytecode::BytecodePreprocessing;
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
@@ -167,6 +168,12 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
     pub fn verify(mut self) -> Result<(), anyhow::Error> {
         let _pprof_verify = pprof_scope!("verify");
         // Parameters are computed from trace length as needed
+
+        // Initialize Dory globals for the verifier
+        // The verifier needs these to compute commitments during verification
+        let padded_trace_len = self.proof.trace_length.next_power_of_two();
+        let _dory_guard =
+            DoryGlobals::initialize(1 << self.one_hot_params.log_k_chunk, padded_trace_len);
 
         fiat_shamir_preamble(
             &self.program_io,

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::subprotocols::sumcheck::BatchedSumcheck;
@@ -15,7 +16,7 @@ use crate::zkvm::ram::RAMPreprocessing;
 use crate::zkvm::witness::all_committed_polynomials;
 use crate::zkvm::Serializable;
 use crate::zkvm::{
-    bytecode::read_raf_checking::ReadRafSumcheckVerifier as BytecodeReadRafSumcheckVerifier,
+    bytecode::read_raf_checking::BytecodeReadRafSumcheckVerifier,
     claim_reductions::{
         HammingWeightClaimReductionVerifier, IncClaimReductionSumcheckVerifier,
         InstructionLookupsClaimReductionSumcheckVerifier, RamRaClaimReductionSumcheckVerifier,
@@ -23,7 +24,7 @@ use crate::zkvm::{
     fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
-        read_raf_checking::ReadRafSumcheckVerifier as LookupsReadRafSumcheckVerifier,
+        read_raf_checking::InstructionReadRafSumcheckVerifier,
     },
     proof_serialization::JoltProof,
     r1cs::key::UniformSpartanKey,
@@ -373,7 +374,7 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
             &self.opening_accumulator,
             &mut self.transcript,
         );
-        let lookups_read_raf = LookupsReadRafSumcheckVerifier::new(
+        let lookups_read_raf = InstructionReadRafSumcheckVerifier::new(
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
@@ -722,11 +723,60 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
     }
 }
 
-#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Clone)]
 pub struct JoltSharedPreprocessing {
-    pub bytecode: BytecodePreprocessing,
+    pub bytecode: Arc<BytecodePreprocessing>,
     pub ram: RAMPreprocessing,
     pub memory_layout: MemoryLayout,
+}
+
+impl CanonicalSerialize for JoltSharedPreprocessing {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        // Serialize the inner BytecodePreprocessing (not the Arc wrapper)
+        self.bytecode
+            .as_ref()
+            .serialize_with_mode(&mut writer, compress)?;
+        self.ram.serialize_with_mode(&mut writer, compress)?;
+        self.memory_layout
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.bytecode.serialized_size(compress)
+            + self.ram.serialized_size(compress)
+            + self.memory_layout.serialized_size(compress)
+    }
+}
+
+impl CanonicalDeserialize for JoltSharedPreprocessing {
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let bytecode =
+            BytecodePreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
+        let ram = RAMPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
+        let memory_layout = MemoryLayout::deserialize_with_mode(&mut reader, compress, validate)?;
+        Ok(Self {
+            bytecode: Arc::new(bytecode),
+            ram,
+            memory_layout,
+        })
+    }
+}
+
+impl ark_serialize::Valid for JoltSharedPreprocessing {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.bytecode.check()?;
+        self.ram.check()?;
+        self.memory_layout.check()
+    }
 }
 
 impl JoltSharedPreprocessing {
@@ -736,7 +786,7 @@ impl JoltSharedPreprocessing {
         memory_layout: MemoryLayout,
         memory_init: Vec<(u64, u8)>,
     ) -> JoltSharedPreprocessing {
-        let bytecode = BytecodePreprocessing::preprocess(bytecode);
+        let bytecode = Arc::new(BytecodePreprocessing::preprocess(bytecode));
         let ram = RAMPreprocessing::preprocess(memory_init);
         Self {
             bytecode,

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -180,8 +180,11 @@ impl<'a, F: JoltField, PCS: CommitmentScheme<Field = F>, ProofTranscript: Transc
         // Initialize Dory globals for the verifier
         // The verifier needs these to compute commitments during verification
         let padded_trace_len = self.proof.trace_length.next_power_of_two();
-        let _dory_guard =
-            DoryGlobals::initialize(1 << self.one_hot_params.log_k_chunk, padded_trace_len);
+        let _ = DoryGlobals::initialize_context(
+            1 << self.one_hot_params.log_k_chunk,
+            padded_trace_len,
+            crate::poly::commitment::dory::DoryContext::Main,
+        );
 
         fiat_shamir_preamble(
             &self.program_io,

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -35,6 +35,12 @@ pub enum CommittedPolynomial {
     /// Note that for RAM, ra and wa are the same polynomial because
     /// there is at most one load or store per cycle.
     RamRa(usize),
+    /// Trusted advice polynomial - committed before proving, verifier has commitment.
+    /// Length cannot exceed max_trace_length.
+    TrustedAdvice,
+    /// Untrusted advice polynomial - committed during proving, commitment in proof.
+    /// Length cannot exceed max_trace_length.
+    UntrustedAdvice,
 }
 
 /// Returns a list of symbols representing all committed polynomials.
@@ -121,6 +127,9 @@ impl CommittedPolynomial {
                     .collect();
                 PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
             }
+            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
+                panic!("Advice polynomials should not use streaming witness generation")
+            }
         }
     }
 
@@ -202,6 +211,9 @@ impl CommittedPolynomial {
                     addresses,
                     one_hot_params.k_chunk,
                 ))
+            }
+            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
+                panic!("Advice polynomials should not use generate_witness")
             }
         }
     }

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -2,7 +2,7 @@
 
 git submodule update --init --recursive
 
-apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3 python3-pip build-essential device-tree-compiler gcc-riscv64-unknown-elf binutils-riscv64-unknown-elf
+apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3 python3-pip python3-dev build-essential device-tree-compiler gcc-riscv64-unknown-elf binutils-riscv64-unknown-elf
 
 mkdir -p ~/.config/pip && printf "[global]\nbreak-system-packages = true\n" > ~/.config/pip/pip.conf
 python3 -m pip install --force-reinstall --upgrade pip

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -227,6 +227,19 @@ fn setup_emulator_with_backtraces(
     let mut emulator = Emulator::new(Box::new(term));
     emulator.update_xlen(get_xlen());
 
+    assert!(
+        trusted_advice.len() as u64 <= memory_config.max_trusted_advice_size,
+        "Trusted advice too long: got {} bytes, max is {} bytes (set by MemoryConfig.max_trusted_advice_size).",
+        trusted_advice.len(),
+        memory_config.max_trusted_advice_size,
+    );
+    assert!(
+        untrusted_advice.len() as u64 <= memory_config.max_untrusted_advice_size,
+        "Untrusted advice too long: got {} bytes, max is {} bytes (set by MemoryConfig.max_untrusted_advice_size).",
+        untrusted_advice.len(),
+        memory_config.max_untrusted_advice_size,
+    );
+
     let mut jolt_device = JoltDevice::new(memory_config);
     jolt_device.inputs = inputs.to_vec();
     jolt_device.trusted_advice = trusted_advice.to_vec();
@@ -513,8 +526,42 @@ impl<I: Iterator<Item: Clone>> Iterator for IterChunks<I> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
+
+    fn minimal_elf() -> Vec<u8> {
+        vec![
+            0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x02, 0x00, 0xf3, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+            0x38, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]
+    }
+
+    #[test]
+    #[should_panic(expected = "Trusted advice too long")]
+    fn panics_when_trusted_advice_exceeds_max() {
+        let elf = minimal_elf();
+        let memory_config = MemoryConfig {
+            program_size: Some(1024),
+            max_trusted_advice_size: 2048,
+            ..Default::default()
+        };
+        let _ = setup_emulator(&elf, b"[]", &[], &[0u8; 4096], &memory_config);
+    }
+
+    #[test]
+    #[should_panic(expected = "Untrusted advice too long")]
+    fn panics_when_untrusted_advice_exceeds_max() {
+        let elf = minimal_elf();
+        let memory_config = MemoryConfig {
+            program_size: Some(1024),
+            max_untrusted_advice_size: 128,
+            ..Default::default()
+        };
+        let _ = setup_emulator(&elf, b"[]", &[0u8; 256], &[], &memory_config);
+    }
     const ELF_CONTENTS: [u8; 6404] = [
         0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x02, 0x00, 0xf3, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x34, 0x00,


### PR DESCRIPTION
Introduce a `DoryLayout` enum to allow switching between row-major and column-major matrix data layouts for Dory commitments.

The current `main` branch uses a row-major Dory layout, which is incompatible with an older "k-chunk major" (column-major) layout used in a C++ integration. This PR adds an enum to configure the Dory matrix layout, enabling compatibility with both existing and new Dory implementations.

---
<a href="https://cursor.com/background-agent?bcId=bc-57c1c8d1-38b5-4b4f-887b-8e5c30a2753b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57c1c8d1-38b5-4b4f-887b-8e5c30a2753b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

