### PR TITLE
Bound proof deserialization without format changes

### DIFF
--- a/jolt-core/src/field/challenge/mont_ark_u128.rs
+++ b/jolt-core/src/field/challenge/mont_ark_u128.rs
@@ -36,6 +36,9 @@ pub struct MontU128Challenge<F: JoltField> {
 // Custom serialization: serialize as [u64; 4] for compatibility with field element format
 impl<F: JoltField> Valid for MontU128Challenge<F> {
     fn check(&self) -> Result<(), SerializationError> {
+        if (self.high >> 61) != 0 {
+            return Err(SerializationError::InvalidData);
+        }
         Ok(())
     }
 }
@@ -63,12 +66,18 @@ impl<F: JoltField> CanonicalDeserialize for MontU128Challenge<F> {
         validate: Validate,
     ) -> Result<Self, SerializationError> {
         let arr = <[u64; 4]>::deserialize_with_mode(reader, compress, validate)?;
-        // arr[0] and arr[1] should be 0, arr[2] is low, arr[3] is high
-        Ok(Self {
+        if arr[0] != 0 || arr[1] != 0 {
+            return Err(SerializationError::InvalidData);
+        }
+        let value = Self {
             low: arr[2],
             high: arr[3],
             _marker: PhantomData,
-        })
+        };
+        if validate == Validate::Yes {
+            value.check()?;
+        }
+        Ok(value)
     }
 }
 
@@ -230,11 +239,28 @@ impl OptimizedMul<TrackedFr, TrackedFr> for MontU128Challenge<TrackedFr> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ark_serialize::CanonicalSerialize;
 
     #[test]
     fn masks_high_three_bits_in_default_challenge_width() {
         let challenge = MontU128Challenge::<ark_bn254::Fr>::new(u128::MAX);
         assert_eq!(challenge.low, u64::MAX);
         assert_eq!(challenge.high, (u64::MAX >> 3));
+    }
+
+    #[test]
+    fn rejects_nonzero_lower_limbs_on_deserialize() {
+        let mut bytes = Vec::new();
+        [1u64, 0, 0, 0].serialize_compressed(&mut bytes).unwrap();
+        assert!(MontU128Challenge::<ark_bn254::Fr>::deserialize_compressed(&bytes[..]).is_err());
+    }
+
+    #[test]
+    fn rejects_high_bits_outside_challenge_width() {
+        let mut bytes = Vec::new();
+        [0u64, 0, 0, 1u64 << 61]
+            .serialize_compressed(&mut bytes)
+            .unwrap();
+        assert!(MontU128Challenge::<ark_bn254::Fr>::deserialize_compressed(&bytes[..]).is_err());
     }
 }

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -1,7 +1,11 @@
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 
 use crate::field::JoltField;
 use crate::poly::eq_poly::EqPolynomial;
+use crate::utils::serialization::{
+    deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+    MAX_BLINDFOLD_VECTOR_LEN,
+};
 
 /// combined[k] = Σ_i eq(ry_row, i) · flat[i*cols + k]
 pub fn combined_row<F: JoltField>(flat: &[F], cols: usize, ry_row: &[F]) -> Vec<F> {
@@ -44,10 +48,56 @@ pub fn combined_blinding<F: JoltField>(row_blindings: &[F], ry_row: &[F]) -> F {
         .sum()
 }
 
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug)]
 pub struct HyraxOpeningProof<F: JoltField> {
     pub combined_row: Vec<F>,
     pub combined_blinding: F,
+}
+
+impl<F: JoltField> CanonicalSerialize for HyraxOpeningProof<F> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        serialize_vec_with_len(&self.combined_row, &mut writer, compress)?;
+        self.combined_blinding
+            .serialize_with_mode(&mut writer, compress)
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        serialized_vec_with_len_size(&self.combined_row, compress)
+            + self.combined_blinding.serialized_size(compress)
+    }
+}
+
+impl<F: JoltField> ark_serialize::Valid for HyraxOpeningProof<F> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.combined_row.check()?;
+        self.combined_blinding.check()
+    }
+}
+
+impl<F: JoltField> CanonicalDeserialize for HyraxOpeningProof<F> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let proof = Self {
+            combined_row: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            combined_blinding: F::deserialize_with_mode(&mut reader, compress, validate)?,
+        };
+        if validate == ark_serialize::Validate::Yes {
+            proof.check()?;
+        }
+        Ok(proof)
+    }
 }
 
 #[cfg(test)]

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -1,4 +1,8 @@
 use crate::field::{ChallengeFieldOps, FieldChallengeOps, JoltField};
+use crate::utils::serialization::{
+    deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+    MAX_UNIPOLY_COEFFS,
+};
 use std::cmp::Ordering;
 use std::iter::zip;
 use std::ops::{Add, AddAssign, Index, IndexMut, Mul, MulAssign, Sub};
@@ -14,21 +18,106 @@ use crate::utils::small_scalar::SmallScalar;
 
 // ax^2 + bx + c stored as vec![c,b,a]
 // ax^3 + bx^2 + cx + d stored as vec![d,c,b,a]
-#[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Clone, PartialEq, Allocative)]
+#[derive(Debug, Clone, PartialEq, Allocative)]
 pub struct UniPoly<F: CanonicalSerialize + CanonicalDeserialize> {
     pub coeffs: Vec<F>,
 }
 
 // ax^2 + bx + c stored as vec![c,a]
 // ax^3 + bx^2 + cx + d stored as vec![d,b,a]
-#[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct CompressedUniPoly<F: JoltField> {
     pub coeffs_except_linear_term: Vec<F>,
 }
 
