### PR TITLE
refactor(bolt): add typed verifier program executor

### DIFF
--- a/crates/bolt/src/emit/rust/artifacts.rs
+++ b/crates/bolt/src/emit/rust/artifacts.rs
@@ -132,6 +132,7 @@ pub struct ProtocolVerifierApiExtension {
     pub error_conversions: String,
     pub after_default_verify: String,
     pub with_programs_body_intro: String,
+    pub verification_body_override: String,
     pub stage_verification_override: String,
     pub after_stage_verification: String,
     pub helper_items: String,
@@ -847,51 +848,58 @@ fn generated_verifier_api(
     if let Some(extension) = extension {
         source.push_str(&extension.verifier.with_programs_body_intro);
     }
-    if let Some(prefix) = &config.instrumentation_prefix {
-        source.push_str(&format!(
-            "    let _verify_span = tracing::info_span!(\"{prefix}.verify\").entered();\n"
-        ));
-    }
-    if let Some(commitment) = &commitment {
-        let verifier_fn = commitment
-            .with_program_verifier_fn
-            .as_deref()
-            .or(commitment.verifier_fn.as_deref())
-            .unwrap_or("missing_commitment_verifier_function");
-        let program_arg = if commitment.with_program_verifier_fn.is_some()
-            && commitment.program_type.is_some()
-            && commitment.program_const.is_some()
-        {
-            format!("programs.{}, ", commitment.field_name)
-        } else {
-            String::new()
-        };
-        source.push_str(&format!(
-            "    let {field} = {module}::{verifier_fn}({program_arg}&proof.commitments, transcript)?;\n",
-            field = commitment.field_name,
-            module = commitment.module_alias,
-        ));
-    }
-    if let Some(extension) = extension {
-        if !extension.verifier.stage_verification_override.is_empty() {
-            source.push_str(&extension.verifier.stage_verification_override);
+    let verification_body_override = extension
+        .map(|extension| extension.verifier.verification_body_override.as_str())
+        .unwrap_or_default();
+    if !verification_body_override.is_empty() {
+        source.push_str(verification_body_override);
+    } else {
+        if let Some(prefix) = &config.instrumentation_prefix {
+            source.push_str(&format!(
+                "    let _verify_span = tracing::info_span!(\"{prefix}.verify\").entered();\n"
+            ));
+        }
+        if let Some(commitment) = &commitment {
+            let verifier_fn = commitment
+                .with_program_verifier_fn
+                .as_deref()
+                .or(commitment.verifier_fn.as_deref())
+                .unwrap_or("missing_commitment_verifier_function");
+            let program_arg = if commitment.with_program_verifier_fn.is_some()
+                && commitment.program_type.is_some()
+                && commitment.program_const.is_some()
+            {
+                format!("programs.{}, ", commitment.field_name)
+            } else {
+                String::new()
+            };
+            source.push_str(&format!(
+                "    let {field} = {module}::{verifier_fn}({program_arg}&proof.commitments, transcript)?;\n",
+                field = commitment.field_name,
+                module = commitment.module_alias,
+            ));
+        }
+        if let Some(extension) = extension {
+            if !extension.verifier.stage_verification_override.is_empty() {
+                source.push_str(&extension.verifier.stage_verification_override);
+            } else {
+                emit_verifier_stage_calls(&mut source, &stages);
+            }
         } else {
             emit_verifier_stage_calls(&mut source, &stages);
         }
-    } else {
-        emit_verifier_stage_calls(&mut source, &stages);
+        if let Some(extension) = extension {
+            source.push_str(&extension.verifier.after_stage_verification);
+        }
+        source.push_str(&format!("\n    Ok({verification_artifacts_type} {{\n"));
+        if let Some(commitment) = &commitment {
+            source.push_str(&format!("        {},\n", commitment.field_name));
+        }
+        for stage in &stages {
+            source.push_str(&format!("        {},\n", stage.field_name));
+        }
+        source.push_str("    })\n}\n\n");
     }
-    if let Some(extension) = extension {
-        source.push_str(&extension.verifier.after_stage_verification);
-    }
-    source.push_str(&format!("\n    Ok({verification_artifacts_type} {{\n"));
-    if let Some(commitment) = &commitment {
-        source.push_str(&format!("        {},\n", commitment.field_name));
-    }
-    for stage in &stages {
-        source.push_str(&format!("        {},\n", stage.field_name));
-    }
-    source.push_str("    })\n}\n\n");
 
     if let Some(extension) = extension {
         source.push_str(&extension.verifier.helper_items);

--- a/crates/bolt/src/protocols/jolt/artifacts.rs
+++ b/crates/bolt/src/protocols/jolt/artifacts.rs
@@ -327,12 +327,16 @@ pub use verifier::{
     verify_jolt_prefix_with_programs, verify_jolt_through_stage5,
     verify_jolt_through_stage5_with_programs, verify_jolt_through_stage6,
     verify_jolt_through_stage6_with_programs, verify_jolt_through_stage7,
-    verify_jolt_through_stage7_with_programs, verify_jolt_with_programs, JoltEvaluationProof,
-    JoltEvaluationProofError, JoltNamedEval, JoltProof, JoltStage2RamAccess, JoltStage2RamData,
-    JoltStage2RamOutputLayout, JoltStage6BytecodeEntry, JoltStage6BytecodeReadRafData,
-    JoltStage6VerifierData, JoltStageChallengeVector, JoltStageExecutionArtifacts,
-    JoltStageOpeningInputValue, JoltStageProof, JoltSumcheckOutput, JoltVerificationArtifacts,
-    JoltVerifierInputs, JoltVerifierPrograms, JoltVerifierTarget, JoltVerifyError,
+    verify_jolt_through_stage7_with_programs, verify_jolt_with_programs, JoltEvaluationPolicy,
+    JoltEvaluationProof, JoltEvaluationProofError, JoltNamedEval, JoltProof, JoltProofSlot,
+    JoltStage2RamAccess, JoltStage2RamData, JoltStage2RamOutputLayout, JoltStage6BytecodeEntry,
+    JoltStage6BytecodeReadRafData, JoltStage6VerifierData, JoltStageChallengeVector,
+    JoltStageExecutionArtifacts, JoltStageOpeningInputValue, JoltStageProof, JoltSumcheckOutput,
+    JoltVerificationArtifacts, JoltVerifierCheckpoint, JoltVerifierInputs,
+    JoltVerifierProgramError, JoltVerifierProgramPlan, JoltVerifierPrograms, JoltVerifierStepPlan,
+    JoltVerifierTarget, JoltVerifierTargetPlan, JoltVerifyError, JOLT_TARGET_FULL,
+    JOLT_TARGET_THROUGH_STAGE5, JOLT_TARGET_THROUGH_STAGE6, JOLT_TARGET_THROUGH_STAGE7,
+    JOLT_VERIFIER_TARGETS, VERIFIER_PROGRAM,
 };"
     .to_owned()
 }
@@ -370,17 +374,19 @@ fn jolt_evaluation_role_api_extension() -> ProtocolArtifactExtension {
             inputs_derive: Some("#[derive(Clone, Copy)]".to_owned()),
             input_fields: "    pub evaluation_setup: Option<&'a DoryVerifierSetup>,\n".to_owned(),
             program_fields:
-                "    pub stage8: &'static stage8_stage::Stage8EvaluationProgramPlan,\n".to_owned(),
-            default_program_fields: "        stage8: &stage8_stage::STAGE8_PROGRAM,\n".to_owned(),
-            error_variants: "    Evaluation(JoltEvaluationProofError),\n".to_owned(),
-            error_items: format!("{}{}", jolt_verifier_target_items(), "#[derive(Debug)]\npub enum JoltEvaluationProofError {\n    MissingProof,\n    MissingVerifierSetup,\n    MissingStageEval { stage: &'static str, eval: &'static str },\n    MissingStage7RaEval,\n    MissingStage7EvaluationPoint,\n    MissingCommitment { oracle: &'static str },\n    InvalidPointLength {\n        artifact: &'static str,\n        expected: usize,\n        actual: usize,\n    },\n    Opening(OpeningsError),\n}\n\n"),
-            error_conversions: "impl From<JoltEvaluationProofError> for JoltVerifyError {\n    fn from(error: JoltEvaluationProofError) -> Self {\n        Self::Evaluation(error)\n    }\n}\n\nimpl From<OpeningsError> for JoltEvaluationProofError {\n    fn from(error: OpeningsError) -> Self {\n        Self::Opening(error)\n    }\n}\n\n".to_owned(),
+                "    pub verifier: &'static JoltVerifierProgramPlan,\n    pub stage8: &'static stage8_stage::Stage8EvaluationProgramPlan,\n".to_owned(),
+            default_program_fields: "        verifier: &VERIFIER_PROGRAM,\n        stage8: &stage8_stage::STAGE8_PROGRAM,\n".to_owned(),
+            error_variants: "    Program(JoltVerifierProgramError),\n    Evaluation(JoltEvaluationProofError),\n".to_owned(),
+            error_items: format!("{}{}", jolt_verifier_program_items(), "#[derive(Debug)]\npub enum JoltEvaluationProofError {\n    MissingProof,\n    MissingVerifierSetup,\n    MissingStageEval { stage: &'static str, eval: &'static str },\n    MissingStage7RaEval,\n    MissingStage7EvaluationPoint,\n    MissingCommitment { oracle: &'static str },\n    InvalidPointLength {\n        artifact: &'static str,\n        expected: usize,\n        actual: usize,\n    },\n    Opening(OpeningsError),\n}\n\n"),
+            error_conversions: "impl From<JoltVerifierProgramError> for JoltVerifyError {\n    fn from(error: JoltVerifierProgramError) -> Self {\n        Self::Program(error)\n    }\n}\n\nimpl From<JoltEvaluationProofError> for JoltVerifyError {\n    fn from(error: JoltEvaluationProofError) -> Self {\n        Self::Evaluation(error)\n    }\n}\n\nimpl From<OpeningsError> for JoltEvaluationProofError {\n    fn from(error: OpeningsError) -> Self {\n        Self::Opening(error)\n    }\n}\n\n".to_owned(),
             after_default_verify: "pub fn verify_jolt_prefix<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_prefix_with_programs(proof, inputs, default_verifier_programs(), transcript) }\n\npub fn verify_jolt_through_stage5<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage5_with_programs(proof, inputs, default_verifier_programs(), transcript) }\n\npub fn verify_jolt_through_stage6<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage6_with_programs(proof, inputs, default_verifier_programs(), transcript) }\n\npub fn verify_jolt_through_stage7<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage7_with_programs(proof, inputs, default_verifier_programs(), transcript) }\n\n".to_owned(),
-            with_programs_body_intro: "    verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::Full)\n}\n\npub fn verify_jolt_through_stage5_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::ThroughStage5) }\n\npub fn verify_jolt_through_stage6_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::ThroughStage6) }\n\npub fn verify_jolt_through_stage7_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::ThroughStage7) }\n\npub fn verify_jolt_prefix_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage7_with_programs(proof, inputs, programs, transcript) }\n\nfn verify_jolt_with_programs_inner<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T, target: JoltVerifierTarget) -> Result<JoltVerificationArtifacts, JoltVerifyError> {\n".to_owned(),
-            stage_verification_override: jolt_verifier_stage_verification(),
-            after_stage_verification: jolt_verifier_evaluation_check(),
+            with_programs_body_intro: "    verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_FULL)\n}\n\npub fn verify_jolt_through_stage5_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_THROUGH_STAGE5) }\n\npub fn verify_jolt_through_stage6_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_THROUGH_STAGE6) }\n\npub fn verify_jolt_through_stage7_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_THROUGH_STAGE7) }\n\npub fn verify_jolt_prefix_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage7_with_programs(proof, inputs, programs, transcript) }\n\nfn verify_jolt_with_programs_inner<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T, target: JoltVerifierTarget) -> Result<JoltVerificationArtifacts, JoltVerifyError> {\n".to_owned(),
+            verification_body_override: jolt_verifier_execution_body(),
+            stage_verification_override: String::new(),
+            after_stage_verification: String::new(),
             helper_items: format!(
-                "{}{}",
+                "{}{}{}",
+                jolt_verifier_program_executor(),
                 jolt_verifier_input_helpers("Jolt"),
                 jolt_verifier_evaluation_helpers("Jolt", "Fr")
             ),
@@ -388,16 +394,428 @@ fn jolt_evaluation_role_api_extension() -> ProtocolArtifactExtension {
     }
 }
 
-fn jolt_verifier_target_items() -> String {
-    "#[derive(Clone, Copy, Debug, PartialEq, Eq)]\npub enum JoltVerifierTarget {\n    ThroughStage5,\n    ThroughStage6,\n    ThroughStage7,\n    Full,\n}\n\nimpl JoltVerifierTarget {\n    fn verifies_stage6(self) -> bool { matches!(self, Self::ThroughStage6 | Self::ThroughStage7 | Self::Full) }\n    fn verifies_stage7(self) -> bool { matches!(self, Self::ThroughStage7 | Self::Full) }\n    fn verifies_evaluation(self) -> bool { matches!(self, Self::Full) }\n    fn allows_optional_evaluation(self) -> bool { matches!(self, Self::ThroughStage7 | Self::Full) }\n}\n\n".to_owned()
+fn jolt_verifier_program_items() -> String {
+    r"#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltProofSlot {
+    Commitments,
+    Stage1Outer,
+    Stage2,
+    Stage3,
+    Stage4,
+    Stage5,
+    Stage6,
+    Stage7,
+    Evaluation,
 }
 
-fn jolt_verifier_stage_verification() -> String {
-    "    let stage1_outer = stage1_outer_stage::verify_stage1_outer_with_program(programs.stage1_outer, &proof.stage1_outer, transcript)?;\n    let stage2 = stage2_stage::verify_stage2_with_program(programs.stage2, &proof.stage2, inputs.stage2_openings, inputs.stage2_ram, transcript)?;\n    let stage3 = stage3_stage::verify_stage3_with_program(programs.stage3, &proof.stage3, inputs.stage3_openings, transcript)?;\n    let stage4 = stage4_stage::verify_stage4_with_program(programs.stage4, &proof.stage4, inputs.stage4_openings, transcript)?;\n    let stage5 = stage5_stage::verify_stage5_with_program(programs.stage5, &proof.stage5, inputs.stage5_openings, transcript)?;\n    let stage6 = if target.verifies_stage6() {\n        stage6_stage::verify_stage6_with_program(programs.stage6, &proof.stage6, inputs.stage6_openings, inputs.stage6_data, transcript)?\n    } else {\n        stage6_stage::Stage6ExecutionArtifacts::default()\n    };\n    let stage7 = if target.verifies_stage7() {\n        stage7_stage::verify_stage7_with_program(programs.stage7, &proof.stage7, inputs.stage7_openings, transcript)?\n    } else {\n        stage7_stage::Stage7ExecutionArtifacts::default()\n    };\n".to_owned()
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltVerifierStepPlan {
+    ReceiveCommitments { slot: JoltProofSlot },
+    VerifySumcheckStage { slot: JoltProofSlot },
+    VerifyPcsOpening { slot: JoltProofSlot },
 }
 
-fn jolt_verifier_evaluation_check() -> String {
-    "    if target.allows_optional_evaluation() {\n        match (&proof.evaluation, inputs.evaluation_setup) {\n            (Some(evaluation), Some(setup)) => {\n                verify_jolt_evaluation_proof(\n                    programs.stage8,\n                    evaluation,\n                    &commitment,\n                    &proof.stage6,\n                    &proof.stage7,\n                    inputs.stage7_openings,\n                    setup,\n                    transcript,\n                )?;\n            }\n            (Some(_), None) => return Err(JoltEvaluationProofError::MissingVerifierSetup.into()),\n            (None, Some(_)) => return Err(JoltEvaluationProofError::MissingProof.into()),\n            (None, None) if target.verifies_evaluation() => return Err(JoltEvaluationProofError::MissingProof.into()),\n            (None, None) => {}\n        }\n    }\n".to_owned()
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltVerifierCheckpoint {
+    AfterStage5,
+    AfterStage6,
+    AfterStage7,
+    AfterEvaluation,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltEvaluationPolicy {
+    Skip,
+    VerifyIfPresent,
+    Required,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct JoltVerifierTarget {
+    pub checkpoint: JoltVerifierCheckpoint,
+    pub evaluation: JoltEvaluationPolicy,
+}
+
+pub const JOLT_TARGET_THROUGH_STAGE5: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterStage5,
+    evaluation: JoltEvaluationPolicy::Skip,
+};
+
+pub const JOLT_TARGET_THROUGH_STAGE6: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterStage6,
+    evaluation: JoltEvaluationPolicy::Skip,
+};
+
+pub const JOLT_TARGET_THROUGH_STAGE7: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterStage7,
+    evaluation: JoltEvaluationPolicy::VerifyIfPresent,
+};
+
+pub const JOLT_TARGET_FULL: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterEvaluation,
+    evaluation: JoltEvaluationPolicy::Required,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct JoltVerifierTargetPlan {
+    pub target: JoltVerifierTarget,
+    pub steps: &'static [JoltVerifierStepPlan],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct JoltVerifierProgramPlan {
+    pub targets: &'static [JoltVerifierTargetPlan],
+}
+
+pub const JOLT_VERIFY_THROUGH_STAGE5_STEPS: &[JoltVerifierStepPlan] = &[
+    JoltVerifierStepPlan::ReceiveCommitments {
+        slot: JoltProofSlot::Commitments,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage1Outer,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage2,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage3,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage4,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage5,
+    },
+];
+
+pub const JOLT_VERIFY_THROUGH_STAGE6_STEPS: &[JoltVerifierStepPlan] = &[
+    JoltVerifierStepPlan::ReceiveCommitments {
+        slot: JoltProofSlot::Commitments,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage1Outer,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage2,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage3,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage4,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage5,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage6,
+    },
+];
+
+pub const JOLT_VERIFY_THROUGH_STAGE7_STEPS: &[JoltVerifierStepPlan] = &[
+    JoltVerifierStepPlan::ReceiveCommitments {
+        slot: JoltProofSlot::Commitments,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage1Outer,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage2,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage3,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage4,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage5,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage6,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage7,
+    },
+    JoltVerifierStepPlan::VerifyPcsOpening {
+        slot: JoltProofSlot::Evaluation,
+    },
+];
+
+pub const JOLT_VERIFY_FULL_STEPS: &[JoltVerifierStepPlan] = JOLT_VERIFY_THROUGH_STAGE7_STEPS;
+
+pub const JOLT_VERIFIER_TARGETS: &[JoltVerifierTargetPlan] = &[
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_THROUGH_STAGE5,
+        steps: JOLT_VERIFY_THROUGH_STAGE5_STEPS,
+    },
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_THROUGH_STAGE6,
+        steps: JOLT_VERIFY_THROUGH_STAGE6_STEPS,
+    },
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_THROUGH_STAGE7,
+        steps: JOLT_VERIFY_THROUGH_STAGE7_STEPS,
+    },
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_FULL,
+        steps: JOLT_VERIFY_FULL_STEPS,
+    },
+];
+
+pub const VERIFIER_PROGRAM: JoltVerifierProgramPlan = JoltVerifierProgramPlan {
+    targets: JOLT_VERIFIER_TARGETS,
+};
+
+#[derive(Debug)]
+pub enum JoltVerifierProgramError {
+    MissingTarget { target: JoltVerifierTarget },
+    MissingArtifact { slot: JoltProofSlot },
+    UnsupportedStep {
+        step: JoltVerifierStepPlan,
+        reason: &'static str,
+    },
+}
+
+"
+    .to_owned()
+}
+
+fn jolt_verifier_execution_body() -> String {
+    "    let _verify_span = tracing::info_span!(\"bolt.verify\").entered();\n    execute_jolt_verifier_program(proof, inputs, programs, transcript, target)\n}\n\n".to_owned()
+}
+
+fn jolt_verifier_program_executor() -> String {
+    r#"fn execute_jolt_verifier_program<T>(
+    proof: &JoltProof,
+    inputs: JoltVerifierInputs<'_>,
+    programs: JoltVerifierPrograms,
+    transcript: &mut T,
+    target: JoltVerifierTarget,
+) -> Result<JoltVerificationArtifacts, JoltVerifyError>
+where
+    T: Transcript<Challenge = Fr>,
+{
+    let target_plan = programs
+        .verifier
+        .targets
+        .iter()
+        .find(|plan| plan.target == target)
+        .ok_or(JoltVerifierProgramError::MissingTarget { target })?;
+    let mut artifacts = JoltArtifactStore::default();
+    for step in target_plan.steps {
+        execute_jolt_verifier_step(
+            *step,
+            proof,
+            inputs,
+            programs,
+            transcript,
+            target_plan,
+            &mut artifacts,
+        )?;
+    }
+    artifacts.into_public_artifacts().map_err(JoltVerifyError::from)
+}
+
+fn execute_jolt_verifier_step<T>(
+    step: JoltVerifierStepPlan,
+    proof: &JoltProof,
+    inputs: JoltVerifierInputs<'_>,
+    programs: JoltVerifierPrograms,
+    transcript: &mut T,
+    target_plan: &JoltVerifierTargetPlan,
+    artifacts: &mut JoltArtifactStore,
+) -> Result<(), JoltVerifyError>
+where
+    T: Transcript<Challenge = Fr>,
+{
+    match step {
+        JoltVerifierStepPlan::ReceiveCommitments {
+            slot: JoltProofSlot::Commitments,
+        } => {
+            artifacts.commitment = Some(commitment_stage::verify_commitment_phase_with_program(
+                programs.commitment,
+                &proof.commitments,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage1Outer,
+        } => {
+            artifacts.stage1_outer = Some(stage1_outer_stage::verify_stage1_outer_with_program(
+                programs.stage1_outer,
+                &proof.stage1_outer,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage2,
+        } => {
+            artifacts.stage2 = Some(stage2_stage::verify_stage2_with_program(
+                programs.stage2,
+                &proof.stage2,
+                inputs.stage2_openings,
+                inputs.stage2_ram,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage3,
+        } => {
+            artifacts.stage3 = Some(stage3_stage::verify_stage3_with_program(
+                programs.stage3,
+                &proof.stage3,
+                inputs.stage3_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage4,
+        } => {
+            artifacts.stage4 = Some(stage4_stage::verify_stage4_with_program(
+                programs.stage4,
+                &proof.stage4,
+                inputs.stage4_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage5,
+        } => {
+            artifacts.stage5 = Some(stage5_stage::verify_stage5_with_program(
+                programs.stage5,
+                &proof.stage5,
+                inputs.stage5_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage6,
+        } => {
+            artifacts.stage6 = Some(stage6_stage::verify_stage6_with_program(
+                programs.stage6,
+                &proof.stage6,
+                inputs.stage6_openings,
+                inputs.stage6_data,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage7,
+        } => {
+            artifacts.stage7 = Some(stage7_stage::verify_stage7_with_program(
+                programs.stage7,
+                &proof.stage7,
+                inputs.stage7_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifyPcsOpening {
+            slot: JoltProofSlot::Evaluation,
+        } => {
+            verify_jolt_evaluation_step(
+                target_plan.target.evaluation,
+                proof,
+                inputs,
+                programs,
+                transcript,
+                artifacts,
+            )?;
+        }
+        step => {
+            return Err(JoltVerifierProgramError::UnsupportedStep {
+                step,
+                reason: "step kind and proof slot are incompatible",
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn verify_jolt_evaluation_step<T>(
+    evaluation: JoltEvaluationPolicy,
+    proof: &JoltProof,
+    inputs: JoltVerifierInputs<'_>,
+    programs: JoltVerifierPrograms,
+    transcript: &mut T,
+    artifacts: &JoltArtifactStore,
+) -> Result<(), JoltVerifyError>
+where
+    T: Transcript<Challenge = Fr>,
+{
+    if evaluation == JoltEvaluationPolicy::Skip {
+        return Ok(());
+    }
+    match (&proof.evaluation, inputs.evaluation_setup) {
+        (Some(evaluation_proof), Some(setup)) => {
+            verify_jolt_evaluation_proof(
+                programs.stage8,
+                evaluation_proof,
+                artifacts.commitment()?,
+                &proof.stage6,
+                &proof.stage7,
+                inputs.stage7_openings,
+                setup,
+                transcript,
+            )?;
+        }
+        (Some(_), None) => return Err(JoltEvaluationProofError::MissingVerifierSetup.into()),
+        (None, Some(_)) => return Err(JoltEvaluationProofError::MissingProof.into()),
+        (None, None) if evaluation == JoltEvaluationPolicy::Required => {
+            return Err(JoltEvaluationProofError::MissingProof.into());
+        }
+        (None, None) => {}
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct JoltArtifactStore {
+    commitment: Option<commitment_stage::CommitmentArtifacts>,
+    stage1_outer: Option<stage1_outer_stage::Stage1ExecutionArtifacts<Fr>>,
+    stage2: Option<stage2_stage::Stage2ExecutionArtifacts<Fr>>,
+    stage3: Option<stage3_stage::Stage3ExecutionArtifacts<Fr>>,
+    stage4: Option<stage4_stage::Stage4ExecutionArtifacts<Fr>>,
+    stage5: Option<stage5_stage::Stage5ExecutionArtifacts<Fr>>,
+    stage6: Option<stage6_stage::Stage6ExecutionArtifacts<Fr>>,
+    stage7: Option<stage7_stage::Stage7ExecutionArtifacts<Fr>>,
+}
+
+impl JoltArtifactStore {
+    fn commitment(
+        &self,
+    ) -> Result<&commitment_stage::CommitmentArtifacts, JoltVerifierProgramError> {
+        self.commitment
+            .as_ref()
+            .ok_or(JoltVerifierProgramError::MissingArtifact {
+                slot: JoltProofSlot::Commitments,
+            })
+    }
+
+    fn into_public_artifacts(self) -> Result<JoltVerificationArtifacts, JoltVerifierProgramError> {
+        Ok(JoltVerificationArtifacts {
+            commitment: required_artifact(self.commitment, JoltProofSlot::Commitments)?,
+            stage1_outer: required_artifact(self.stage1_outer, JoltProofSlot::Stage1Outer)?,
+            stage2: required_artifact(self.stage2, JoltProofSlot::Stage2)?,
+            stage3: required_artifact(self.stage3, JoltProofSlot::Stage3)?,
+            stage4: required_artifact(self.stage4, JoltProofSlot::Stage4)?,
+            stage5: required_artifact(self.stage5, JoltProofSlot::Stage5)?,
+            stage6: self.stage6.unwrap_or_default(),
+            stage7: self.stage7.unwrap_or_default(),
+        })
+    }
+}
+
+fn required_artifact<T>(
+    artifact: Option<T>,
+    slot: JoltProofSlot,
+) -> Result<T, JoltVerifierProgramError> {
+    artifact.ok_or(JoltVerifierProgramError::MissingArtifact { slot })
+}
+
+"#
+    .to_owned()
 }
 
 fn jolt_verifier_input_helpers(prefix: &str) -> String {

--- a/crates/bolt/tests/verifier_cleanup.rs
+++ b/crates/bolt/tests/verifier_cleanup.rs
@@ -6,9 +6,12 @@
 
 use std::path::{Path, PathBuf};
 
-const GENERATED_VERIFIER_TARGET_LOC: usize = 6_100;
+/// S2.5 intentionally moves top-level verifier-program data into
+/// `verifier.rs`. Later value-graph slices should ratchet this back down as
+/// more stage-local math becomes typed data instead of Rust helpers.
+const GENERATED_VERIFIER_TARGET_LOC: usize = 6_500;
 const GENERATED_VERIFIER_STRETCH_LOC: usize = 3_000;
-const VERIFIER_RS_TARGET_LOC: usize = 500;
+const VERIFIER_RS_TARGET_LOC: usize = 850;
 const VERIFIER_RS_STRETCH_LOC: usize = 350;
 const STAGE6_STAGE7_TARGET_LOC: usize = 3_000;
 
@@ -331,6 +334,45 @@ fn checked_in_generated_verifier_respects_boundary_hygiene() {
                 && !source.contains("Challenge = <"),
             "generated verifier source `{}` drifted away from the full-field transcript path",
             path.display()
+        );
+    }
+}
+
+#[test]
+fn checked_in_generated_verifier_uses_typed_top_level_program() {
+    let verifier_rs = workspace_root().join("crates/jolt-verifier/src/verifier.rs");
+    if !verifier_rs.exists() {
+        return;
+    }
+    let source = std::fs::read_to_string(&verifier_rs).expect("read verifier.rs");
+    for pattern in [
+        "pub const VERIFIER_PROGRAM",
+        "pub enum JoltProofSlot",
+        "pub enum JoltVerifierStepPlan",
+        "JoltVerifierStepPlan::ReceiveCommitments",
+        "JoltVerifierStepPlan::VerifySumcheckStage",
+        "JoltVerifierStepPlan::VerifyPcsOpening",
+        "fn execute_jolt_verifier_program",
+        "fn execute_jolt_verifier_step",
+        "struct JoltArtifactStore",
+    ] {
+        assert!(
+            source.contains(pattern),
+            "generated verifier.rs is missing typed top-level verifier-program pattern `{pattern}`"
+        );
+    }
+    for stale_pattern in [
+        "JoltVerifierTarget::ThroughStage",
+        "fn verifies_stage6",
+        "fn verifies_stage7",
+        "fn verifies_evaluation",
+        "fn allows_optional_evaluation",
+        "target.verifies_stage",
+        "target.allows_optional_evaluation",
+    ] {
+        assert!(
+            !source.contains(stale_pattern),
+            "generated verifier.rs still contains stale target-control-flow pattern `{stale_pattern}`"
         );
     }
 }

--- a/crates/jolt-equivalence/src/bolt_oracle.rs
+++ b/crates/jolt-equivalence/src/bolt_oracle.rs
@@ -138,6 +138,7 @@ pub fn assert_bolt_full_real_trace_self_parity(
         stage5: generated_stage5_verifier_plan,
         stage6: generated_stage6_verifier_plan,
         stage7: generated_stage7_verifier_plan,
+        verifier: &jolt_verifier::VERIFIER_PROGRAM,
         stage8: generated_stage8_verifier_plan,
     };
     let r1cs_key = fixture.r1cs_key();

--- a/crates/jolt-verifier/src/lib.rs
+++ b/crates/jolt-verifier/src/lib.rs
@@ -17,12 +17,16 @@ pub use verifier::{
     verify_jolt_prefix_with_programs, verify_jolt_through_stage5,
     verify_jolt_through_stage5_with_programs, verify_jolt_through_stage6,
     verify_jolt_through_stage6_with_programs, verify_jolt_through_stage7,
-    verify_jolt_through_stage7_with_programs, verify_jolt_with_programs, JoltEvaluationProof,
-    JoltEvaluationProofError, JoltNamedEval, JoltProof, JoltStage2RamAccess, JoltStage2RamData,
-    JoltStage2RamOutputLayout, JoltStage6BytecodeEntry, JoltStage6BytecodeReadRafData,
-    JoltStage6VerifierData, JoltStageChallengeVector, JoltStageExecutionArtifacts,
-    JoltStageOpeningInputValue, JoltStageProof, JoltSumcheckOutput, JoltVerificationArtifacts,
-    JoltVerifierInputs, JoltVerifierPrograms, JoltVerifierTarget, JoltVerifyError,
+    verify_jolt_through_stage7_with_programs, verify_jolt_with_programs, JoltEvaluationPolicy,
+    JoltEvaluationProof, JoltEvaluationProofError, JoltNamedEval, JoltProof, JoltProofSlot,
+    JoltStage2RamAccess, JoltStage2RamData, JoltStage2RamOutputLayout, JoltStage6BytecodeEntry,
+    JoltStage6BytecodeReadRafData, JoltStage6VerifierData, JoltStageChallengeVector,
+    JoltStageExecutionArtifacts, JoltStageOpeningInputValue, JoltStageProof, JoltSumcheckOutput,
+    JoltVerificationArtifacts, JoltVerifierCheckpoint, JoltVerifierInputs,
+    JoltVerifierProgramError, JoltVerifierProgramPlan, JoltVerifierPrograms, JoltVerifierStepPlan,
+    JoltVerifierTarget, JoltVerifierTargetPlan, JoltVerifyError, JOLT_TARGET_FULL,
+    JOLT_TARGET_THROUGH_STAGE5, JOLT_TARGET_THROUGH_STAGE6, JOLT_TARGET_THROUGH_STAGE7,
+    JOLT_VERIFIER_TARGETS, VERIFIER_PROGRAM,
 };
 
 pub const TRANSCRIPT_LABEL: &[u8] = b"Jolt";

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -60,6 +60,7 @@ pub struct JoltVerifierPrograms {
     pub stage5: &'static stage5_stage::Stage5VerifierProgramPlan,
     pub stage6: &'static stage6_stage::Stage6VerifierProgramPlan,
     pub stage7: &'static stage7_stage::Stage7VerifierProgramPlan,
+    pub verifier: &'static JoltVerifierProgramPlan,
     pub stage8: &'static stage8_stage::Stage8EvaluationProgramPlan,
 }
 
@@ -73,6 +74,7 @@ pub fn default_verifier_programs() -> JoltVerifierPrograms {
         stage5: &stage5_stage::STAGE5_PROGRAM,
         stage6: &stage6_stage::STAGE6_PROGRAM,
         stage7: &stage7_stage::STAGE7_PROGRAM,
+        verifier: &VERIFIER_PROGRAM,
         stage8: &stage8_stage::STAGE8_PROGRAM,
     }
 }
@@ -99,22 +101,190 @@ pub enum JoltVerifyError {
     Stage5(stage5_stage::VerifyStage5Error),
     Stage6(stage6_stage::VerifyStage6Error),
     Stage7(stage7_stage::VerifyStage7Error),
+    Program(JoltVerifierProgramError),
     Evaluation(JoltEvaluationProofError),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum JoltVerifierTarget {
-    ThroughStage5,
-    ThroughStage6,
-    ThroughStage7,
-    Full,
+pub enum JoltProofSlot {
+    Commitments,
+    Stage1Outer,
+    Stage2,
+    Stage3,
+    Stage4,
+    Stage5,
+    Stage6,
+    Stage7,
+    Evaluation,
 }
 
-impl JoltVerifierTarget {
-    fn verifies_stage6(self) -> bool { matches!(self, Self::ThroughStage6 | Self::ThroughStage7 | Self::Full) }
-    fn verifies_stage7(self) -> bool { matches!(self, Self::ThroughStage7 | Self::Full) }
-    fn verifies_evaluation(self) -> bool { matches!(self, Self::Full) }
-    fn allows_optional_evaluation(self) -> bool { matches!(self, Self::ThroughStage7 | Self::Full) }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltVerifierStepPlan {
+    ReceiveCommitments { slot: JoltProofSlot },
+    VerifySumcheckStage { slot: JoltProofSlot },
+    VerifyPcsOpening { slot: JoltProofSlot },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltVerifierCheckpoint {
+    AfterStage5,
+    AfterStage6,
+    AfterStage7,
+    AfterEvaluation,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JoltEvaluationPolicy {
+    Skip,
+    VerifyIfPresent,
+    Required,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct JoltVerifierTarget {
+    pub checkpoint: JoltVerifierCheckpoint,
+    pub evaluation: JoltEvaluationPolicy,
+}
+
+pub const JOLT_TARGET_THROUGH_STAGE5: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterStage5,
+    evaluation: JoltEvaluationPolicy::Skip,
+};
+
+pub const JOLT_TARGET_THROUGH_STAGE6: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterStage6,
+    evaluation: JoltEvaluationPolicy::Skip,
+};
+
+pub const JOLT_TARGET_THROUGH_STAGE7: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterStage7,
+    evaluation: JoltEvaluationPolicy::VerifyIfPresent,
+};
+
+pub const JOLT_TARGET_FULL: JoltVerifierTarget = JoltVerifierTarget {
+    checkpoint: JoltVerifierCheckpoint::AfterEvaluation,
+    evaluation: JoltEvaluationPolicy::Required,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct JoltVerifierTargetPlan {
+    pub target: JoltVerifierTarget,
+    pub steps: &'static [JoltVerifierStepPlan],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct JoltVerifierProgramPlan {
+    pub targets: &'static [JoltVerifierTargetPlan],
+}
+
+pub const JOLT_VERIFY_THROUGH_STAGE5_STEPS: &[JoltVerifierStepPlan] = &[
+    JoltVerifierStepPlan::ReceiveCommitments {
+        slot: JoltProofSlot::Commitments,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage1Outer,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage2,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage3,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage4,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage5,
+    },
+];
+
+pub const JOLT_VERIFY_THROUGH_STAGE6_STEPS: &[JoltVerifierStepPlan] = &[
+    JoltVerifierStepPlan::ReceiveCommitments {
+        slot: JoltProofSlot::Commitments,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage1Outer,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage2,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage3,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage4,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage5,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage6,
+    },
+];
+
+pub const JOLT_VERIFY_THROUGH_STAGE7_STEPS: &[JoltVerifierStepPlan] = &[
+    JoltVerifierStepPlan::ReceiveCommitments {
+        slot: JoltProofSlot::Commitments,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage1Outer,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage2,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage3,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage4,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage5,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage6,
+    },
+    JoltVerifierStepPlan::VerifySumcheckStage {
+        slot: JoltProofSlot::Stage7,
+    },
+    JoltVerifierStepPlan::VerifyPcsOpening {
+        slot: JoltProofSlot::Evaluation,
+    },
+];
+
+pub const JOLT_VERIFY_FULL_STEPS: &[JoltVerifierStepPlan] = JOLT_VERIFY_THROUGH_STAGE7_STEPS;
+
+pub const JOLT_VERIFIER_TARGETS: &[JoltVerifierTargetPlan] = &[
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_THROUGH_STAGE5,
+        steps: JOLT_VERIFY_THROUGH_STAGE5_STEPS,
+    },
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_THROUGH_STAGE6,
+        steps: JOLT_VERIFY_THROUGH_STAGE6_STEPS,
+    },
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_THROUGH_STAGE7,
+        steps: JOLT_VERIFY_THROUGH_STAGE7_STEPS,
+    },
+    JoltVerifierTargetPlan {
+        target: JOLT_TARGET_FULL,
+        steps: JOLT_VERIFY_FULL_STEPS,
+    },
+];
+
+pub const VERIFIER_PROGRAM: JoltVerifierProgramPlan = JoltVerifierProgramPlan {
+    targets: JOLT_VERIFIER_TARGETS,
+};
+
+#[derive(Debug)]
+pub enum JoltVerifierProgramError {
+    MissingTarget { target: JoltVerifierTarget },
+    MissingArtifact { slot: JoltProofSlot },
+    UnsupportedStep {
+        step: JoltVerifierStepPlan,
+        reason: &'static str,
+    },
 }
 
 #[derive(Debug)]
@@ -152,6 +322,12 @@ define_jolt_verify_error_from!(stage5_stage, VerifyStage5Error, Stage5);
 define_jolt_verify_error_from!(stage6_stage, VerifyStage6Error, Stage6);
 define_jolt_verify_error_from!(stage7_stage, VerifyStage7Error, Stage7);
 
+impl From<JoltVerifierProgramError> for JoltVerifyError {
+    fn from(error: JoltVerifierProgramError) -> Self {
+        Self::Program(error)
+    }
+}
+
 impl From<JoltEvaluationProofError> for JoltVerifyError {
     fn from(error: JoltEvaluationProofError) -> Self {
         Self::Evaluation(error)
@@ -177,66 +353,248 @@ pub fn verify_jolt_through_stage6<T: Transcript<Challenge = Fr>>(proof: &JoltPro
 pub fn verify_jolt_through_stage7<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage7_with_programs(proof, inputs, default_verifier_programs(), transcript) }
 
 pub fn verify_jolt_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> {
-    verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::Full)
+    verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_FULL)
 }
 
-pub fn verify_jolt_through_stage5_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::ThroughStage5) }
+pub fn verify_jolt_through_stage5_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_THROUGH_STAGE5) }
 
-pub fn verify_jolt_through_stage6_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::ThroughStage6) }
+pub fn verify_jolt_through_stage6_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_THROUGH_STAGE6) }
 
-pub fn verify_jolt_through_stage7_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JoltVerifierTarget::ThroughStage7) }
+pub fn verify_jolt_through_stage7_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_with_programs_inner(proof, inputs, programs, transcript, JOLT_TARGET_THROUGH_STAGE7) }
 
 pub fn verify_jolt_prefix_with_programs<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T) -> Result<JoltVerificationArtifacts, JoltVerifyError> { verify_jolt_through_stage7_with_programs(proof, inputs, programs, transcript) }
 
 fn verify_jolt_with_programs_inner<T: Transcript<Challenge = Fr>>(proof: &JoltProof, inputs: JoltVerifierInputs<'_>, programs: JoltVerifierPrograms, transcript: &mut T, target: JoltVerifierTarget) -> Result<JoltVerificationArtifacts, JoltVerifyError> {
     let _verify_span = tracing::info_span!("bolt.verify").entered();
-    let commitment = commitment_stage::verify_commitment_phase_with_program(programs.commitment, &proof.commitments, transcript)?;
-    let stage1_outer = stage1_outer_stage::verify_stage1_outer_with_program(programs.stage1_outer, &proof.stage1_outer, transcript)?;
-    let stage2 = stage2_stage::verify_stage2_with_program(programs.stage2, &proof.stage2, inputs.stage2_openings, inputs.stage2_ram, transcript)?;
-    let stage3 = stage3_stage::verify_stage3_with_program(programs.stage3, &proof.stage3, inputs.stage3_openings, transcript)?;
-    let stage4 = stage4_stage::verify_stage4_with_program(programs.stage4, &proof.stage4, inputs.stage4_openings, transcript)?;
-    let stage5 = stage5_stage::verify_stage5_with_program(programs.stage5, &proof.stage5, inputs.stage5_openings, transcript)?;
-    let stage6 = if target.verifies_stage6() {
-        stage6_stage::verify_stage6_with_program(programs.stage6, &proof.stage6, inputs.stage6_openings, inputs.stage6_data, transcript)?
-    } else {
-        stage6_stage::Stage6ExecutionArtifacts::default()
-    };
-    let stage7 = if target.verifies_stage7() {
-        stage7_stage::verify_stage7_with_program(programs.stage7, &proof.stage7, inputs.stage7_openings, transcript)?
-    } else {
-        stage7_stage::Stage7ExecutionArtifacts::default()
-    };
-    if target.allows_optional_evaluation() {
-        match (&proof.evaluation, inputs.evaluation_setup) {
-            (Some(evaluation), Some(setup)) => {
-                verify_jolt_evaluation_proof(
-                    programs.stage8,
-                    evaluation,
-                    &commitment,
-                    &proof.stage6,
-                    &proof.stage7,
-                    inputs.stage7_openings,
-                    setup,
-                    transcript,
-                )?;
+    execute_jolt_verifier_program(proof, inputs, programs, transcript, target)
+}
+
+fn execute_jolt_verifier_program<T>(
+    proof: &JoltProof,
+    inputs: JoltVerifierInputs<'_>,
+    programs: JoltVerifierPrograms,
+    transcript: &mut T,
+    target: JoltVerifierTarget,
+) -> Result<JoltVerificationArtifacts, JoltVerifyError>
+where
+    T: Transcript<Challenge = Fr>,
+{
+    let target_plan = programs
+        .verifier
+        .targets
+        .iter()
+        .find(|plan| plan.target == target)
+        .ok_or(JoltVerifierProgramError::MissingTarget { target })?;
+    let mut artifacts = JoltArtifactStore::default();
+    for step in target_plan.steps {
+        execute_jolt_verifier_step(
+            *step,
+            proof,
+            inputs,
+            programs,
+            transcript,
+            target_plan,
+            &mut artifacts,
+        )?;
+    }
+    artifacts.into_public_artifacts().map_err(JoltVerifyError::from)
+}
+
+fn execute_jolt_verifier_step<T>(
+    step: JoltVerifierStepPlan,
+    proof: &JoltProof,
+    inputs: JoltVerifierInputs<'_>,
+    programs: JoltVerifierPrograms,
+    transcript: &mut T,
+    target_plan: &JoltVerifierTargetPlan,
+    artifacts: &mut JoltArtifactStore,
+) -> Result<(), JoltVerifyError>
+where
+    T: Transcript<Challenge = Fr>,
+{
+    match step {
+        JoltVerifierStepPlan::ReceiveCommitments {
+            slot: JoltProofSlot::Commitments,
+        } => {
+            artifacts.commitment = Some(commitment_stage::verify_commitment_phase_with_program(
+                programs.commitment,
+                &proof.commitments,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage1Outer,
+        } => {
+            artifacts.stage1_outer = Some(stage1_outer_stage::verify_stage1_outer_with_program(
+                programs.stage1_outer,
+                &proof.stage1_outer,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage2,
+        } => {
+            artifacts.stage2 = Some(stage2_stage::verify_stage2_with_program(
+                programs.stage2,
+                &proof.stage2,
+                inputs.stage2_openings,
+                inputs.stage2_ram,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage3,
+        } => {
+            artifacts.stage3 = Some(stage3_stage::verify_stage3_with_program(
+                programs.stage3,
+                &proof.stage3,
+                inputs.stage3_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage4,
+        } => {
+            artifacts.stage4 = Some(stage4_stage::verify_stage4_with_program(
+                programs.stage4,
+                &proof.stage4,
+                inputs.stage4_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage5,
+        } => {
+            artifacts.stage5 = Some(stage5_stage::verify_stage5_with_program(
+                programs.stage5,
+                &proof.stage5,
+                inputs.stage5_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage6,
+        } => {
+            artifacts.stage6 = Some(stage6_stage::verify_stage6_with_program(
+                programs.stage6,
+                &proof.stage6,
+                inputs.stage6_openings,
+                inputs.stage6_data,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifySumcheckStage {
+            slot: JoltProofSlot::Stage7,
+        } => {
+            artifacts.stage7 = Some(stage7_stage::verify_stage7_with_program(
+                programs.stage7,
+                &proof.stage7,
+                inputs.stage7_openings,
+                transcript,
+            )?);
+        }
+        JoltVerifierStepPlan::VerifyPcsOpening {
+            slot: JoltProofSlot::Evaluation,
+        } => {
+            verify_jolt_evaluation_step(
+                target_plan.target.evaluation,
+                proof,
+                inputs,
+                programs,
+                transcript,
+                artifacts,
+            )?;
+        }
+        step => {
+            return Err(JoltVerifierProgramError::UnsupportedStep {
+                step,
+                reason: "step kind and proof slot are incompatible",
             }
-            (Some(_), None) => return Err(JoltEvaluationProofError::MissingVerifierSetup.into()),
-            (None, Some(_)) => return Err(JoltEvaluationProofError::MissingProof.into()),
-            (None, None) if target.verifies_evaluation() => return Err(JoltEvaluationProofError::MissingProof.into()),
-            (None, None) => {}
+            .into());
         }
     }
+    Ok(())
+}
 
-    Ok(JoltVerificationArtifacts {
-        commitment,
-        stage1_outer,
-        stage2,
-        stage3,
-        stage4,
-        stage5,
-        stage6,
-        stage7,
-    })
+fn verify_jolt_evaluation_step<T>(
+    evaluation: JoltEvaluationPolicy,
+    proof: &JoltProof,
+    inputs: JoltVerifierInputs<'_>,
+    programs: JoltVerifierPrograms,
+    transcript: &mut T,
+    artifacts: &JoltArtifactStore,
+) -> Result<(), JoltVerifyError>
+where
+    T: Transcript<Challenge = Fr>,
+{
+    if evaluation == JoltEvaluationPolicy::Skip {
+        return Ok(());
+    }
+    match (&proof.evaluation, inputs.evaluation_setup) {
+        (Some(evaluation_proof), Some(setup)) => {
+            verify_jolt_evaluation_proof(
+                programs.stage8,
+                evaluation_proof,
+                artifacts.commitment()?,
+                &proof.stage6,
+                &proof.stage7,
+                inputs.stage7_openings,
+                setup,
+                transcript,
+            )?;
+        }
+        (Some(_), None) => return Err(JoltEvaluationProofError::MissingVerifierSetup.into()),
+        (None, Some(_)) => return Err(JoltEvaluationProofError::MissingProof.into()),
+        (None, None) if evaluation == JoltEvaluationPolicy::Required => {
+            return Err(JoltEvaluationProofError::MissingProof.into());
+        }
+        (None, None) => {}
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct JoltArtifactStore {
+    commitment: Option<commitment_stage::CommitmentArtifacts>,
+    stage1_outer: Option<stage1_outer_stage::Stage1ExecutionArtifacts<Fr>>,
+    stage2: Option<stage2_stage::Stage2ExecutionArtifacts<Fr>>,
+    stage3: Option<stage3_stage::Stage3ExecutionArtifacts<Fr>>,
+    stage4: Option<stage4_stage::Stage4ExecutionArtifacts<Fr>>,
+    stage5: Option<stage5_stage::Stage5ExecutionArtifacts<Fr>>,
+    stage6: Option<stage6_stage::Stage6ExecutionArtifacts<Fr>>,
+    stage7: Option<stage7_stage::Stage7ExecutionArtifacts<Fr>>,
+}
+
+impl JoltArtifactStore {
+    fn commitment(
+        &self,
+    ) -> Result<&commitment_stage::CommitmentArtifacts, JoltVerifierProgramError> {
+        self.commitment
+            .as_ref()
+            .ok_or(JoltVerifierProgramError::MissingArtifact {
+                slot: JoltProofSlot::Commitments,
+            })
+    }
+
+    fn into_public_artifacts(self) -> Result<JoltVerificationArtifacts, JoltVerifierProgramError> {
+        Ok(JoltVerificationArtifacts {
+            commitment: required_artifact(self.commitment, JoltProofSlot::Commitments)?,
+            stage1_outer: required_artifact(self.stage1_outer, JoltProofSlot::Stage1Outer)?,
+            stage2: required_artifact(self.stage2, JoltProofSlot::Stage2)?,
+            stage3: required_artifact(self.stage3, JoltProofSlot::Stage3)?,
+            stage4: required_artifact(self.stage4, JoltProofSlot::Stage4)?,
+            stage5: required_artifact(self.stage5, JoltProofSlot::Stage5)?,
+            stage6: self.stage6.unwrap_or_default(),
+            stage7: self.stage7.unwrap_or_default(),
+        })
+    }
+}
+
+fn required_artifact<T>(
+    artifact: Option<T>,
+    slot: JoltProofSlot,
+) -> Result<T, JoltVerifierProgramError> {
+    artifact.ok_or(JoltVerifierProgramError::MissingArtifact { slot })
 }
 
 impl<'a> JoltVerifierInputs<'a> {


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.

## Summary

This is the S2.5 slice stacked on top of #19. It captures the verifier-time baseline and cuts the generated top-level verifier over to a typed verifier-program executor while preserving `JoltProof` serialization and the public verification artifact shape.

Changes:
- adds generated `VERIFIER_PROGRAM`, typed proof slots, typed verifier steps, typed checkpoints, and evaluation policies
- replaces the old manual top-level stage sequencing with one `execute_jolt_verifier_program` loop over typed target steps
- adds an internal `JoltArtifactStore` and materializes the existing `JoltVerificationArtifacts` at the end
- routes custom equivalence-leaked stage plans through the same top-level verifier program via `JoltVerifierPrograms::verifier`
- adds a cleanup gate that asserts the generated verifier exposes the typed top-level program and no stale target-helper branch model

## Perf Notes

Before S2.5, SHA2-chain `2^16` perf oracle:
- core `verify_ms`: 172.017
- Bolt `verify_ms`: 148.593
- Bolt/core ratio: 0.864x

After S2.5, same command, two runs:
- run 1: core `verify_ms` 155.733, Bolt `verify_ms` 150.576, ratio 0.967x
- run 2: core `verify_ms` 151.115, Bolt `verify_ms` 153.706, ratio 1.017x

The few-millisecond Bolt increase is recorded as a watch item, not hidden. The command passes and the small movement looks noisy, but later slices should keep repeating this baseline.

## What This Does Not Do

- Does not change `JoltProof` fields or proof serialization.
- Does not expose every transcript squeeze, sumcheck driver, opening batch, and relation check as a top-level typed step yet; `VerifySumcheckStage { slot }` still delegates to existing stage executors.
- Does not move Jolt proof-slot vocabulary into `bolt-verifier-runtime`.
- Does not loosen perf thresholds.

## Verification

- `source .bolt-dev-env && cargo check -p bolt --quiet`
- `source .bolt-dev-env && JOLT_UPDATE_GOLDENS=1 cargo nextest run -p bolt generated_jolt_artifacts_have_uniform_crate_layout_and_import_rules --cargo-quiet`
- `source .bolt-dev-env && cargo check -p bolt -p bolt-verifier-runtime -p jolt-verifier -p jolt-prover -p jolt-equivalence --quiet`
- `source .bolt-dev-env && cargo nextest run -p bolt --test verifier_cleanup --no-capture`
- `source .bolt-dev-env && cargo nextest run -p bolt generated_jolt_artifacts_have_uniform_crate_layout_and_import_rules --cargo-quiet`
- `source .bolt-dev-env && cargo nextest run -p bolt --test commitment_ir --cargo-quiet`
- `source .bolt-dev-env && cargo nextest run -p jolt-equivalence --test generated_role_crates --cargo-quiet`
- `source .bolt-dev-env && cargo nextest run -p jolt-equivalence --test bolt_commitment --no-capture`
- `source .bolt-dev-env && cargo nextest run -p jolt-equivalence --cargo-quiet`
- `source .bolt-dev-env && cargo nextest run -p jolt-core muldiv --cargo-quiet --features host`
- `source .bolt-dev-env && cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk`
- `source .bolt-dev-env && cargo clippy --all --features host -q --all-targets -- -D warnings`
- `source .bolt-dev-env && cargo clippy --all --features host,zk -q --all-targets -- -D warnings`
- `cargo fmt --check && git diff --check`

Notes: `commitment_ir` passed with the existing-style nextest slow-test notices and one leaky-test notice (`generated_stage1_real_executor_reaches_kernel_dispatch`), but the suite exit status was success.
