### PR TITLE
feat: add committed program preprocessing model

### DIFF
--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -197,6 +197,9 @@ impl<F: JoltField> RLCPolynomial<F> {
                         advice_polys.push((*coeff, advice_poly_map.remove(poly_id).unwrap()));
                     }
                 }
+                CommittedPolynomial::BytecodeChunk(_) | CommittedPolynomial::ProgramImageInit => {
+                    panic!("committed program precommitments are not wired into Stage 8 yet")
+                }
             }
         }
 

--- a/jolt-core/src/utils/errors.rs
+++ b/jolt-core/src/utils/errors.rs
@@ -28,6 +28,8 @@ pub enum ProofVerifyError {
     InvalidReadWriteConfig(String),
     #[error("Invalid one-hot configuration: {0}")]
     InvalidOneHotConfig(String),
+    #[error("Invalid bytecode commitment configuration: {0}")]
+    InvalidBytecodeConfig(String),
     #[error("Invalid ram_K: got {got}, expected power of two in [{min}, {max}]")]
     InvalidRamK { got: usize, min: usize, max: usize },
     #[error("Invalid trace_length: got {0}, max allowed {1}")]
@@ -44,4 +46,6 @@ pub enum ProofVerifyError {
     ZkFeatureRequired,
     #[error("BlindFold verification failed: {0}")]
     BlindFoldError(String),
+    #[error("Bytecode type mismatch: {0}")]
+    BytecodeTypeMismatch(String),
 }

--- a/jolt-core/src/zkvm/bytecode/chunks.rs
+++ b/jolt-core/src/zkvm/bytecode/chunks.rs
@@ -1,0 +1,207 @@
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::thread::unsafe_allocate_zero_vec;
+use crate::zkvm::instruction::{
+    Flags, InstructionLookup, InterleavedBitsMarker, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
+};
+use crate::zkvm::lookup_table::LookupTables;
+use common::constants::{REGISTER_COUNT, XLEN};
+use jolt_riscv::JoltInstructionRow;
+
+/// Total number of lanes encoded by committed-bytecode rows.
+pub const fn total_lanes() -> usize {
+    3 * (REGISTER_COUNT as usize)
+        + 2
+        + NUM_CIRCUIT_FLAGS
+        + NUM_INSTRUCTION_FLAGS
+        + <LookupTables<XLEN> as strum::EnumCount>::COUNT
+        + 1
+}
+
+/// Fixed lane capacity for committed bytecode rows.
+pub const COMMITTED_BYTECODE_LANE_CAPACITY: usize = total_lanes().next_power_of_two();
+
+#[inline(always)]
+pub const fn committed_lanes() -> usize {
+    COMMITTED_BYTECODE_LANE_CAPACITY
+}
+
+pub const DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 1;
+pub const MAX_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 256;
+
+#[inline]
+pub fn validate_committed_bytecode_chunk_count(chunk_count: usize) {
+    assert!(chunk_count > 0, "bytecode chunk count must be non-zero");
+    assert!(
+        chunk_count <= MAX_COMMITTED_BYTECODE_CHUNK_COUNT,
+        "bytecode chunk count must be at most {MAX_COMMITTED_BYTECODE_CHUNK_COUNT}"
+    );
+    assert!(
+        chunk_count.is_power_of_two(),
+        "bytecode chunk count must be a power of two"
+    );
+}
+
+#[inline(always)]
+pub fn validate_committed_bytecode_chunking_for_len(bytecode_len: usize, chunk_count: usize) {
+    validate_committed_bytecode_chunk_count(chunk_count);
+    assert!(
+        bytecode_len.is_multiple_of(chunk_count),
+        "bytecode length ({bytecode_len}) must be divisible by chunk count ({chunk_count})"
+    );
+}
+
+#[inline(always)]
+pub fn committed_bytecode_chunk_cycle_len(bytecode_len: usize, chunk_count: usize) -> usize {
+    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
+    bytecode_len / chunk_count
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BytecodeLaneLayout {
+    pub rs1_start: usize,
+    pub rs2_start: usize,
+    pub rd_start: usize,
+    pub unexp_pc_idx: usize,
+    pub imm_idx: usize,
+    pub circuit_start: usize,
+    pub instr_start: usize,
+    pub lookup_start: usize,
+    pub raf_flag_idx: usize,
+}
+
+impl BytecodeLaneLayout {
+    pub const fn new() -> Self {
+        let reg_count = REGISTER_COUNT as usize;
+        let rs1_start = 0usize;
+        let rs2_start = rs1_start + reg_count;
+        let rd_start = rs2_start + reg_count;
+        let unexp_pc_idx = rd_start + reg_count;
+        let imm_idx = unexp_pc_idx + 1;
+        let circuit_start = imm_idx + 1;
+        let instr_start = circuit_start + NUM_CIRCUIT_FLAGS;
+        let lookup_start = instr_start + NUM_INSTRUCTION_FLAGS;
+        let raf_flag_idx = lookup_start + <LookupTables<XLEN> as strum::EnumCount>::COUNT;
+        Self {
+            rs1_start,
+            rs2_start,
+            rd_start,
+            unexp_pc_idx,
+            imm_idx,
+            circuit_start,
+            instr_start,
+            lookup_start,
+            raf_flag_idx,
+        }
+    }
+}
+
+pub const BYTECODE_LANE_LAYOUT: BytecodeLaneLayout = BytecodeLaneLayout::new();
+
+#[derive(Clone, Copy, Debug)]
+pub enum ActiveLaneValue<F: JoltField> {
+    One,
+    Scalar(F),
+}
+
+#[inline(always)]
+pub fn for_each_active_lane_value<F: JoltField>(
+    instruction: &JoltInstructionRow,
+    mut visit: impl FnMut(usize, ActiveLaneValue<F>),
+) {
+    let l = BYTECODE_LANE_LAYOUT;
+
+    let circuit_flags = instruction.circuit_flags();
+    let instr_flags = instruction.instruction_flags();
+    let lookup_idx = InstructionLookup::<XLEN>::lookup_table(instruction)
+        .map(|t| LookupTables::<XLEN>::enum_index(&t));
+    let raf_flag = !InterleavedBitsMarker::is_interleaved_operands(&circuit_flags);
+
+    if let Some(r) = instruction.operands.rs1 {
+        visit(l.rs1_start + (r as usize), ActiveLaneValue::One);
+    }
+    if let Some(r) = instruction.operands.rs2 {
+        visit(l.rs2_start + (r as usize), ActiveLaneValue::One);
+    }
+    if let Some(r) = instruction.operands.rd {
+        visit(l.rd_start + (r as usize), ActiveLaneValue::One);
+    }
+
+    let unexpanded_pc = F::from_u64(instruction.address as u64);
+    if !unexpanded_pc.is_zero() {
+        visit(l.unexp_pc_idx, ActiveLaneValue::Scalar(unexpanded_pc));
+    }
+    let imm = F::from_i128(instruction.operands.imm);
+    if !imm.is_zero() {
+        visit(l.imm_idx, ActiveLaneValue::Scalar(imm));
+    }
+
+    for i in 0..NUM_CIRCUIT_FLAGS {
+        if circuit_flags[i] {
+            visit(l.circuit_start + i, ActiveLaneValue::One);
+        }
+    }
+    for i in 0..NUM_INSTRUCTION_FLAGS {
+        if instr_flags[i] {
+            visit(l.instr_start + i, ActiveLaneValue::One);
+        }
+    }
+    if let Some(t) = lookup_idx {
+        visit(l.lookup_start + t, ActiveLaneValue::One);
+    }
+    if raf_flag {
+        visit(l.raf_flag_idx, ActiveLaneValue::One);
+    }
+}
+
+#[tracing::instrument(skip_all, name = "bytecode::build_committed_bytecode_chunk_coeffs")]
+pub fn build_committed_bytecode_chunk_coeffs<F: JoltField>(
+    instructions: &[JoltInstructionRow],
+    chunk_count: usize,
+) -> Vec<Vec<F>> {
+    let bytecode_len = instructions.len();
+    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
+
+    let chunk_cycle_len = committed_bytecode_chunk_cycle_len(bytecode_len, chunk_count);
+    let lane_capacity = committed_lanes();
+    let mut chunk_coeffs: Vec<Vec<F>> = (0..chunk_count)
+        .map(|_| unsafe_allocate_zero_vec(lane_capacity * chunk_cycle_len))
+        .collect();
+
+    for (cycle, instr) in instructions.iter().enumerate() {
+        let cycle_chunk_idx = cycle / chunk_cycle_len;
+        let chunk_cycle = cycle % chunk_cycle_len;
+        let coeffs = &mut chunk_coeffs[cycle_chunk_idx];
+
+        for_each_active_lane_value::<F>(instr, |global_lane, lane_val| {
+            let idx = DoryGlobals::get_layout().address_cycle_to_index(
+                global_lane,
+                chunk_cycle,
+                lane_capacity,
+                chunk_cycle_len,
+            );
+            let lane_value = match lane_val {
+                ActiveLaneValue::One => F::one(),
+                ActiveLaneValue::Scalar(v) => v,
+            };
+            coeffs[idx] += lane_value;
+        });
+    }
+
+    chunk_coeffs
+}
+
+#[tracing::instrument(
+    skip_all,
+    name = "bytecode::build_committed_bytecode_chunk_polynomials"
+)]
+pub fn build_committed_bytecode_chunk_polynomials<F: JoltField>(
+    instructions: &[JoltInstructionRow],
+    chunk_count: usize,
+) -> Vec<MultilinearPolynomial<F>> {
+    build_committed_bytecode_chunk_coeffs::<F>(instructions, chunk_count)
+        .into_iter()
+        .map(MultilinearPolynomial::from)
+        .collect()
+}

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -1,8 +1,79 @@
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use tracer::instruction::Cycle;
 
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::{
+    build_committed_bytecode_chunk_polynomials, committed_bytecode_chunk_cycle_len,
+    committed_lanes, validate_committed_bytecode_chunking_for_len,
+};
+
+pub mod chunks;
 pub mod read_raf_checking;
 
 pub use jolt_program::preprocess::{BytecodePCMapper, BytecodePreprocessing, PreprocessingError};
