### PR TITLE
Tighten small soundness edge cases

### DIFF
--- a/jolt-core/src/poly/lagrange_poly.rs
+++ b/jolt-core/src/poly/lagrange_poly.rs
@@ -550,7 +550,7 @@ impl LagrangeHelper {
                 sums[k] += pow;
                 pow = match pow.checked_mul(t) {
                     Some(v) => v,
-                    None => 0, // saturate to 0 in const context; for our ranges this won't trigger
+                    None => panic!("power_sums overflow"),
                 };
                 k += 1;
             }

--- a/jolt-core/src/subprotocols/mles_product_sum.rs
+++ b/jolt-core/src/subprotocols/mles_product_sum.rs
@@ -344,8 +344,8 @@ pub fn eval_linear_prod_accumulate<F: JoltField>(
         3 => eval_prod_3_accumulate(pairs.try_into().unwrap(), sums),
         5 => eval_prod_5_accumulate(pairs.try_into().unwrap(), sums),
         9 => eval_prod_9_accumulate(pairs.try_into().unwrap(), sums),
-        // Implement more efficient than naive if these ever get used.
-        4 | 6 | 7 | 8 => unimplemented!("n_pairs = {}", pairs.len()),
+        // These arities are uncommon enough that the generic fallback is preferable to panicking.
+        4 | 6 | 7 | 8 => product_eval_univariate_naive_accumulate(pairs, sums),
         _ => product_eval_univariate_naive_accumulate(pairs, sums),
     }
 }

--- a/jolt-core/src/zkvm/r1cs/constraints.rs
+++ b/jolt-core/src/zkvm/r1cs/constraints.rs
@@ -146,7 +146,7 @@ pub const fn constraint_eq_conditional_lc(condition: LC, left: LC, right: LC) ->
         condition,
         match left.checked_sub(right) {
             Some(b) => b,
-            None => LC::zero(),
+            None => panic!("constraint_eq_conditional_lc overflow"),
         },
     )
 }
@@ -351,6 +351,8 @@ pub static R1CS_CONSTRAINTS: [NamedR1CSConstraint; NUM_R1CS_CONSTRAINTS] = [
     // if Jump && !NextIsNoop {
     //     assert!(NextUnexpandedPC == LookupOutput)
     // }
+    // `ShouldJump` is defined as `Jump * (1 - NextIsNoop)` in the product-virtualization
+    // stage, so valid proofs cannot silently drop the `NextIsNoop` guard here.
     r1cs_eq_conditional!(
         label: R1CSConstraintLabel::NextUnexpPCEqLookupIfShouldJump,
         if { { JoltR1CSInputs::ShouldJump } }
@@ -373,7 +375,8 @@ pub static R1CS_CONSTRAINTS: [NamedR1CSConstraint; NUM_R1CS_CONSTRAINTS] = [
     //         assert!(NextUnexpandedPC == UnexpandedPC + 4)
     //     }
     // }
-    // Note that ShouldBranch and Jump instructions are mutually exclusive
+    // Note that `ShouldBranch` and `Jump` are mutually exclusive for valid bytecode:
+    // `ShouldBranch` includes the branch instruction flag, while `Jump` is a distinct opcode.
     // And that DoNotUpdatePC and isCompressed are mutually exclusive
     r1cs_eq_conditional!(
         label: R1CSConstraintLabel::NextUnexpPCUpdateOtherwise,


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5.4) on behalf of the user (Quang Dao) with approval.

## Summary
- make `constraint_eq_conditional_lc` fail closed on overflow
- replace the product-eval `unimplemented!()` arity gap with the naive fallback
- turn the `power_sums` overflow zero-fallback into a hard failure
- document the already-mitigated `ShouldJump` and `ShouldBranch` invariants inline

## Validation
- validated locally on the full stack with the required fmt, clippy, and nextest commands