+impl<F: CanonicalSerialize + CanonicalDeserialize> CanonicalSerialize for UniPoly<F> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        serialize_vec_with_len(&self.coeffs, writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        serialized_vec_with_len_size(&self.coeffs, compress)
+    }
+}
+
+impl<F: CanonicalSerialize + CanonicalDeserialize> Valid for UniPoly<F> {
+    fn check(&self) -> Result<(), SerializationError> {
+        if self.coeffs.is_empty() {
+            return Err(SerializationError::InvalidData);
+        }
+        self.coeffs.check()
+    }
+}
+
+impl<F: CanonicalSerialize + CanonicalDeserialize> CanonicalDeserialize for UniPoly<F> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let coeffs = deserialize_bounded_vec(reader, compress, validate, MAX_UNIPOLY_COEFFS)?;
+        let poly = Self { coeffs };
+        if validate == Validate::Yes {
+            poly.check()?;
+        }
+        Ok(poly)
+    }
+}
+
+impl<F: JoltField> CanonicalSerialize for CompressedUniPoly<F> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        serialize_vec_with_len(&self.coeffs_except_linear_term, writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        serialized_vec_with_len_size(&self.coeffs_except_linear_term, compress)
+    }
+}
+
+impl<F: JoltField> Valid for CompressedUniPoly<F> {
+    fn check(&self) -> Result<(), SerializationError> {
+        if self.coeffs_except_linear_term.is_empty() {
+            return Err(SerializationError::InvalidData);
+        }
+        self.coeffs_except_linear_term.check()
+    }
+}
+
+impl<F: JoltField> CanonicalDeserialize for CompressedUniPoly<F> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let coeffs_except_linear_term =
+            deserialize_bounded_vec(reader, compress, validate, MAX_UNIPOLY_COEFFS)?;
+        let poly = Self {
+            coeffs_except_linear_term,
+        };
+        if validate == Validate::Yes {
+            poly.check()?;
+        }
+        Ok(poly)
+    }
+}
+
 impl<F: JoltField> UniPoly<F> {
     pub fn from_coeff(coeffs: Vec<F>) -> Self {
-        UniPoly { coeffs }
+        if coeffs.is_empty() {
+            UniPoly {
+                coeffs: vec![F::zero()],
+            }
+        } else {
+            UniPoly { coeffs }
+        }
     }
 
     /// Interpolate a polynomial from its evaluations at the points 0, 1, 2, ..., n-1.
@@ -188,10 +277,11 @@ impl<F: JoltField> UniPoly<F> {
     }
 
     pub fn zero() -> Self {
-        Self::from_coeff(Vec::new())
+        Self::from_coeff(vec![F::zero()])
     }
 
     pub fn degree(&self) -> usize {
+        debug_assert!(!self.coeffs.is_empty());
         self.coeffs.len() - 1
     }
 
@@ -297,10 +387,14 @@ impl<F: JoltField> UniPoly<F> {
     }
 
     pub fn compress(&self) -> CompressedUniPoly<F> {
-        let mut coeffs_except_linear_term = Vec::with_capacity(self.coeffs.len() - 1);
+        debug_assert!(!self.coeffs.is_empty());
+        let mut coeffs_except_linear_term =
+            Vec::with_capacity(self.coeffs.len().saturating_sub(1).max(1));
         coeffs_except_linear_term.push(self.coeffs[0]);
-        coeffs_except_linear_term.extend_from_slice(&self.coeffs[2..]);
-        debug_assert_eq!(coeffs_except_linear_term.len() + 1, self.coeffs.len());
+        if self.coeffs.len() > 2 {
+            coeffs_except_linear_term.extend_from_slice(&self.coeffs[2..]);
+            debug_assert_eq!(coeffs_except_linear_term.len() + 1, self.coeffs.len());
+        }
         CompressedUniPoly {
             coeffs_except_linear_term,
         }
@@ -484,6 +578,10 @@ impl<F: JoltField> CompressedUniPoly<F> {
     // we require eval(0) + eval(1) = hint, so we can solve for the linear term as:
     // linear_term = hint - 2 * constant_term - deg2 term - deg3 term
     pub fn decompress(&self, hint: &F) -> UniPoly<F> {
+        debug_assert!(!self.coeffs_except_linear_term.is_empty());
+        if self.coeffs_except_linear_term.len() == 1 {
+            return UniPoly::from_coeff(vec![self.coeffs_except_linear_term[0]]);
+        }
         let mut linear_term =
             *hint - self.coeffs_except_linear_term[0] - self.coeffs_except_linear_term[0];
         for i in 1..self.coeffs_except_linear_term.len() {
@@ -499,6 +597,10 @@ impl<F: JoltField> CompressedUniPoly<F> {
     // In the verifier we do not have to check that f(0) + f(1) = hint as we can just
     // recover the linear term assuming the prover did it right, then eval the poly
     pub fn eval_from_hint(&self, hint: &F, x: &F::Challenge) -> F {
+        debug_assert!(!self.coeffs_except_linear_term.is_empty());
+        if self.coeffs_except_linear_term.len() == 1 {
+            return self.coeffs_except_linear_term[0];
+        }
         let mut linear_term =
             *hint - self.coeffs_except_linear_term[0] - self.coeffs_except_linear_term[0];
         for i in 1..self.coeffs_except_linear_term.len() {
@@ -515,7 +617,12 @@ impl<F: JoltField> CompressedUniPoly<F> {
     }
 
     pub fn degree(&self) -> usize {
-        self.coeffs_except_linear_term.len()
+        debug_assert!(!self.coeffs_except_linear_term.is_empty());
+        if self.coeffs_except_linear_term.len() == 1 {
+            0
+        } else {
+            self.coeffs_except_linear_term.len()
+        }
     }
 }
 
@@ -523,6 +630,7 @@ impl<F: JoltField> CompressedUniPoly<F> {
 mod tests {
     use super::*;
     use ark_bn254::Fr;
+    use ark_serialize::CanonicalSerialize;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
@@ -660,5 +768,19 @@ mod tests {
             hint,
         );
         assert_eq!(poly.coeffs, true_poly.coeffs);
+    }
+
+    #[test]
+    fn rejects_empty_unipoly_deserialization() {
+        let mut bytes = Vec::new();
+        0usize.serialize_compressed(&mut bytes).unwrap();
+        assert!(UniPoly::<Fr>::deserialize_compressed(&bytes[..]).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_compressed_unipoly_deserialization() {
+        let mut bytes = Vec::new();
+        0usize.serialize_compressed(&mut bytes).unwrap();
+        assert!(CompressedUniPoly::<Fr>::deserialize_compressed(&bytes[..]).is_err());
     }
 }

--- a/jolt-core/src/subprotocols/blindfold/protocol.rs
+++ b/jolt-core/src/subprotocols/blindfold/protocol.rs
@@ -6,7 +6,7 @@
 //! 3. Using Spartan sumcheck to prove R1CS satisfaction without revealing the witness
 //! 4. Hyrax-style openings to verify W(ry) and E(rx) evaluations
 
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 
 use crate::curve::{JoltCurve, JoltGroupElement};
 use crate::field::JoltField;
@@ -16,6 +16,10 @@ use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::unipoly::CompressedUniPoly;
 use crate::transcripts::Transcript;
 use crate::utils::math::Math;
+use crate::utils::serialization::{
+    deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+    MAX_BLINDFOLD_VECTOR_LEN, MAX_OPENING_CLAIMS, MAX_SUMCHECK_ROUNDS,
+};
 
 use super::folding::{commit_cross_term_rows, compute_cross_term, sample_random_satisfying_pair};
 use super::r1cs::VerifierR1CS;
@@ -27,7 +31,7 @@ use super::spartan::{INNER_SUMCHECK_DEGREE_BOUND, SPARTAN_DEGREE_BOUND};
 /// The real instance is NOT included — verifier reconstructs from round_commitments,
 /// eval_commitments, public_inputs. The random instance IS included — verifier reads
 /// it from the proof and absorbs into transcript, never learning the random witness.
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug)]
 pub struct BlindFoldProof<F: JoltField, C: JoltCurve<F = F>> {
     pub random_instance: RelaxedR1CSInstance<F, C>,
 
@@ -47,6 +51,121 @@ pub struct BlindFoldProof<F: JoltField, C: JoltCurve<F = F>> {
     pub folded_eval_outputs: Vec<F>,
     /// Folded eval blinding values (one per extra constraint / eval_commitment).
     pub folded_eval_blindings: Vec<F>,
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>> CanonicalSerialize for BlindFoldProof<F, C> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.random_instance
+            .serialize_with_mode(&mut writer, compress)?;
+        serialize_vec_with_len(&self.noncoeff_row_commitments, &mut writer, compress)?;
+        serialize_vec_with_len(&self.cross_term_row_commitments, &mut writer, compress)?;
+        serialize_vec_with_len(&self.spartan_proof, &mut writer, compress)?;
+        self.az_r.serialize_with_mode(&mut writer, compress)?;
+        self.bz_r.serialize_with_mode(&mut writer, compress)?;
+        self.cz_r.serialize_with_mode(&mut writer, compress)?;
+        serialize_vec_with_len(&self.inner_sumcheck_proof, &mut writer, compress)?;
+        self.w_opening.serialize_with_mode(&mut writer, compress)?;
+        self.e_opening.serialize_with_mode(&mut writer, compress)?;
+        serialize_vec_with_len(&self.folded_eval_outputs, &mut writer, compress)?;
+        serialize_vec_with_len(&self.folded_eval_blindings, writer, compress)
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.random_instance.serialized_size(compress)
+            + serialized_vec_with_len_size(&self.noncoeff_row_commitments, compress)
+            + serialized_vec_with_len_size(&self.cross_term_row_commitments, compress)
+            + serialized_vec_with_len_size(&self.spartan_proof, compress)
+            + self.az_r.serialized_size(compress)
+            + self.bz_r.serialized_size(compress)
+            + self.cz_r.serialized_size(compress)
+            + serialized_vec_with_len_size(&self.inner_sumcheck_proof, compress)
+            + self.w_opening.serialized_size(compress)
+            + self.e_opening.serialized_size(compress)
+            + serialized_vec_with_len_size(&self.folded_eval_outputs, compress)
+            + serialized_vec_with_len_size(&self.folded_eval_blindings, compress)
+    }
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>> ark_serialize::Valid for BlindFoldProof<F, C> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.random_instance.check()?;
+        self.noncoeff_row_commitments.check()?;
+        self.cross_term_row_commitments.check()?;
+        self.spartan_proof.check()?;
+        self.az_r.check()?;
+        self.bz_r.check()?;
+        self.cz_r.check()?;
+        self.inner_sumcheck_proof.check()?;
+        self.w_opening.check()?;
+        self.e_opening.check()?;
+        self.folded_eval_outputs.check()?;
+        self.folded_eval_blindings.check()
+    }
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>> CanonicalDeserialize for BlindFoldProof<F, C> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let proof = Self {
+            random_instance: RelaxedR1CSInstance::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            noncoeff_row_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            cross_term_row_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            spartan_proof: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_SUMCHECK_ROUNDS,
+            )?,
+            az_r: F::deserialize_with_mode(&mut reader, compress, validate)?,
+            bz_r: F::deserialize_with_mode(&mut reader, compress, validate)?,
+            cz_r: F::deserialize_with_mode(&mut reader, compress, validate)?,
+            inner_sumcheck_proof: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_SUMCHECK_ROUNDS,
+            )?,
+            w_opening: HyraxOpeningProof::deserialize_with_mode(&mut reader, compress, validate)?,
+            e_opening: HyraxOpeningProof::deserialize_with_mode(&mut reader, compress, validate)?,
+            folded_eval_outputs: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_OPENING_CLAIMS,
+            )?,
+            folded_eval_blindings: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_OPENING_CLAIMS,
+            )?,
+        };
+        if validate == ark_serialize::Validate::Yes {
+            proof.check()?;
+        }
+        Ok(proof)
+    }
 }
 
 pub struct BlindFoldProver<'a, F: JoltField, C: JoltCurve<F = F>> {

--- a/jolt-core/src/subprotocols/blindfold/relaxed_r1cs.rs
+++ b/jolt-core/src/subprotocols/blindfold/relaxed_r1cs.rs
@@ -17,7 +17,11 @@
 
 use crate::curve::{JoltCurve, JoltGroupElement};
 use crate::field::JoltField;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use crate::utils::serialization::{
+    deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+    MAX_BLINDFOLD_VECTOR_LEN,
+};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use rayon::prelude::*;
 
 use super::protocol::BlindFoldVerifyError;
@@ -30,7 +34,7 @@ use super::r1cs::VerifierR1CS;
 /// - `round_commitments`: coefficient row commitments (reuse existing sumcheck round commitments)
 /// - `noncoeff_row_commitments`: non-coefficient row commitments (prover sends in proof)
 /// - `e_row_commitments`: E row commitments (derived from cross-term and random instance)
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug)]
 pub struct RelaxedR1CSInstance<F: JoltField, C: JoltCurve<F = F>> {
     pub u: F,
     /// Per-round commitments from ZK sumcheck (= coefficient row commitments)
@@ -50,7 +54,7 @@ pub struct RelaxedR1CSInstance<F: JoltField, C: JoltCurve<F = F>> {
 ///
 /// W is in grid layout (R' × C). Row blindings cover all W rows.
 /// E is flat but has per-row blindings for Hyrax opening.
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug)]
 pub struct RelaxedR1CSWitness<F: JoltField> {
     /// Error vector (zeros for non-relaxed)
     pub E: Vec<F>,
@@ -60,6 +64,145 @@ pub struct RelaxedR1CSWitness<F: JoltField> {
     pub w_row_blindings: Vec<F>,
     /// One blinding per E row (R_E elements)
     pub e_row_blindings: Vec<F>,
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>> CanonicalSerialize for RelaxedR1CSInstance<F, C> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.u.serialize_with_mode(&mut writer, compress)?;
+        serialize_vec_with_len(&self.round_commitments, &mut writer, compress)?;
+        serialize_vec_with_len(&self.output_claims_row_commitments, &mut writer, compress)?;
+        serialize_vec_with_len(&self.noncoeff_row_commitments, &mut writer, compress)?;
+        serialize_vec_with_len(&self.e_row_commitments, &mut writer, compress)?;
+        serialize_vec_with_len(&self.eval_commitments, writer, compress)
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.u.serialized_size(compress)
+            + serialized_vec_with_len_size(&self.round_commitments, compress)
+            + serialized_vec_with_len_size(&self.output_claims_row_commitments, compress)
+            + serialized_vec_with_len_size(&self.noncoeff_row_commitments, compress)
+            + serialized_vec_with_len_size(&self.e_row_commitments, compress)
+            + serialized_vec_with_len_size(&self.eval_commitments, compress)
+    }
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>> ark_serialize::Valid for RelaxedR1CSInstance<F, C> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.u.check()?;
+        self.round_commitments.check()?;
+        self.output_claims_row_commitments.check()?;
+        self.noncoeff_row_commitments.check()?;
+        self.e_row_commitments.check()?;
+        self.eval_commitments.check()
+    }
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>> CanonicalDeserialize for RelaxedR1CSInstance<F, C> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let instance = Self {
+            u: F::deserialize_with_mode(&mut reader, compress, validate)?,
+            round_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            output_claims_row_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            noncoeff_row_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            e_row_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            eval_commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+        };
+        if validate == ark_serialize::Validate::Yes {
+            instance.check()?;
+        }
+        Ok(instance)
+    }
+}
+
+impl<F: JoltField> CanonicalSerialize for RelaxedR1CSWitness<F> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        serialize_vec_with_len(&self.E, &mut writer, compress)?;
+        serialize_vec_with_len(&self.W, &mut writer, compress)?;
+        serialize_vec_with_len(&self.w_row_blindings, &mut writer, compress)?;
+        serialize_vec_with_len(&self.e_row_blindings, writer, compress)
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        serialized_vec_with_len_size(&self.E, compress)
+            + serialized_vec_with_len_size(&self.W, compress)
+            + serialized_vec_with_len_size(&self.w_row_blindings, compress)
+            + serialized_vec_with_len_size(&self.e_row_blindings, compress)
+    }
+}
+
+impl<F: JoltField> ark_serialize::Valid for RelaxedR1CSWitness<F> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.E.check()?;
+        self.W.check()?;
+        self.w_row_blindings.check()?;
+        self.e_row_blindings.check()
+    }
+}
+
+impl<F: JoltField> CanonicalDeserialize for RelaxedR1CSWitness<F> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let witness = Self {
+            E: deserialize_bounded_vec(&mut reader, compress, validate, MAX_BLINDFOLD_VECTOR_LEN)?,
+            W: deserialize_bounded_vec(&mut reader, compress, validate, MAX_BLINDFOLD_VECTOR_LEN)?,
+            w_row_blindings: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+            e_row_blindings: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_BLINDFOLD_VECTOR_LEN,
+            )?,
+        };
+        if validate == ark_serialize::Validate::Yes {
+            witness.check()?;
+        }
+        Ok(witness)
+    }
 }
 
 impl<F: JoltField, C: JoltCurve<F = F>> RelaxedR1CSInstance<F, C> {

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -15,6 +15,10 @@ use crate::transcripts::Transcript;
 use crate::utils::errors::ProofVerifyError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::utils::profiling::print_current_memory_usage;
+use crate::utils::serialization::{
+    deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+    MAX_OPENING_CLAIMS, MAX_SUMCHECK_ROUNDS,
+};
 
 use ark_serialize::*;
 #[cfg(feature = "zk")]
@@ -547,10 +551,56 @@ impl BatchedSumcheck {
 
 /// Clear (non-ZK) sumcheck proof - coefficients visible to verifier.
 /// Used in non-ZK mode where the verifier evaluates polynomials directly.
-#[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ClearSumcheckProof<F: JoltField, ProofTranscript: Transcript> {
     pub compressed_polys: Vec<CompressedUniPoly<F>>,
     _marker: PhantomData<ProofTranscript>,
+}
+
+impl<F: JoltField, ProofTranscript: Transcript> CanonicalSerialize
+    for ClearSumcheckProof<F, ProofTranscript>
+{
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        serialize_vec_with_len(&self.compressed_polys, writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        serialized_vec_with_len_size(&self.compressed_polys, compress)
+    }
+}
+
+impl<F: JoltField, ProofTranscript: Transcript> Valid for ClearSumcheckProof<F, ProofTranscript> {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.compressed_polys.check()
+    }
+}
+
+impl<F: JoltField, ProofTranscript: Transcript> CanonicalDeserialize
+    for ClearSumcheckProof<F, ProofTranscript>
+{
+    fn deserialize_with_mode<R: std::io::Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let proof = Self {
+            compressed_polys: deserialize_bounded_vec(
+                reader,
+                compress,
+                validate,
+                MAX_SUMCHECK_ROUNDS,
+            )?,
+            _marker: PhantomData,
+        };
+        if validate == Validate::Yes {
+            proof.check()?;
+        }
+        Ok(proof)
+    }
 }
 
 impl<F: JoltField, ProofTranscript: Transcript> ClearSumcheckProof<F, ProofTranscript> {
@@ -579,6 +629,14 @@ impl<F: JoltField, ProofTranscript: Transcript> ClearSumcheckProof<F, ProofTrans
             ));
         }
         for i in 0..self.compressed_polys.len() {
+            if self.compressed_polys[i]
+                .coeffs_except_linear_term
+                .is_empty()
+            {
+                return Err(ProofVerifyError::MalformedProof(
+                    "empty compressed sumcheck polynomial".to_string(),
+                ));
+            }
             if self.compressed_polys[i].degree() > degree_bound {
                 return Err(ProofVerifyError::InvalidInputLength(
                     degree_bound,
@@ -658,10 +716,11 @@ impl<F: JoltField, C: JoltCurve<F = F>, ProofTranscript: Transcript> CanonicalDe
         validate: ark_serialize::Validate,
     ) -> Result<Self, ark_serialize::SerializationError> {
         let round_commitments =
-            Vec::<C::G1>::deserialize_with_mode(&mut reader, compress, validate)?;
-        let poly_degrees = Vec::<usize>::deserialize_with_mode(&mut reader, compress, validate)?;
+            deserialize_bounded_vec(&mut reader, compress, validate, MAX_SUMCHECK_ROUNDS)?;
+        let poly_degrees =
+            deserialize_bounded_vec(&mut reader, compress, validate, MAX_SUMCHECK_ROUNDS)?;
         let output_claims_commitments =
-            Vec::<C::G1>::deserialize_with_mode(reader, compress, validate)?;
+            deserialize_bounded_vec(reader, compress, validate, MAX_OPENING_CLAIMS)?;
         Ok(Self {
             round_commitments,
             poly_degrees,

--- a/jolt-core/src/subprotocols/univariate_skip.rs
+++ b/jolt-core/src/subprotocols/univariate_skip.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
 #[cfg(feature = "zk")]
 use rand_core::CryptoRngCore;
 
@@ -17,6 +19,10 @@ use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
 use crate::subprotocols::sumcheck_verifier::SumcheckInstanceVerifier;
 use crate::transcripts::Transcript;
 use crate::utils::errors::ProofVerifyError;
+use crate::utils::serialization::{
+    deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+    MAX_OPENING_CLAIMS,
+};
 
 /// Returns the interleaved symmetric univariate-skip target indices outside the base window.
 ///
@@ -214,10 +220,47 @@ pub fn prove_uniskip_round_zk<
 
 /// The sumcheck proof for a univariate skip round
 /// Consists of the (single) univariate polynomial sent in that round, no omission of any coefficient
-#[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct UniSkipFirstRoundProof<F: JoltField, T: Transcript> {
     pub uni_poly: UniPoly<F>,
     _marker: PhantomData<T>,
+}
+
+impl<F: JoltField, T: Transcript> CanonicalSerialize for UniSkipFirstRoundProof<F, T> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.uni_poly.serialize_with_mode(&mut writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        self.uni_poly.serialized_size(compress)
+    }
+}
+
+impl<F: JoltField, T: Transcript> Valid for UniSkipFirstRoundProof<F, T> {
+    fn check(&self) -> Result<(), SerializationError> {
+        self.uni_poly.check()
+    }
+}
+
+impl<F: JoltField, T: Transcript> CanonicalDeserialize for UniSkipFirstRoundProof<F, T> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let proof = Self {
+            uni_poly: UniPoly::deserialize_with_mode(reader, compress, validate)?,
+            _marker: PhantomData,
+        };
+        if validate == Validate::Yes {
+            proof.check()?;
+        }
+        Ok(proof)
+    }
 }
 
 impl<F: JoltField, T: Transcript> UniSkipFirstRoundProof<F, T> {
@@ -237,6 +280,11 @@ impl<F: JoltField, T: Transcript> UniSkipFirstRoundProof<F, T> {
         transcript: &mut T,
     ) -> Result<F::Challenge, ProofVerifyError> {
         let degree_bound = sumcheck_instance.degree();
+        if proof.uni_poly.coeffs.is_empty() {
+            return Err(ProofVerifyError::MalformedProof(
+                "empty uniskip polynomial".to_string(),
+            ));
+        }
         // Degree check for the high-degree first polynomial
         if proof.uni_poly.degree() > degree_bound {
             return Err(ProofVerifyError::InvalidInputLength(
@@ -325,19 +373,18 @@ impl<F: JoltField, C: JoltCurve<F = F>, T: Transcript> CanonicalSerialize
     fn serialize_with_mode<W: std::io::Write>(
         &self,
         mut writer: W,
-        compress: ark_serialize::Compress,
-    ) -> Result<(), ark_serialize::SerializationError> {
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
         self.commitment.serialize_with_mode(&mut writer, compress)?;
         self.poly_degree
             .serialize_with_mode(&mut writer, compress)?;
-        self.output_claims_commitments
-            .serialize_with_mode(writer, compress)
+        serialize_vec_with_len(&self.output_claims_commitments, writer, compress)
     }
 
-    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+    fn serialized_size(&self, compress: Compress) -> usize {
         self.commitment.serialized_size(compress)
             + self.poly_degree.serialized_size(compress)
-            + self.output_claims_commitments.serialized_size(compress)
+            + serialized_vec_with_len_size(&self.output_claims_commitments, compress)
     }
 }
 
@@ -346,13 +393,13 @@ impl<F: JoltField, C: JoltCurve<F = F>, T: Transcript> CanonicalDeserialize
 {
     fn deserialize_with_mode<R: std::io::Read>(
         mut reader: R,
-        compress: ark_serialize::Compress,
-        validate: ark_serialize::Validate,
-    ) -> Result<Self, ark_serialize::SerializationError> {
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
         let commitment = C::G1::deserialize_with_mode(&mut reader, compress, validate)?;
         let poly_degree = usize::deserialize_with_mode(&mut reader, compress, validate)?;
         let output_claims_commitments =
-            Vec::<C::G1>::deserialize_with_mode(reader, compress, validate)?;
+            deserialize_bounded_vec(reader, compress, validate, MAX_OPENING_CLAIMS)?;
         Ok(Self::new(
             commitment,
             poly_degree,
@@ -364,7 +411,7 @@ impl<F: JoltField, C: JoltCurve<F = F>, T: Transcript> CanonicalDeserialize
 impl<F: JoltField, C: JoltCurve<F = F>, T: Transcript> ark_serialize::Valid
     for ZkUniSkipFirstRoundProof<F, C, T>
 {
-    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+    fn check(&self) -> Result<(), SerializationError> {
         self.commitment.check()?;
         self.output_claims_commitments.check()
     }

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -12,6 +12,7 @@ pub mod math;
 #[cfg(feature = "monitor")]
 pub mod monitor;
 pub mod profiling;
+pub mod serialization;
 pub mod small_scalar;
 pub mod thread;
 

--- a/jolt-core/src/utils/serialization.rs
+++ b/jolt-core/src/utils/serialization.rs
@@ -1,0 +1,73 @@
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Validate,
+};
+use std::io::{Read, Write};
+
+pub const MAX_JOLT_COMMITMENTS: usize = 1 << 12;
+pub const MAX_OPENING_CLAIMS: usize = 1 << 16;
+pub const MAX_SUMCHECK_ROUNDS: usize = 1 << 16;
+pub const MAX_UNIPOLY_COEFFS: usize = 1 << 16;
+pub const MAX_BLINDFOLD_VECTOR_LEN: usize = 1 << 20;
+
+pub fn serialize_vec_with_len<T: CanonicalSerialize, W: Write>(
+    values: &[T],
+    mut writer: W,
+    compress: Compress,
+) -> Result<(), SerializationError> {
+    values.len().serialize_with_mode(&mut writer, compress)?;
+    for value in values {
+        value.serialize_with_mode(&mut writer, compress)?;
+    }
+    Ok(())
+}
+
+pub fn serialized_vec_with_len_size<T: CanonicalSerialize>(
+    values: &[T],
+    compress: Compress,
+) -> usize {
+    values.len().serialized_size(compress)
+        + values
+            .iter()
+            .map(|value| value.serialized_size(compress))
+            .sum::<usize>()
+}
+
+pub fn deserialize_bounded_len<R: Read>(
+    mut reader: R,
+    compress: Compress,
+    validate: Validate,
+    max_len: usize,
+) -> Result<usize, SerializationError> {
+    let len = usize::deserialize_with_mode(&mut reader, compress, validate)?;
+    if len > max_len {
+        return Err(SerializationError::InvalidData);
+    }
+    Ok(len)
+}
+
+pub fn deserialize_bounded_vec<T: CanonicalDeserialize, R: Read>(
+    mut reader: R,
+    compress: Compress,
+    validate: Validate,
+    max_len: usize,
+) -> Result<Vec<T>, SerializationError> {
+    let len = deserialize_bounded_len(&mut reader, compress, validate, max_len)?;
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        values.push(T::deserialize_with_mode(&mut reader, compress, validate)?);
+    }
+    Ok(values)
+}
+
+pub fn deserialize_bounded_u32_len<R: Read>(
+    mut reader: R,
+    compress: Compress,
+    validate: Validate,
+    max_len: usize,
+) -> Result<usize, SerializationError> {
+    let len = u32::deserialize_with_mode(&mut reader, compress, validate)? as usize;
+    if len > max_len {
+        return Err(SerializationError::InvalidData);
+    }
+    Ok(len)
+}

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -12,6 +12,8 @@ use strum::EnumCount;
 use crate::poly::opening_proof::{OpeningPoint, Openings};
 #[cfg(feature = "zk")]
 use crate::subprotocols::blindfold::BlindFoldProof;
+#[cfg(not(feature = "zk"))]
+use crate::utils::serialization::MAX_OPENING_CLAIMS;
 use crate::{
     curve::JoltCurve,
     field::JoltField,
@@ -25,6 +27,10 @@ use crate::{
         sumcheck::SumcheckInstanceProof, univariate_skip::UniSkipFirstRoundProofVariant,
     },
     transcripts::Transcript,
+    utils::serialization::{
+        deserialize_bounded_vec, serialize_vec_with_len, serialized_vec_with_len_size,
+        MAX_JOLT_COMMITMENTS,
+    },
     zkvm::{
         config::{OneHotConfig, ReadWriteConfig},
         instruction::{CircuitFlags, InstructionFlags},
@@ -32,7 +38,7 @@ use crate::{
     },
 };
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone)]
 pub struct JoltProof<
     F: JoltField,
     C: JoltCurve<F = F>,
@@ -62,7 +68,218 @@ pub struct JoltProof<
     pub dory_layout: DoryLayout,
 }
 
+impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>, FS: Transcript>
+    CanonicalSerialize for JoltProof<F, C, PCS, FS>
+{
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        serialize_vec_with_len(&self.commitments, &mut writer, compress)?;
+        self.stage1_uni_skip_first_round_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage1_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage2_uni_skip_first_round_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage2_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage3_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage4_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage5_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage6_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.stage7_sumcheck_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        #[cfg(feature = "zk")]
+        self.blindfold_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.joint_opening_proof
+            .serialize_with_mode(&mut writer, compress)?;
+        self.untrusted_advice_commitment
+            .serialize_with_mode(&mut writer, compress)?;
+        #[cfg(not(feature = "zk"))]
+        self.opening_claims
+            .serialize_with_mode(&mut writer, compress)?;
+        self.trace_length
+            .serialize_with_mode(&mut writer, compress)?;
+        self.ram_K.serialize_with_mode(&mut writer, compress)?;
+        self.rw_config.serialize_with_mode(&mut writer, compress)?;
+        self.one_hot_config
+            .serialize_with_mode(&mut writer, compress)?;
+        self.dory_layout.serialize_with_mode(writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        serialized_vec_with_len_size(&self.commitments, compress)
+            + self
+                .stage1_uni_skip_first_round_proof
+                .serialized_size(compress)
+            + self.stage1_sumcheck_proof.serialized_size(compress)
+            + self
+                .stage2_uni_skip_first_round_proof
+                .serialized_size(compress)
+            + self.stage2_sumcheck_proof.serialized_size(compress)
+            + self.stage3_sumcheck_proof.serialized_size(compress)
+            + self.stage4_sumcheck_proof.serialized_size(compress)
+            + self.stage5_sumcheck_proof.serialized_size(compress)
+            + self.stage6_sumcheck_proof.serialized_size(compress)
+            + self.stage7_sumcheck_proof.serialized_size(compress)
+            + {
+                #[cfg(feature = "zk")]
+                {
+                    self.blindfold_proof.serialized_size(compress)
+                }
+                #[cfg(not(feature = "zk"))]
+                {
+                    0
+                }
+            }
+            + self.joint_opening_proof.serialized_size(compress)
+            + self.untrusted_advice_commitment.serialized_size(compress)
+            + {
+                #[cfg(not(feature = "zk"))]
+                {
+                    self.opening_claims.serialized_size(compress)
+                }
+                #[cfg(feature = "zk")]
+                {
+                    0
+                }
+            }
+            + self.trace_length.serialized_size(compress)
+            + self.ram_K.serialized_size(compress)
+            + self.rw_config.serialized_size(compress)
+            + self.one_hot_config.serialized_size(compress)
+            + self.dory_layout.serialized_size(compress)
+    }
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>, FS: Transcript> Valid
+    for JoltProof<F, C, PCS, FS>
+{
+    fn check(&self) -> Result<(), SerializationError> {
+        self.commitments.check()?;
+        self.stage1_uni_skip_first_round_proof.check()?;
+        self.stage1_sumcheck_proof.check()?;
+        self.stage2_uni_skip_first_round_proof.check()?;
+        self.stage2_sumcheck_proof.check()?;
+        self.stage3_sumcheck_proof.check()?;
+        self.stage4_sumcheck_proof.check()?;
+        self.stage5_sumcheck_proof.check()?;
+        self.stage6_sumcheck_proof.check()?;
+        self.stage7_sumcheck_proof.check()?;
+        #[cfg(feature = "zk")]
+        self.blindfold_proof.check()?;
+        self.joint_opening_proof.check()?;
+        self.untrusted_advice_commitment.check()?;
+        #[cfg(not(feature = "zk"))]
+        self.opening_claims.check()?;
+        self.rw_config.check()?;
+        self.one_hot_config.check()?;
+        self.dory_layout.check()
+    }
+}
+
+impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>, FS: Transcript>
+    CanonicalDeserialize for JoltProof<F, C, PCS, FS>
+{
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let proof = Self {
+            commitments: deserialize_bounded_vec(
+                &mut reader,
+                compress,
+                validate,
+                MAX_JOLT_COMMITMENTS,
+            )?,
+            stage1_uni_skip_first_round_proof:
+                UniSkipFirstRoundProofVariant::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?,
+            stage1_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            stage2_uni_skip_first_round_proof:
+                UniSkipFirstRoundProofVariant::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?,
+            stage2_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            stage3_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            stage4_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            stage5_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            stage6_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            stage7_sumcheck_proof: SumcheckInstanceProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            #[cfg(feature = "zk")]
+            blindfold_proof: BlindFoldProof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            joint_opening_proof: PCS::Proof::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            untrusted_advice_commitment: Option::<PCS::Commitment>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            #[cfg(not(feature = "zk"))]
+            opening_claims: Claims::deserialize_with_mode(&mut reader, compress, validate)?,
+            trace_length: usize::deserialize_with_mode(&mut reader, compress, validate)?,
+            ram_K: usize::deserialize_with_mode(&mut reader, compress, validate)?,
+            rw_config: ReadWriteConfig::deserialize_with_mode(&mut reader, compress, validate)?,
+            one_hot_config: OneHotConfig::deserialize_with_mode(&mut reader, compress, validate)?,
+            dory_layout: DoryLayout::deserialize_with_mode(&mut reader, compress, validate)?,
+        };
+        if validate == Validate::Yes {
+            proof.check()?;
+        }
+        Ok(proof)
+    }
+}
+
 #[cfg(not(feature = "zk"))]
+#[derive(Clone)]
 pub struct Claims<F: JoltField>(pub Openings<F>);
 
 #[cfg(not(feature = "zk"))]
@@ -93,7 +310,12 @@ impl<F: JoltField> CanonicalSerialize for Claims<F> {
 #[cfg(not(feature = "zk"))]
 impl<F: JoltField> Valid for Claims<F> {
     fn check(&self) -> Result<(), SerializationError> {
-        Ok(())
+        self.0
+            .iter()
+            .try_for_each(|(id, (_point, claim))| -> Result<(), SerializationError> {
+                id.check()?;
+                claim.check()
+            })
     }
 }
 
@@ -105,13 +327,25 @@ impl<F: JoltField> CanonicalDeserialize for Claims<F> {
         validate: Validate,
     ) -> Result<Self, SerializationError> {
         let size = usize::deserialize_with_mode(&mut reader, compress, validate)?;
+        if size > MAX_OPENING_CLAIMS {
+            return Err(SerializationError::InvalidData);
+        }
         let mut claims = BTreeMap::new();
         for _ in 0..size {
             let key = OpeningId::deserialize_with_mode(&mut reader, compress, validate)?;
             let claim = F::deserialize_with_mode(&mut reader, compress, validate)?;
-            claims.insert(key, (OpeningPoint::default(), claim));
+            if claims
+                .insert(key, (OpeningPoint::default(), claim))
+                .is_some()
+            {
+                return Err(SerializationError::InvalidData);
+            }
         }
-        Ok(Claims(claims))
+        let claims = Claims(claims);
+        if validate == Validate::Yes {
+            claims.check()?;
+        }
+        Ok(claims)
     }
 }
 
@@ -514,4 +748,35 @@ pub fn serialize_and_print_size(
     tracing::info!("{item_name} Written to {file_name}");
     tracing::info!("{item_name} size: {file_size_kb:.1} kB");
     Ok(())
+}
+
+#[cfg(all(test, not(feature = "zk")))]
+mod tests {
+    use super::*;
+    use ark_bn254::Fr;
+
+    #[test]
+    fn claims_reject_duplicate_keys() {
+        let key = OpeningId::committed(
+            CommittedPolynomial::InstructionRa(0),
+            SumcheckId::HammingWeightClaimReduction,
+        );
+        let mut bytes = Vec::new();
+        2usize.serialize_compressed(&mut bytes).unwrap();
+        key.serialize_compressed(&mut bytes).unwrap();
+        Fr::from(1u64).serialize_compressed(&mut bytes).unwrap();
+        key.serialize_compressed(&mut bytes).unwrap();
+        Fr::from(1u64).serialize_compressed(&mut bytes).unwrap();
+
+        assert!(Claims::<Fr>::deserialize_compressed(&bytes[..]).is_err());
+    }
+
+    #[test]
+    fn claims_reject_oversized_length_prefix() {
+        let mut bytes = Vec::new();
+        (MAX_OPENING_CLAIMS + 1)
+            .serialize_compressed(&mut bytes)
+            .unwrap();
+        assert!(Claims::<Fr>::deserialize_compressed(&bytes[..]).is_err());
+    }
 }

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -3443,6 +3443,27 @@ mod tests {
         assert!(verifier.verify().is_err());
     }
 
+    #[cfg(not(feature = "zk"))]
+    #[test]
+    #[serial]
+    fn verifier_rejects_empty_sumcheck_round_polynomial() {
+        let (verifier_preprocessing, mut proof, program_io) = prove_fibonacci(9);
+        let crate::subprotocols::sumcheck::SumcheckInstanceProof::Clear(stage1) =
+            &mut proof.stage1_sumcheck_proof
+        else {
+            panic!("expected standard sumcheck proof");
+        };
+        stage1.compressed_polys[0].coeffs_except_linear_term.clear();
+
+        let verifier =
+            RV64IMACVerifier::new(&verifier_preprocessing, proof, program_io, None, None).unwrap();
+        assert!(matches!(
+            verifier.verify(),
+            Err(ProofVerifyError::MalformedProof(message))
+                if message.contains("empty compressed sumcheck polynomial")
+        ));
+    }
+
     /// Security property: the verifier must reject a proof when the verifier's preprocessing
     /// has a different entry_address than the one used to generate the proof.
     ///


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5.4) on behalf of the user (Quang Dao) with approval.

## Summary
- add bounded manual deserialization helpers while preserving the existing wire format
- bound attacker-controlled vectors across Jolt proof, sumcheck, BlindFold, Hyrax, and uni-poly types
- reject duplicate claim keys, empty polynomials, and invalid `MontU128Challenge` values
- add regression coverage for malformed length prefixes and empty polynomial paths

## Validation
- validated locally on the full stack with the required fmt, clippy, and nextest commands
- targeted deserialization and polynomial regression tests were also run in `host` mode