+
+#[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct TrustedBytecodeCommitments<PCS: CommitmentScheme> {
+    pub commitments: Vec<PCS::Commitment>,
+    pub num_columns: usize,
+    pub log_k_chunk: u8,
+    pub bytecode_chunk_count: usize,
+    pub bytecode_len: usize,
+    pub bytecode_T: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct TrustedBytecodeHints<PCS: CommitmentScheme> {
+    pub hints: Vec<PCS::OpeningProofHint>,
+}
+
+impl<PCS: CommitmentScheme> TrustedBytecodeCommitments<PCS> {
+    #[tracing::instrument(skip_all, name = "TrustedBytecodeCommitments::derive")]
+    pub fn derive(
+        bytecode: &BytecodePreprocessing,
+        generators: &PCS::ProverSetup,
+        log_k_chunk: usize,
+        bytecode_chunk_count: usize,
+    ) -> (Self, TrustedBytecodeHints<PCS>) {
+        let bytecode_len = bytecode.code_size;
+        validate_committed_bytecode_chunking_for_len(bytecode_len, bytecode_chunk_count);
+        let bytecode_T = committed_bytecode_chunk_cycle_len(bytecode_len, bytecode_chunk_count);
+
+        let total_vars = bytecode_T.log_2() + committed_lanes().log_2();
+        let (bytecode_sigma, _) = DoryGlobals::balanced_sigma_nu(total_vars);
+        let num_columns = 1usize << bytecode_sigma;
+
+        let bytecode_chunk_polys = build_committed_bytecode_chunk_polynomials::<PCS::Field>(
+            &bytecode.bytecode,
+            bytecode_chunk_count,
+        );
+        let _bytecode_guard = DoryGlobals::initialize_context(
+            committed_lanes(),
+            bytecode_T,
+            DoryContext::UntrustedAdvice,
+            None,
+        );
+        let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+        let (commitments, hints): (Vec<_>, Vec<_>) = bytecode_chunk_polys
+            .iter()
+            .map(|poly| PCS::commit(poly, generators))
+            .unzip();
+
+        (
+            Self {
+                commitments,
+                num_columns,
+                log_k_chunk: log_k_chunk as u8,
+                bytecode_chunk_count,
+                bytecode_len,
+                bytecode_T,
+            },
+            TrustedBytecodeHints { hints },
+        )
+    }
+}
 
 pub fn get_pc_for_cycle(bytecode: &BytecodePreprocessing, cycle: &Cycle) -> usize {
     if matches!(cycle, Cycle::NoOp) {

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -82,6 +82,7 @@ use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
 use crate::field::JoltField;
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
 use crate::poly::{
@@ -424,10 +425,10 @@ impl<F: JoltField> HammingWeightClaimReductionProver<F> {
     /// Initialize the prover by computing all G_i polynomials.
     /// Returns (prover, ram_hw_claims) where ram_hw_claims contains the computed H_i for RAM polynomials.
     #[tracing::instrument(skip_all, name = "HammingWeightClaimReductionProver::initialize")]
-    pub fn initialize(
+    pub fn initialize<PCS: CommitmentScheme>(
         params: HammingWeightClaimReductionParams<F>,
         trace: &[Cycle],
-        preprocessing: &JoltSharedPreprocessing,
+        preprocessing: &JoltSharedPreprocessing<PCS>,
         one_hot_params: &OneHotParams,
     ) -> Self {
         // Compute all G_i polynomials via streaming.

--- a/jolt-core/src/zkvm/config.rs
+++ b/jolt-core/src/zkvm/config.rs
@@ -1,5 +1,8 @@
 use allocative::Allocative;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
+use std::io::{Read, Write};
 
 use crate::field::JoltField;
 use crate::utils::math::Math;
@@ -17,6 +20,52 @@ pub fn get_instruction_sumcheck_phases(log_t: usize) -> usize {
         16
     } else {
         8
+    }
+}
+
+/// Controls how bytecode and program-image data are handled by the verifier.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative, Default)]
+pub enum ProgramMode {
+    /// Verifier has full bytecode and program image available.
+    #[default]
+    Full = 0,
+    /// Verifier uses commitments for bytecode/program-image openings in Stage 8.
+    Committed = 1,
+}
+
+impl CanonicalSerialize for ProgramMode {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        (*self as u8).serialize_with_mode(writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        (*self as u8).serialized_size(compress)
+    }
+}
+
+impl Valid for ProgramMode {
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for ProgramMode {
+    fn deserialize_with_mode<R: Read>(
+        reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let value = u8::deserialize_with_mode(reader, compress, validate)?;
+        match value {
+            0 => Ok(Self::Full),
+            1 => Ok(Self::Committed),
+            _ => Err(SerializationError::InvalidData),
+        }
     }
 }
 
@@ -90,15 +139,6 @@ impl ReadWriteConfig {
             ));
         }
         Ok(())
-    }
-
-    /// Returns true if all cycle variables are bound in phase 1.
-    ///
-    /// When this returns true, the advice opening points for `RamValCheck` and
-    /// `RamValCheck` are identical, so we only need one advice opening.
-    #[inline]
-    pub fn needs_single_advice_opening(&self, log_T: usize) -> bool {
-        self.ram_rw_phase1_num_rounds as usize == log_T
     }
 }
 

--- a/jolt-core/src/zkvm/program.rs
+++ b/jolt-core/src/zkvm/program.rs
@@ -3,11 +3,19 @@ use std::io::{Read, Write};
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
 };
+
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::errors::ProofVerifyError;
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::{
+    BytecodePreprocessing, PreprocessingError, TrustedBytecodeCommitments, TrustedBytecodeHints,
+};
+use crate::zkvm::ram::RAMPreprocessing;
+use common::jolt_device::MemoryLayout;
 use jolt_riscv::{JoltInstructionRow, RV64IMAC_JOLT};
 use tracer::instruction::Cycle;
-
-use crate::zkvm::bytecode::{BytecodePreprocessing, PreprocessingError};
-use crate::zkvm::ram::RAMPreprocessing;
 
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FullProgramPreprocessing {
@@ -28,7 +36,7 @@ impl Default for FullProgramPreprocessing {
 }
 
 impl FullProgramPreprocessing {
-    #[tracing::instrument(skip_all, name = "FullProgramPreprocessing::preprocess")]
+    #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
     pub fn preprocess(
         instructions: Vec<JoltInstructionRow>,
         memory_init: Vec<(u64, u8)>,
@@ -44,6 +52,31 @@ impl FullProgramPreprocessing {
         })
     }
 
+    pub fn bytecode_len(&self) -> usize {
+        self.bytecode.code_size
+    }
+
+    pub fn program_image_len_words(&self) -> usize {
+        self.ram.bytecode_words.len()
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words().next_power_of_two().max(2)
+    }
+
+    pub fn committed_program_image_num_words(&self, memory_layout: &MemoryLayout) -> usize {
+        self.meta().committed_program_image_num_words(memory_layout)
+    }
+
+    pub fn meta(&self) -> ProgramMetadata {
+        ProgramMetadata {
+            entry_address: self.bytecode.entry_address,
+            min_bytecode_address: self.ram.min_bytecode_address,
+            program_image_len_words: self.program_image_len_words(),
+            bytecode_len: self.bytecode_len(),
+        }
+    }
+
     #[inline(always)]
     pub fn get_pc(&self, cycle: &Cycle) -> usize {
         crate::zkvm::bytecode::get_pc_for_cycle(&self.bytecode, cycle)
@@ -56,11 +89,34 @@ impl FullProgramPreprocessing {
 }
 
 #[derive(Debug, Clone)]
-pub enum ProgramPreprocessing {
-    Full(FullProgramPreprocessing),
+pub struct CommittedProgramPreprocessing<PCS: CommitmentScheme> {
+    pub meta: ProgramMetadata,
+    pub bytecode_commitments: TrustedBytecodeCommitments<PCS>,
+    pub program_commitments: TrustedProgramCommitments<PCS>,
+    #[cfg(feature = "prover")]
+    pub prover_data: Option<CommittedProgramProverData<PCS>>,
 }
 
-impl CanonicalSerialize for ProgramPreprocessing {
+#[cfg(feature = "prover")]
+#[derive(Debug, Clone)]
+pub struct CommittedProgramProverData<PCS: CommitmentScheme> {
+    pub full: FullProgramPreprocessing,
+    pub bytecode_hints: TrustedBytecodeHints<PCS>,
+    pub program_hints: TrustedProgramHints<PCS>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ProgramPreprocessing<
+    PCS: CommitmentScheme = crate::poly::commitment::dory::DoryCommitmentScheme,
+> {
+    Full(FullProgramPreprocessing),
+    Committed(CommittedProgramPreprocessing<PCS>),
+}
+
+impl<PCS: CommitmentScheme> CanonicalSerialize for ProgramPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalSerialize,
+{
     fn serialize_with_mode<W: Write>(
         &self,
         mut writer: W,
@@ -71,6 +127,16 @@ impl CanonicalSerialize for ProgramPreprocessing {
                 0u8.serialize_with_mode(&mut writer, compress)?;
                 full.serialize_with_mode(&mut writer, compress)?;
             }
+            Self::Committed(committed) => {
+                1u8.serialize_with_mode(&mut writer, compress)?;
+                committed.meta.serialize_with_mode(&mut writer, compress)?;
+                committed
+                    .bytecode_commitments
+                    .serialize_with_mode(&mut writer, compress)?;
+                committed
+                    .program_commitments
+                    .serialize_with_mode(&mut writer, compress)?;
+            }
         }
         Ok(())
     }
@@ -78,19 +144,36 @@ impl CanonicalSerialize for ProgramPreprocessing {
     fn serialized_size(&self, compress: Compress) -> usize {
         1 + match self {
             Self::Full(full) => full.serialized_size(compress),
+            Self::Committed(committed) => {
+                committed.meta.serialized_size(compress)
+                    + committed.bytecode_commitments.serialized_size(compress)
+                    + committed.program_commitments.serialized_size(compress)
+            }
         }
     }
 }
 
-impl Valid for ProgramPreprocessing {
+impl<PCS: CommitmentScheme> Valid for ProgramPreprocessing<PCS>
+where
+    PCS::Commitment: Valid,
+{
     fn check(&self) -> Result<(), SerializationError> {
         match self {
             Self::Full(full) => full.check(),
+            Self::Committed(committed) => {
+                committed.meta.check()?;
+                committed.bytecode_commitments.check()?;
+                committed.program_commitments.check()?;
+                Ok(())
+            }
         }
     }
 }
 
-impl CanonicalDeserialize for ProgramPreprocessing {
+impl<PCS: CommitmentScheme> CanonicalDeserialize for ProgramPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalDeserialize,
+{
     fn deserialize_with_mode<R: Read>(
         mut reader: R,
         compress: Compress,
@@ -103,18 +186,33 @@ impl CanonicalDeserialize for ProgramPreprocessing {
                 compress,
                 validate,
             )?)),
+            1 => Ok(Self::Committed(CommittedProgramPreprocessing {
+                meta: ProgramMetadata::deserialize_with_mode(&mut reader, compress, validate)?,
+                bytecode_commitments: TrustedBytecodeCommitments::<PCS>::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?,
+                program_commitments: TrustedProgramCommitments::<PCS>::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?,
+                #[cfg(feature = "prover")]
+                prover_data: None,
+            })),
             _ => Err(SerializationError::InvalidData),
         }
     }
 }
 
-impl Default for ProgramPreprocessing {
+impl<PCS: CommitmentScheme> Default for ProgramPreprocessing<PCS> {
     fn default() -> Self {
         Self::Full(FullProgramPreprocessing::default())
     }
 }
 
-impl ProgramPreprocessing {
+impl<PCS: CommitmentScheme> ProgramPreprocessing<PCS> {
     #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
     pub fn preprocess(
         instructions: Vec<JoltInstructionRow>,
@@ -128,17 +226,261 @@ impl ProgramPreprocessing {
         )?))
     }
 
-    pub fn as_full(&self) -> &FullProgramPreprocessing {
+    pub fn commit(
+        self,
+        memory_layout: &MemoryLayout,
+        generators: &PCS::ProverSetup,
+        bytecode_chunk_count: usize,
+        max_log_k_chunk: usize,
+    ) -> Self {
+        let Self::Full(full) = self else {
+            panic!("cannot commit already-committed program preprocessing");
+        };
+        let meta = full.meta();
+        #[cfg(feature = "prover")]
+        let (bytecode_commitments, bytecode_hints) = TrustedBytecodeCommitments::derive(
+            &full.bytecode,
+            generators,
+            max_log_k_chunk,
+            bytecode_chunk_count,
+        );
+        #[cfg(not(feature = "prover"))]
+        let (bytecode_commitments, _bytecode_hints) = TrustedBytecodeCommitments::derive(
+            &full.bytecode,
+            generators,
+            max_log_k_chunk,
+            bytecode_chunk_count,
+        );
+        #[cfg(feature = "prover")]
+        let (program_commitments, program_hints) =
+            TrustedProgramCommitments::derive(&full, memory_layout, generators);
+        #[cfg(not(feature = "prover"))]
+        let (program_commitments, _program_hints) =
+            TrustedProgramCommitments::derive(&full, memory_layout, generators);
+        Self::Committed(CommittedProgramPreprocessing {
+            meta,
+            bytecode_commitments,
+            program_commitments,
+            #[cfg(feature = "prover")]
+            prover_data: Some(CommittedProgramProverData {
+                full,
+                bytecode_hints,
+                program_hints,
+            }),
+        })
+    }
+
+    pub fn full(&self) -> Option<&FullProgramPreprocessing> {
         match self {
-            Self::Full(full) => full,
+            Self::Full(full) => Some(full),
+            Self::Committed(_committed) => {
+                #[cfg(feature = "prover")]
+                {
+                    _committed.prover_data.as_ref().map(|data| &data.full)
+                }
+                #[cfg(not(feature = "prover"))]
+                {
+                    None
+                }
+            }
         }
     }
 
-    pub fn bytecode(&self) -> &BytecodePreprocessing {
-        &self.as_full().bytecode
+    pub fn as_full(&self) -> Result<&FullProgramPreprocessing, ProofVerifyError> {
+        self.full().ok_or_else(|| {
+            ProofVerifyError::BytecodeTypeMismatch(
+                "full program preprocessing unavailable in committed mode".to_string(),
+            )
+        })
     }
 
-    pub fn ram(&self) -> &RAMPreprocessing {
-        &self.as_full().ram
+    pub fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
     }
+
+    pub fn is_committed(&self) -> bool {
+        matches!(self, Self::Committed(_))
+    }
+
+    pub fn bytecode_commitments(&self) -> Option<&TrustedBytecodeCommitments<PCS>> {
+        match self {
+            Self::Committed(committed) => Some(&committed.bytecode_commitments),
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn bytecode_hints(&self) -> Option<&TrustedBytecodeHints<PCS>> {
+        match self {
+            #[cfg(feature = "prover")]
+            Self::Committed(committed) => committed
+                .prover_data
+                .as_ref()
+                .map(|data| &data.bytecode_hints),
+            #[cfg(not(feature = "prover"))]
+            Self::Committed(_) => None,
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn program_commitments(&self) -> Option<&TrustedProgramCommitments<PCS>> {
+        match self {
+            Self::Committed(committed) => Some(&committed.program_commitments),
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn program_hints(&self) -> Option<&TrustedProgramHints<PCS>> {
+        match self {
+            #[cfg(feature = "prover")]
+            Self::Committed(committed) => committed
+                .prover_data
+                .as_ref()
+                .map(|data| &data.program_hints),
+            #[cfg(not(feature = "prover"))]
+            Self::Committed(_) => None,
+            Self::Full(_) => None,
+        }
+    }
+
+    pub fn as_committed(&self) -> Result<&TrustedProgramCommitments<PCS>, ProofVerifyError> {
+        self.program_commitments().ok_or_else(|| {
+            ProofVerifyError::BytecodeTypeMismatch("expected Committed, got Full".to_string())
+        })
+    }
+
+    pub fn bytecode_len(&self) -> usize {
+        match self {
+            Self::Full(full) => full.bytecode_len(),
+            Self::Committed(committed) => committed.meta.bytecode_len,
+        }
+    }
+
+    pub fn program_image_len_words(&self) -> usize {
+        match self {
+            Self::Full(full) => full.program_image_len_words(),
+            Self::Committed(committed) => committed.meta.program_image_len_words,
+        }
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words().next_power_of_two().max(2)
+    }
+
+    pub fn committed_program_image_num_words(&self, memory_layout: &MemoryLayout) -> usize {
+        self.meta().committed_program_image_num_words(memory_layout)
+    }
+
+    pub fn meta(&self) -> ProgramMetadata {
+        match self {
+            Self::Full(full) => full.meta(),
+            Self::Committed(committed) => committed.meta.clone(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_pc(&self, cycle: &Cycle) -> usize {
+        self.as_full()
+            .expect("full program preprocessing required to compute PC")
+            .get_pc(cycle)
+    }
+
+    #[inline(always)]
+    pub fn entry_bytecode_index(&self) -> usize {
+        self.as_full()
+            .expect("full program preprocessing required to compute entry bytecode index")
+            .entry_bytecode_index()
+    }
+
+    pub fn to_verifier_program(&self) -> Self {
+        match self {
+            Self::Full(full) => Self::Full(full.clone()),
+            Self::Committed(committed) => Self::Committed(CommittedProgramPreprocessing {
+                meta: committed.meta.clone(),
+                bytecode_commitments: committed.bytecode_commitments.clone(),
+                program_commitments: committed.program_commitments.clone(),
+                #[cfg(feature = "prover")]
+                prover_data: None,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ProgramMetadata {
+    pub entry_address: u64,
+    pub min_bytecode_address: u64,
+    pub program_image_len_words: usize,
+    pub bytecode_len: usize,
+}
+
+impl ProgramMetadata {
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words.next_power_of_two().max(2)
+    }
+
+    pub fn committed_program_image_num_words(&self, _memory_layout: &MemoryLayout) -> usize {
+        self.program_image_len_words_padded()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct TrustedProgramCommitments<PCS: CommitmentScheme> {
+    pub program_image_commitment: PCS::Commitment,
+    pub program_image_num_columns: usize,
+    pub program_image_num_words: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct TrustedProgramHints<PCS: CommitmentScheme> {
+    pub program_image_hint: PCS::OpeningProofHint,
+}
+
+impl<PCS: CommitmentScheme> TrustedProgramCommitments<PCS> {
+    #[tracing::instrument(skip_all, name = "TrustedProgramCommitments::derive")]
+    pub fn derive(
+        program: &FullProgramPreprocessing,
+        memory_layout: &MemoryLayout,
+        generators: &PCS::ProverSetup,
+    ) -> (Self, TrustedProgramHints<PCS>) {
+        let program_image_num_words = program.committed_program_image_num_words(memory_layout);
+        let (program_image_sigma, _) =
+            crate::poly::commitment::dory::DoryGlobals::balanced_sigma_nu(
+                program_image_num_words.log_2(),
+            );
+        let program_image_num_columns = 1usize << program_image_sigma;
+        let program_image_poly = MultilinearPolynomial::from(build_program_image_words_padded(
+            program,
+            program_image_num_words,
+        ));
+        let _program_image_guard = DoryGlobals::initialize_context(
+            1,
+            program_image_num_words,
+            DoryContext::UntrustedAdvice,
+            None,
+        );
+        let (program_image_commitment, program_image_hint) = {
+            let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+            PCS::commit(&program_image_poly, generators)
+        };
+
+        (
+            Self {
+                program_image_commitment,
+                program_image_num_columns,
+                program_image_num_words,
+            },
+            TrustedProgramHints { program_image_hint },
+        )
+    }
+}
+
+pub(crate) fn build_program_image_words_padded(
+    program: &FullProgramPreprocessing,
+    padded_len: usize,
+) -> Vec<u64> {
+    debug_assert!(padded_len.is_power_of_two());
+    debug_assert!(padded_len >= program.ram.bytecode_words.len().max(1));
+    let mut coeffs = vec![0u64; padded_len];
+    coeffs[..program.ram.bytecode_words.len()].copy_from_slice(&program.ram.bytecode_words);
+    coeffs
 }

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -298,13 +298,25 @@ impl CanonicalSerialize for CommittedPolynomial {
             }
             Self::TrustedAdvice => 5u8.serialize_with_mode(writer, compress),
             Self::UntrustedAdvice => 6u8.serialize_with_mode(writer, compress),
+            Self::BytecodeChunk(i) => {
+                7u8.serialize_with_mode(&mut writer, compress)?;
+                (u8::try_from(*i).unwrap()).serialize_with_mode(writer, compress)
+            }
+            Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
         }
     }
 
     fn serialized_size(&self, _compress: Compress) -> usize {
         match self {
-            Self::RdInc | Self::RamInc | Self::TrustedAdvice | Self::UntrustedAdvice => 1,
-            Self::InstructionRa(_) | Self::BytecodeRa(_) | Self::RamRa(_) => 2,
+            Self::RdInc
+            | Self::RamInc
+            | Self::TrustedAdvice
+            | Self::UntrustedAdvice
+            | Self::ProgramImageInit => 1,
+            Self::InstructionRa(_)
+            | Self::BytecodeRa(_)
+            | Self::RamRa(_)
+            | Self::BytecodeChunk(_) => 2,
         }
     }
 }
@@ -339,6 +351,11 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 }
                 5 => Self::TrustedAdvice,
                 6 => Self::UntrustedAdvice,
+                7 => {
+                    let i = u8::deserialize_with_mode(reader, compress, validate)?;
+                    Self::BytecodeChunk(i as usize)
+                }
+                8 => Self::ProgramImageInit,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2174,7 +2174,7 @@ pub struct JoltProverPreprocessing<
     PCS: CommitmentScheme<Field = F>,
 > {
     pub generators: PCS::ProverSetup,
-    pub shared: JoltSharedPreprocessing,
+    pub shared: JoltSharedPreprocessing<PCS>,
     _curve: std::marker::PhantomData<C>,
 }
 
@@ -2184,23 +2184,24 @@ where
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
 {
-    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::gen")]
-    pub fn new(shared: JoltSharedPreprocessing) -> Self {
-        use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
-        let max_T: usize = shared.max_padded_trace_length.next_power_of_two();
-        let max_log_T = max_T.log_2();
-        let max_log_k_chunk = if max_log_T < ONEHOT_CHUNK_THRESHOLD_LOG_T {
-            4
-        } else {
-            8
-        };
-        let generators = PCS::setup_prover(max_log_k_chunk + max_log_T);
-
-        JoltProverPreprocessing {
+    pub fn new_with_generators(
+        shared: JoltSharedPreprocessing<PCS>,
+        generators: PCS::ProverSetup,
+    ) -> Self {
+        Self {
             generators,
             shared,
             _curve: std::marker::PhantomData,
         }
+    }
+
+    #[tracing::instrument(skip_all, name = "JoltProverPreprocessing::new")]
+    pub fn new(shared: JoltSharedPreprocessing<PCS>) -> Self {
+        let committed_mode = shared.program.is_committed();
+        let (max_total_vars, _) = shared.compute_max_total_vars(committed_mode);
+        let generators = PCS::setup_prover(max_total_vars);
+
+        Self::new_with_generators(shared, generators)
     }
 
     #[cfg(feature = "zk")]
@@ -2350,6 +2351,60 @@ mod tests {
             memory_layout,
             max_trace_len,
         ))
+    }
+
+    #[test]
+    fn committed_bytecode_chunk_count_validation_rejects_invalid_counts() {
+        use crate::zkvm::bytecode::chunks::validate_committed_bytecode_chunk_count;
+
+        assert!(std::panic::catch_unwind(|| validate_committed_bytecode_chunk_count(0)).is_err());
+        assert!(std::panic::catch_unwind(|| validate_committed_bytecode_chunk_count(3)).is_err());
+        assert!(std::panic::catch_unwind(|| validate_committed_bytecode_chunk_count(512)).is_err());
+        validate_committed_bytecode_chunk_count(1);
+        validate_committed_bytecode_chunk_count(256);
+    }
+
+    #[test]
+    #[serial]
+    fn committed_preprocessing_serialization_roundtrip_strips_prover_data() {
+        use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+        DoryGlobals::reset();
+        let mut program = host::Program::new("fibonacci-guest");
+        let inputs = postcard::to_stdvec(&5u32).unwrap();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
+        let program_data =
+            ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap();
+
+        let shared = JoltSharedPreprocessing::<DoryCommitmentScheme>::new_committed(
+            program_data,
+            io_device.memory_layout.clone(),
+            1 << 16,
+            1,
+        );
+        assert!(shared.program.is_committed());
+        assert!(
+            shared.program.full().is_some(),
+            "prover-side committed preprocessing should retain full program data"
+        );
+
+        let mut bytes = Vec::new();
+        shared.serialize_compressed(&mut bytes).unwrap();
+        let decoded =
+            JoltSharedPreprocessing::<DoryCommitmentScheme>::deserialize_compressed(&*bytes)
+                .unwrap();
+
+        assert!(decoded.program.is_committed());
+        assert_eq!(
+            decoded.program_meta.bytecode_len,
+            shared.program_meta.bytecode_len
+        );
+        assert_eq!(decoded.bytecode_chunk_count, shared.bytecode_chunk_count);
+        assert!(
+            decoded.program.full().is_none(),
+            "serialized verifier preprocessing must not retain prover-only full program data"
+        );
     }
 
     #[test]
@@ -3402,7 +3457,9 @@ mod tests {
         let mut tampered_shared = shared.clone();
         let mut tampered_bytecode = tampered_shared.bytecode().clone();
         tampered_bytecode.entry_address = e_entry.wrapping_add(4);
-        let ProgramPreprocessing::Full(full) = &mut tampered_shared.program;
+        let ProgramPreprocessing::Full(full) = &mut tampered_shared.program else {
+            panic!("test_shared_preprocessing must produce full preprocessing")
+        };
         full.bytecode = tampered_bytecode;
         let tampered_entry_index =
             crate::zkvm::bytecode::entry_bytecode_index(tampered_shared.bytecode());

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -27,10 +27,14 @@ use crate::subprotocols::sumcheck::SumcheckInstanceProof;
 use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 #[cfg(feature = "zk")]
 use crate::subprotocols::univariate_skip::UniSkipFirstRoundProofVariant;
+use crate::zkvm::bytecode::chunks::{
+    committed_lanes, validate_committed_bytecode_chunk_count,
+    DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT,
+};
 use crate::zkvm::claim_reductions::advice::ReductionPhase;
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
 use crate::zkvm::config::OneHotParams;
-use crate::zkvm::program::ProgramPreprocessing;
+use crate::zkvm::program::{ProgramMetadata, ProgramPreprocessing};
 #[cfg(feature = "prover")]
 use crate::zkvm::prover::JoltProverPreprocessing;
 #[cfg(feature = "zk")]
@@ -1733,13 +1737,20 @@ impl<
 }
 
 #[derive(Debug, Clone)]
-pub struct JoltSharedPreprocessing {
-    pub program: ProgramPreprocessing,
+pub struct JoltSharedPreprocessing<
+    PCS: CommitmentScheme = crate::poly::commitment::dory::DoryCommitmentScheme,
+> {
+    pub program: ProgramPreprocessing<PCS>,
+    pub program_meta: ProgramMetadata,
     pub memory_layout: MemoryLayout,
     pub max_padded_trace_length: usize,
+    pub bytecode_chunk_count: usize,
 }
 
-impl JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalSerialize,
+{
     /// Blake2b-256 digest of the serialized preprocessing, used to bind
     /// the program identity to the Fiat-Shamir transcript.
     pub fn digest(&self) -> [u8; 32] {
@@ -1752,69 +1763,127 @@ impl JoltSharedPreprocessing {
     }
 }
 
-impl CanonicalSerialize for JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> CanonicalSerialize for JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalSerialize,
+{
     fn serialize_with_mode<W: std::io::Write>(
         &self,
         mut writer: W,
         compress: ark_serialize::Compress,
     ) -> Result<(), ark_serialize::SerializationError> {
         self.program.serialize_with_mode(&mut writer, compress)?;
+        self.program_meta
+            .serialize_with_mode(&mut writer, compress)?;
         self.memory_layout
             .serialize_with_mode(&mut writer, compress)?;
         self.max_padded_trace_length
+            .serialize_with_mode(&mut writer, compress)?;
+        self.bytecode_chunk_count
             .serialize_with_mode(&mut writer, compress)?;
         Ok(())
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
         self.program.serialized_size(compress)
+            + self.program_meta.serialized_size(compress)
             + self.memory_layout.serialized_size(compress)
             + self.max_padded_trace_length.serialized_size(compress)
+            + self.bytecode_chunk_count.serialized_size(compress)
     }
 }
 
-impl CanonicalDeserialize for JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> CanonicalDeserialize for JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: CanonicalDeserialize,
+{
     fn deserialize_with_mode<R: std::io::Read>(
         mut reader: R,
         compress: ark_serialize::Compress,
         validate: ark_serialize::Validate,
     ) -> Result<Self, ark_serialize::SerializationError> {
         let program = ProgramPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
+        let program_meta = ProgramMetadata::deserialize_with_mode(&mut reader, compress, validate)?;
         let memory_layout = MemoryLayout::deserialize_with_mode(&mut reader, compress, validate)?;
         let max_padded_trace_length =
             usize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let bytecode_chunk_count = usize::deserialize_with_mode(&mut reader, compress, validate)?;
         Ok(Self {
             program,
+            program_meta,
             memory_layout,
             max_padded_trace_length,
+            bytecode_chunk_count,
         })
     }
 }
 
-impl ark_serialize::Valid for JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> ark_serialize::Valid for JoltSharedPreprocessing<PCS>
+where
+    PCS::Commitment: ark_serialize::Valid,
+{
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
         self.program.check()?;
+        self.program_meta.check()?;
         self.memory_layout.check()?;
         Ok(())
     }
 }
 
-impl JoltSharedPreprocessing {
+impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
     #[tracing::instrument(skip_all, name = "JoltSharedPreprocessing::new")]
     pub fn new(
-        program: ProgramPreprocessing,
+        program: ProgramPreprocessing<PCS>,
         memory_layout: MemoryLayout,
         max_padded_trace_length: usize,
-    ) -> JoltSharedPreprocessing {
+    ) -> JoltSharedPreprocessing<PCS> {
         Self {
+            program_meta: program.meta(),
             program,
             memory_layout,
             max_padded_trace_length,
+            bytecode_chunk_count: DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT,
         }
     }
 
+    #[tracing::instrument(skip_all, name = "JoltSharedPreprocessing::new_committed")]
+    pub fn new_committed(
+        program: ProgramPreprocessing<PCS>,
+        memory_layout: MemoryLayout,
+        max_padded_trace_length: usize,
+        bytecode_chunk_count: usize,
+    ) -> JoltSharedPreprocessing<PCS> {
+        validate_committed_bytecode_chunk_count(bytecode_chunk_count);
+        assert!(
+            program.bytecode_len().is_multiple_of(bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode size ({})",
+            program.bytecode_len()
+        );
+        let mut shared = Self {
+            program_meta: program.meta(),
+            program,
+            memory_layout,
+            max_padded_trace_length,
+            bytecode_chunk_count,
+        };
+        let (max_total_vars, max_log_k_chunk) = shared.compute_max_total_vars(true);
+        let generators = PCS::setup_prover(max_total_vars);
+        shared.program = shared.program.commit(
+            &shared.memory_layout,
+            &generators,
+            shared.bytecode_chunk_count,
+            max_log_k_chunk,
+        );
+        shared.program_meta = shared.program.meta();
+        shared
+    }
+
     pub fn bytecode(&self) -> &crate::zkvm::bytecode::BytecodePreprocessing {
-        self.program.bytecode()
+        &self
+            .program
+            .as_full()
+            .expect("full program preprocessing required")
+            .bytecode
     }
 
     pub fn bytecode_arc(&self) -> Arc<crate::zkvm::bytecode::BytecodePreprocessing> {
@@ -1822,7 +1891,84 @@ impl JoltSharedPreprocessing {
     }
 
     pub fn ram(&self) -> &RAMPreprocessing {
-        self.program.ram()
+        &self
+            .program
+            .as_full()
+            .expect("full program preprocessing required")
+            .ram
+    }
+
+    pub fn is_committed_mode(&self) -> bool {
+        self.program.is_committed()
+    }
+
+    pub fn bytecode_size(&self) -> usize {
+        self.program_meta.bytecode_len
+    }
+
+    #[inline]
+    pub fn committed_program_image_num_words(&self) -> usize {
+        self.program_meta
+            .committed_program_image_num_words(&self.memory_layout)
+    }
+
+    pub(crate) fn precommitted_candidate_total_vars(
+        &self,
+        include_committed: bool,
+        include_trusted_advice: bool,
+        include_untrusted_advice: bool,
+    ) -> Vec<usize> {
+        let mut candidates = Vec::with_capacity(
+            include_committed as usize * 2
+                + include_trusted_advice as usize
+                + include_untrusted_advice as usize,
+        );
+
+        if include_trusted_advice {
+            let (trusted_sigma, trusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.memory_layout.max_trusted_advice_size as usize,
+            );
+            candidates.push(trusted_sigma + trusted_nu);
+        }
+
+        if include_untrusted_advice {
+            let (untrusted_sigma, untrusted_nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.memory_layout.max_untrusted_advice_size as usize,
+            );
+            candidates.push(untrusted_sigma + untrusted_nu);
+        }
+
+        if include_committed {
+            let chunk_cycle_log_t = (self.bytecode_size() / self.bytecode_chunk_count)
+                .next_power_of_two()
+                .log_2();
+            candidates.push(committed_lanes().log_2() + chunk_cycle_log_t);
+            candidates.push(self.committed_program_image_num_words().log_2());
+        }
+
+        candidates
+    }
+
+    pub(crate) fn compute_max_total_vars(&self, include_committed: bool) -> (usize, usize) {
+        use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
+
+        let max_T = self.max_padded_trace_length.next_power_of_two();
+        let max_log_T = max_T.log_2();
+        let max_log_k_chunk = if max_log_T < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+            4
+        } else {
+            8
+        };
+        let main_total_vars = max_log_k_chunk + max_log_T;
+        let precommitted_total_vars = self
+            .precommitted_candidate_total_vars(include_committed, true, true)
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+        (
+            main_total_vars.max(precommitted_total_vars),
+            max_log_k_chunk,
+        )
     }
 }
 
@@ -1851,7 +1997,7 @@ where
     PCS: CommitmentScheme<Field = F>,
 {
     pub generators: PCS::VerifierSetup,
-    pub shared: JoltSharedPreprocessing,
+    pub shared: JoltSharedPreprocessing<PCS>,
     pub blindfold_setup: Option<BlindfoldSetup<C>>,
 }
 
@@ -1892,10 +2038,11 @@ impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>>
 {
     #[tracing::instrument(skip_all, name = "JoltVerifierPreprocessing::new")]
     pub fn new(
-        shared: JoltSharedPreprocessing,
+        mut shared: JoltSharedPreprocessing<PCS>,
         generators: PCS::VerifierSetup,
         blindfold_setup: Option<BlindfoldSetup<C>>,
     ) -> Self {
+        shared.program = shared.program.to_verifier_program();
         Self {
             generators,
             shared,

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -31,6 +31,8 @@ pub enum CommittedPolynomial {
     InstructionRa(usize),
     /// One-hot ra polynomial for the bytecode instance of Shout
     BytecodeRa(usize),
+    /// Dense committed bytecode chunk polynomial for committed program mode.
+    BytecodeChunk(usize),
     /// One-hot ra/wa polynomial for the RAM instance of Twist
     /// Note that for RAM, ra and wa are the same polynomial because
     /// there is at most one load or store per cycle.
@@ -41,6 +43,8 @@ pub enum CommittedPolynomial {
     /// Untrusted advice polynomial - committed during proving, commitment in proof.
     /// Length cannot exceed max_trace_length.
     UntrustedAdvice,
+    /// Program image (initial RAM image) polynomial for committed program mode.
+    ProgramImageInit,
 }
 
 /// Returns a list of symbols representing all committed polynomials.
@@ -63,7 +67,7 @@ impl CommittedPolynomial {
     pub fn stream_witness_and_commit_rows<F, PCS>(
         &self,
         setup: &PCS::ProverSetup,
-        preprocessing: &JoltSharedPreprocessing,
+        preprocessing: &JoltSharedPreprocessing<PCS>,
         row_cycles: &[tracer::instruction::Cycle],
         one_hot_params: &OneHotParams,
     ) -> <PCS as StreamingCommitmentScheme>::ChunkState
@@ -130,8 +134,11 @@ impl CommittedPolynomial {
                     .collect();
                 PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
             }
-            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                panic!("Advice polynomials should not use streaming witness generation")
+            CommittedPolynomial::TrustedAdvice
+            | CommittedPolynomial::UntrustedAdvice
+            | CommittedPolynomial::BytecodeChunk(_)
+            | CommittedPolynomial::ProgramImageInit => {
+                panic!("Precommitted polynomials should not use streaming witness generation")
             }
         }
     }
@@ -216,8 +223,11 @@ impl CommittedPolynomial {
                     one_hot_params.k_chunk,
                 ))
             }
-            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                panic!("Advice polynomials should not use generate_witness")
+            CommittedPolynomial::TrustedAdvice
+            | CommittedPolynomial::UntrustedAdvice
+            | CommittedPolynomial::BytecodeChunk(_)
+            | CommittedPolynomial::ProgramImageInit => {
+                panic!("Precommitted polynomials should not use generate_witness")
             }
         }
     }

--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -159,14 +159,29 @@ fn main() {
         real_preprocessing.shared.memory_layout
     );
 
+    let symbolic_program = match &real_preprocessing.shared.program {
+        jolt_core::zkvm::program::ProgramPreprocessing::Full(full) => {
+            jolt_core::zkvm::program::ProgramPreprocessing::Full(full.clone())
+        }
+        jolt_core::zkvm::program::ProgramPreprocessing::Committed(_) => {
+            panic!("committed preprocessing is not supported by the transpiler yet")
+        }
+    };
+    let symbolic_shared = jolt_core::zkvm::verifier::JoltSharedPreprocessing::<AstCommitmentScheme> {
+        program_meta: symbolic_program.meta(),
+        program: symbolic_program,
+        memory_layout: real_preprocessing.shared.memory_layout.clone(),
+        max_padded_trace_length: real_preprocessing.shared.max_padded_trace_length,
+        bytecode_chunk_count: real_preprocessing.shared.bytecode_chunk_count,
+    };
+
     // Convert to symbolic preprocessing: replace Dory generators with AstVerifierSetup stub.
-    // The `shared` field (memory layout, bytecode info) is reused as-is.
     // AstCommitmentScheme satisfies the CommitmentScheme trait but performs no cryptographic
     // operations. PCS verification is skipped in stages 1-6.
     let symbolic_preprocessing: JoltVerifierPreprocessing<MleAst, AstCurve, AstCommitmentScheme> =
         JoltVerifierPreprocessing {
             generators: transpiler::symbolic_traits::ast_commitment_scheme::AstVerifierSetup,
-            shared: real_preprocessing.shared.clone(),
+            shared: symbolic_shared,
             blindfold_setup: None,
         };
 


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.

Stack position: `02`
Base branch: `stack/01-program-preprocessing-refactor`
Source implementation reference: `LayerZero-Research/amir/bytecode-commitment-merged@a351d5078b83577db8f3264fa53dfaddcf5ed687`

Owned paths:
```
jolt-core/src/zkvm/program.rs jolt-core/src/zkvm/config.rs jolt-core/src/zkvm/bytecode/chunks.rs jolt-core/src/zkvm/bytecode/mod.rs jolt-core/src/zkvm/proof_serialization.rs jolt-core/src/zkvm/witness.rs jolt-core/src/utils/errors.rs
```

See `specs/1344-committed-bytecode-program-image.md` for the slice checklist and verification expectations.
