### PR TITLE
refactor: generalize precommitted Dory geometry

### DIFF
--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -1,6 +1,6 @@
 //! Dory polynomial commitment scheme implementation
 
-use super::dory_globals::{DoryGlobals, DoryLayout};
+use super::dory_globals::DoryGlobals;
 use super::jolt_dory_routines::{JoltG1Routines, JoltG2Routines};
 use super::wrappers::{
     ark_to_jolt, jolt_to_ark, ArkDoryProof, ArkFr, ArkG1, ArkGT, ArkworksProverSetup,
@@ -42,6 +42,17 @@ impl DoryOpeningProofHint {
             row_commitments,
             commit_blind,
         }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            row_commitments: Vec::new(),
+            commit_blind: <ArkFr as DoryField>::zero(),
+        }
+    }
+
+    pub fn rows(&self) -> &[ArkG1] {
+        &self.row_commitments
     }
 
     fn into_parts(self) -> (Vec<ArkG1>, ArkFr) {
@@ -194,8 +205,7 @@ impl CommitmentScheme for DoryCommitmentScheme {
         let sigma = num_cols.log_2();
         let nu = num_rows.log_2();
 
-        let reordered_point = reorder_opening_point_for_layout::<ark_bn254::Fr>(opening_point);
-        let ark_point: Vec<ArkFr> = reordered_point
+        let ark_point: Vec<ArkFr> = opening_point
             .iter()
             .rev()
             .map(|p| {
@@ -237,10 +247,8 @@ impl CommitmentScheme for DoryCommitmentScheme {
     ) -> Result<(), ProofVerifyError> {
         let _span = trace_span!("DoryCommitmentScheme::verify").entered();
 
-        let reordered_point = reorder_opening_point_for_layout::<ark_bn254::Fr>(opening_point);
-
         // Dory uses the opposite endian-ness as Jolt
-        let ark_point: Vec<ArkFr> = reordered_point
+        let ark_point: Vec<ArkFr> = opening_point
             .iter()
             .rev()
             .map(|p| {
@@ -484,26 +492,5 @@ where
             .collect();
         let h1 = C::G1::from(setup.0.h1);
         Some((g1s, h1))
-    }
-}
-
-/// Reorders opening_point for AddressMajor layout.
-///
-/// For AddressMajor layout, reorders opening_point from [r_address, r_cycle] to [r_cycle, r_address].
-/// This ensures that after Dory's reversal and splitting:
-/// - Column (right) vector gets address variables (matching AddressMajor column indexing)
-/// - Row (left) vector gets cycle variables (matching AddressMajor row indexing)
-///
-/// For CycleMajor layout, returns the point unchanged.
-fn reorder_opening_point_for_layout<F: JoltField>(
-    opening_point: &[F::Challenge],
-) -> Vec<F::Challenge> {
-    if DoryGlobals::get_layout() == DoryLayout::AddressMajor {
-        let log_T = DoryGlobals::get_T().log_2();
-        let log_K = opening_point.len().saturating_sub(log_T);
-        let (r_address, r_cycle) = opening_point.split_at(log_K);
-        [r_cycle, r_address].concat()
-    } else {
-        opening_point.to_vec()
     }
 }

--- a/jolt-core/src/poly/commitment/dory/dory_globals.rs
+++ b/jolt-core/src/poly/commitment/dory/dory_globals.rs
@@ -4,7 +4,7 @@ use crate::utils::math::Math;
 use allocative::Allocative;
 use dory::backends::arkworks::{init_cache, ArkG1, ArkG2};
 use std::sync::{
-    atomic::{AtomicU8, Ordering},
+    atomic::{AtomicU8, AtomicUsize, Ordering},
     RwLock,
 };
 #[cfg(test)]
@@ -143,6 +143,7 @@ impl From<DoryLayout> for u8 {
 
 // Main polynomial globals
 static GLOBAL_T: RwLock<Option<usize>> = RwLock::new(None);
+static MAIN_K_CHUNK: RwLock<Option<usize>> = RwLock::new(None);
 static MAX_NUM_ROWS: RwLock<Option<usize>> = RwLock::new(None);
 static NUM_COLUMNS: RwLock<Option<usize>> = RwLock::new(None);
 
@@ -161,6 +162,8 @@ static CURRENT_CONTEXT: AtomicU8 = AtomicU8::new(0);
 
 // Layout tracking: 0=CycleMajor, 1=AddressMajor
 static CURRENT_LAYOUT: AtomicU8 = AtomicU8::new(0);
+// Largest Main log-embedding needed for precommitted/embed calculations.
+static MAIN_LOG_EMBEDDING: AtomicUsize = AtomicUsize::new(0);
 
 /// Dory commitment context - determines which set of global parameters to use
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,6 +259,22 @@ impl DoryGlobals {
         log_t.saturating_sub(sigma_main)
     }
 
+    #[inline]
+    pub fn get_main_log_embedding() -> usize {
+        let stored = MAIN_LOG_EMBEDDING.load(Ordering::SeqCst);
+        if stored > 0 {
+            stored
+        } else {
+            let main_cols = Self::configured_main_num_columns();
+            let main_rows = *MAX_NUM_ROWS
+                .read()
+                .unwrap()
+                .as_ref()
+                .expect("main max_num_rows not initialized");
+            main_cols.log_2() + main_rows.log_2()
+        }
+    }
+
     /// Get the current Dory context
     pub fn current_context() -> DoryContext {
         CURRENT_CONTEXT.load(Ordering::SeqCst).into()
@@ -288,11 +307,84 @@ impl DoryGlobals {
         (Self::get_max_num_rows(), Self::get_num_columns())
     }
 
+    #[inline]
+    pub(crate) fn main_k() -> usize {
+        *MAIN_K_CHUNK
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("main k not initialized")
+    }
+
+    #[inline]
+    pub(crate) fn main_t() -> usize {
+        *GLOBAL_T
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("main t not initialized")
+    }
+
+    #[inline]
+    pub(crate) fn configured_main_num_columns() -> usize {
+        *NUM_COLUMNS
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("main num_columns not initialized")
+    }
+
+    #[inline]
+    fn main_embedding_extra_vars() -> usize {
+        let main_total_vars = Self::main_k().log_2() + Self::get_T().log_2();
+        Self::get_main_log_embedding().saturating_sub(main_total_vars)
+    }
+
+    /// Column stride for one-hot embeddings in the current layout/context.
+    pub fn one_hot_stride() -> usize {
+        if Self::current_context() != DoryContext::Main
+            || Self::get_layout() != DoryLayout::AddressMajor
+        {
+            return 1;
+        }
+        1usize << Self::main_embedding_extra_vars()
+    }
+
+    /// Column stride for dense trace-domain embeddings in the current layout/context.
+    pub fn dense_stride() -> usize {
+        if Self::current_context() != DoryContext::Main
+            || Self::get_layout() != DoryLayout::AddressMajor
+        {
+            return 1;
+        }
+        let dense_stride_log = Self::main_embedding_extra_vars() + Self::main_k().log_2();
+        1usize << dense_stride_log
+    }
+
+    /// Returns the embedded cycle-domain size for the current Dory matrix.
+    pub fn get_embedded_t() -> usize {
+        let context = Self::current_context();
+        if context != DoryContext::Main {
+            return Self::get_T();
+        }
+
+        let k = Self::main_k();
+        let num_rows = Self::get_max_num_rows();
+        let num_cols = Self::get_num_columns();
+        let total = num_rows * num_cols;
+        debug_assert_eq!(
+            total % k,
+            0,
+            "Invalid Main DoryGlobals: num_rows*num_cols must be divisible by K"
+        );
+        total / k
+    }
+
     /// Returns the "K" used to initialize the *main* Dory matrix for OneHot polynomials.
-    ///
-    /// This is derived from the identity:
-    /// `K * T == num_rows * num_cols`  (all values are powers of two in our usage).
     pub fn k_from_matrix_shape() -> usize {
+        if Self::current_context() == DoryContext::Main {
+            return Self::main_k();
+        }
         let (num_rows, num_cols) = Self::matrix_shape();
         let t = Self::get_T();
         debug_assert_eq!(
@@ -301,22 +393,6 @@ impl DoryGlobals {
             "Invalid DoryGlobals: num_rows*num_cols must be divisible by T"
         );
         (num_rows * num_cols) / t
-    }
-
-    /// For `AddressMajor`, each Dory matrix row corresponds to this many cycles.
-    ///
-    /// Equivalent to `T / num_rows` and to `num_cols / K`.
-    pub fn address_major_cycles_per_row() -> usize {
-        let (num_rows, num_cols) = Self::matrix_shape();
-        let k = Self::k_from_matrix_shape();
-        debug_assert!(k > 0);
-        debug_assert_eq!(num_cols % k, 0, "Expected num_cols to be divisible by K");
-        debug_assert_eq!(
-            Self::get_T() % num_rows,
-            0,
-            "Expected T to be divisible by num_rows"
-        );
-        num_cols / k
     }
 
     fn set_max_num_rows_for_context(max_num_rows: usize, context: DoryContext) {
@@ -363,6 +439,10 @@ impl DoryGlobals {
                 *UNTRUSTED_ADVICE_NUM_COLUMNS.write().unwrap() = Some(num_columns);
             }
         }
+    }
+
+    fn set_main_k(k: usize) {
+        *MAIN_K_CHUNK.write().unwrap() = Some(k);
     }
 
     pub fn get_num_columns() -> usize {
@@ -430,6 +510,20 @@ impl DoryGlobals {
         (num_columns, num_rows, T)
     }
 
+    fn initialize_context_common(
+        K: usize,
+        embedded_t: usize,
+        stored_t: usize,
+        context: DoryContext,
+    ) -> Option<()> {
+        let (num_columns, num_rows, _) = Self::calculate_dimensions(K, embedded_t);
+        Self::set_num_columns_for_context(num_columns, context);
+        Self::set_T_for_context(stored_t, context);
+        Self::set_max_num_rows_for_context(num_rows, context);
+
+        Some(())
+    }
+
     /// Initialize the globals for a specific Dory context
     ///
     /// # Arguments
@@ -451,20 +545,30 @@ impl DoryGlobals {
     ) -> Option<()> {
         #[cfg(test)]
         Self::configure_test_cache_root();
-
-        let (num_columns, num_rows, t) = Self::calculate_dimensions(K, T);
-        Self::set_num_columns_for_context(num_columns, context);
-        Self::set_T_for_context(t, context);
-        Self::set_max_num_rows_for_context(num_rows, context);
-
-        // For Main context, set layout (if provided) and ensure subsequent uses of `get_*` read from it
         if context == DoryContext::Main {
-            if let Some(l) = layout {
-                CURRENT_LAYOUT.store(l as u8, Ordering::SeqCst);
-            }
-            CURRENT_CONTEXT.store(DoryContext::Main as u8, Ordering::SeqCst);
+            return Self::initialize_main_with_log_embedding(K, T, K.log_2() + T.log_2(), layout);
         }
+        Self::initialize_context_common(K, T, T, context)?;
+        Some(())
+    }
 
+    /// Initialize Main context with execution `T` and explicit `main_log_embedding` for
+    /// global precommitted geometry.
+    pub fn initialize_main_with_log_embedding(
+        K: usize,
+        T: usize,
+        matrix_total_vars: usize,
+        layout: Option<DoryLayout>,
+    ) -> Option<()> {
+        let log_k = K.log_2();
+        let embedded_t = 1usize << matrix_total_vars.saturating_sub(log_k);
+        Self::initialize_context_common(K, embedded_t, T, DoryContext::Main)?;
+        Self::set_main_k(K);
+        if let Some(l) = layout {
+            CURRENT_LAYOUT.store(l as u8, Ordering::SeqCst);
+        }
+        CURRENT_CONTEXT.store(DoryContext::Main as u8, Ordering::SeqCst);
+        MAIN_LOG_EMBEDDING.store(matrix_total_vars, Ordering::SeqCst);
         Some(())
     }
 
@@ -475,6 +579,7 @@ impl DoryGlobals {
 
         // Reset main globals
         *GLOBAL_T.write().unwrap() = None;
+        *MAIN_K_CHUNK.write().unwrap() = None;
         *MAX_NUM_ROWS.write().unwrap() = None;
         *NUM_COLUMNS.write().unwrap() = None;
 
@@ -492,6 +597,7 @@ impl DoryGlobals {
         *UNTRUSTED_ADVICE_NUM_COLUMNS.write().unwrap() = None;
 
         CURRENT_CONTEXT.store(0, Ordering::SeqCst);
+        MAIN_LOG_EMBEDDING.store(0, Ordering::SeqCst);
     }
 
     /// Initialize the prepared point cache for faster pairing operations

--- a/jolt-core/src/poly/commitment/dory/mod.rs
+++ b/jolt-core/src/poly/commitment/dory/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 
 #[cfg(feature = "zk")]
 pub use commitment_scheme::bind_opening_inputs_zk;
-pub use commitment_scheme::{bind_opening_inputs, DoryCommitmentScheme};
+pub use commitment_scheme::{bind_opening_inputs, DoryCommitmentScheme, DoryOpeningProofHint};
 pub use dory_globals::{DoryContext, DoryGlobals, DoryLayout};
 pub use jolt_dory_routines::{JoltG1Routines, JoltG2Routines};
 pub use wrappers::{

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -8,6 +8,7 @@ mod tests {
     use crate::poly::dense_mlpoly::DensePolynomial;
     use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
     use crate::transcripts::{Blake2bTranscript, Transcript};
+    use crate::utils::math::Math;
     use ark_ff::biginteger::S128;
     use ark_std::rand::{thread_rng, Rng};
     use ark_std::{UniformRand, Zero};
@@ -906,19 +907,26 @@ mod tests {
         let num_vars = one_hot_poly.get_num_vars();
         let poly = MultilinearPolynomial::OneHot(one_hot_poly);
 
-        let opening_point: Vec<<Fr as JoltField>::Challenge> = (0..num_vars)
+        // AddressMajor Dory opening points are consumed as [cycle vars || address vars],
+        // while OneHotPolynomial::evaluate expects [address vars || cycle vars].
+        let log_t = T.log_2();
+        let log_k = num_vars - log_t;
+        let r_cycle: Vec<<Fr as JoltField>::Challenge> = (0..log_t)
             .map(|_| <Fr as JoltField>::Challenge::random(&mut rng))
             .collect();
+        let r_address: Vec<<Fr as JoltField>::Challenge> = (0..log_k)
+            .map(|_| <Fr as JoltField>::Challenge::random(&mut rng))
+            .collect();
+        let opening_point = [r_cycle.clone(), r_address.clone()].concat();
+        let eval_point = [r_address, r_cycle].concat();
 
         let prover_setup = DoryCommitmentScheme::setup_prover(num_vars);
         let verifier_setup = DoryCommitmentScheme::setup_verifier(&prover_setup);
 
         let (commitment, row_commitments) = DoryCommitmentScheme::commit(&poly, &prover_setup);
 
-        let evaluation = <MultilinearPolynomial<Fr> as PolynomialEvaluation<Fr>>::evaluate(
-            &poly,
-            &opening_point,
-        );
+        let evaluation =
+            <MultilinearPolynomial<Fr> as PolynomialEvaluation<Fr>>::evaluate(&poly, &eval_point);
 
         let mut prove_transcript = Blake2bTranscript::new(b"dory_test");
         bind_opening_inputs::<Fr, _>(&mut prove_transcript, &opening_point, &evaluation);
@@ -1002,16 +1010,28 @@ mod tests {
         let vmp_result = rlc_poly.vector_matrix_product(&left_vec);
 
         let mut expected = vec![Fr::zero(); num_columns];
-        let cycles_per_row = DoryGlobals::address_major_cycles_per_row();
+        let dense_stride = DoryGlobals::dense_stride();
+        let cycles_per_row = num_columns
+            .checked_div(dense_stride)
+            .filter(|&cycles| cycles > 0);
 
         // Dense contribution for AddressMajor layout:
         // Dense coefficients occupy evenly-spaced columns (every K-th column).
         // Coefficient i maps to: row = i / cycles_per_row, col = (i % cycles_per_row) * K
         for (i, &coeff) in rlc_dense.iter().enumerate() {
-            let row = i / cycles_per_row;
-            let col = (i % cycles_per_row) * K;
-            if row < num_rows && col < num_columns {
-                expected[col] += left_vec[row] * coeff;
+            if let Some(cycles_per_row) = cycles_per_row {
+                let row = i / cycles_per_row;
+                let col = (i % cycles_per_row) * K;
+                if row < num_rows && col < num_columns {
+                    expected[col] += left_vec[row] * coeff;
+                }
+            } else {
+                let scaled_index = i * dense_stride;
+                let row = scaled_index / num_columns;
+                let col = scaled_index % num_columns;
+                if row < num_rows && col < num_columns {
+                    expected[col] += left_vec[row] * coeff;
+                }
             }
         }
 

--- a/jolt-core/src/poly/commitment/dory/wrappers.rs
+++ b/jolt-core/src/poly/commitment/dory/wrappers.rs
@@ -202,30 +202,109 @@ where
     let dory_context = DoryGlobals::current_context();
     let dory_layout = DoryGlobals::get_layout();
 
-    // Dense polynomials (all scalar variants except OneHot/RLC) are committed row-wise.
-    // Under AddressMajor, dense coefficients occupy evenly-spaced columns, so each row
-    // commitment uses `cycles_per_row` bases (one per occupied column).
-    let (dense_affine_bases, dense_chunk_size): (Vec<_>, usize) = match (dory_context, dory_layout)
-    {
-        (DoryContext::Main, DoryLayout::AddressMajor) => {
-            let cycles_per_row = DoryGlobals::address_major_cycles_per_row();
-            let bases: Vec<_> = g1_slice
-                .par_iter()
-                .take(row_len)
-                .step_by(row_len / cycles_per_row)
-                .map(|g| g.0.into_affine())
-                .collect();
-            (bases, cycles_per_row)
+    let is_dense_poly = !matches!(
+        poly,
+        MultilinearPolynomial::OneHot(_) | MultilinearPolynomial::RLC(_)
+    );
+
+    let is_trace_dense_addr_major = matches!(dory_context, DoryContext::Main)
+        && dory_layout == DoryLayout::AddressMajor
+        && is_dense_poly;
+    debug_assert!(
+        !is_trace_dense_addr_major || poly.original_len() <= DoryGlobals::get_T(),
+        "Main+AddressMajor dense polynomial length exceeds trace T"
+    );
+
+    let (dense_affine_bases, dense_chunk_size, dense_sparse_row_terms) =
+        if is_trace_dense_addr_major {
+            let stride = DoryGlobals::dense_stride();
+            let cycles_per_row = row_len / stride;
+            // This branch is taken when the AddressMajor trace-dense embedding stride exceeds
+            // the post-embedded Main row width (`row_len`), i.e. `row_len < stride`.
+            //
+            // With:
+            // - M = DoryGlobals::get_main_log_embedding() = total embedded Main vars
+            // - k = log2(main K)
+            // - t = log2(execution T)
+            // - e = embedding extra vars = M - (k + t)
+            //
+            // we have:
+            // - row_len = 2^sigma_main, where sigma_main = ceil(M/2)
+            //          = 2^ceil((e + k + t)/2)
+            // - stride  = 2^(main_embedding_extra_vars + k) = 2^(M - t) = 2^(e + k)
+            //
+            // so `cycles_per_row == 0` exactly when:
+            //   ceil(M/2) < (M - t)   <=>   t < floor(M/2).
+            if cycles_per_row == 0 {
+                let dense_len = poly.original_len();
+                let dense_affine_bases: Vec<_> = g1_slice
+                    .par_iter()
+                    .take(row_len)
+                    .map(|g| g.0.into_affine())
+                    .collect();
+                let num_rows = DoryGlobals::get_max_num_rows();
+                let sparse_terms: Vec<(usize, usize, Fr)> = (0..dense_len)
+                    .into_par_iter()
+                    .filter_map(|cycle| {
+                        let coeff = poly.get_coeff(cycle);
+                        if coeff.is_zero() {
+                            return None;
+                        }
+                        let scaled_index = cycle.saturating_mul(stride);
+                        let row_index = scaled_index / row_len;
+                        let col_index = scaled_index % row_len;
+                        debug_assert!(row_index < num_rows);
+                        Some((row_index, col_index, coeff))
+                    })
+                    .collect();
+                let mut row_terms: Vec<Vec<(usize, Fr)>> = vec![Vec::new(); num_rows];
+                for (row_index, col_index, coeff) in sparse_terms {
+                    row_terms[row_index].push((col_index, coeff));
+                }
+                (dense_affine_bases, 1, Some(row_terms))
+            } else {
+                let dense_affine_bases: Vec<_> = g1_slice
+                    .par_iter()
+                    .take(row_len)
+                    .step_by(stride)
+                    .map(|g| g.0.into_affine())
+                    .collect();
+                (dense_affine_bases, cycles_per_row, None)
+            }
+        } else {
+            (
+                g1_slice
+                    .par_iter()
+                    .take(row_len)
+                    .map(|g| g.0.into_affine())
+                    .collect(),
+                row_len,
+                None,
+            )
+        };
+
+    if let Some(row_terms) = dense_sparse_row_terms {
+        let result: Vec<ArkG1> = row_terms
+            .into_par_iter()
+            .map(|terms| {
+                if terms.is_empty() {
+                    return ArkG1(ark_bn254::G1Projective::zero());
+                }
+                let mut bases = Vec::with_capacity(terms.len());
+                let mut scalars = Vec::with_capacity(terms.len());
+                for (col_index, scalar) in terms {
+                    bases.push(dense_affine_bases[col_index]);
+                    scalars.push(scalar);
+                }
+                ArkG1(VariableBaseMSM::msm_field_elements(&bases, &scalars).unwrap())
+            })
+            .collect();
+        // SAFETY: Vec<ArkG1> and Vec<E::G1> have the same memory layout when E = BN254.
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            return Ok(std::mem::transmute(result));
         }
-        _ => (
-            g1_slice
-                .par_iter()
-                .take(row_len)
-                .map(|g| g.0.into_affine())
-                .collect(),
-            row_len,
-        ),
-    };
+    }
 
     let result: Vec<ArkG1> = match poly {
         MultilinearPolynomial::LargeScalars(poly) => poly

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -56,10 +56,11 @@ impl<F: JoltField> OneHotPolynomial<F> {
     ///
     /// Note: the Dory matrix may be square or almost-square depending on `log2(K*T)`.
     pub fn num_rows(&self) -> usize {
-        let t = self.nonzero_indices.len();
         match DoryGlobals::get_layout() {
-            DoryLayout::AddressMajor => t.div_ceil(DoryGlobals::address_major_cycles_per_row()),
-            DoryLayout::CycleMajor => (t * self.K).div_ceil(DoryGlobals::get_num_columns()),
+            DoryLayout::AddressMajor => DoryGlobals::get_max_num_rows(),
+            DoryLayout::CycleMajor => {
+                (DoryGlobals::get_T() * self.K).div_ceil(DoryGlobals::get_num_columns())
+            }
         }
     }
 
@@ -104,7 +105,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
     }
 
     pub fn from_indices(nonzero_indices: Vec<Option<u8>>, K: usize) -> Self {
-        debug_assert_eq!(DoryGlobals::get_T(), nonzero_indices.len());
+        debug_assert!(nonzero_indices.len() <= DoryGlobals::get_T());
         assert!(K <= 1usize << u8::BITS, "K must be <= 256 for indices");
 
         Self {
@@ -120,9 +121,15 @@ impl<F: JoltField> OneHotPolynomial<F> {
         bases: &[G::Affine],
     ) -> Vec<G> {
         let layout = DoryGlobals::get_layout();
+        let one_hot_stride = DoryGlobals::one_hot_stride();
         let num_rows = self.num_rows();
         let row_len = DoryGlobals::get_num_columns();
         let t = self.nonzero_indices.len();
+        let effective_t = DoryGlobals::get_T();
+        debug_assert_eq!(
+            effective_t, t,
+            "one-hot polynomial length must match configured Main T"
+        );
 
         debug_assert!(
             bases.len() >= row_len,
@@ -172,11 +179,16 @@ impl<F: JoltField> OneHotPolynomial<F> {
 
         // General path: collect column indices for each row based on layout
         let mut row_indices: Vec<Vec<usize>> = vec![Vec::new(); num_rows];
+        let dense_stride = DoryGlobals::dense_stride();
         for (cycle, k) in self.nonzero_indices.iter().enumerate() {
             if let Some(k) = k {
-                let global_index = layout.address_cycle_to_index(*k as usize, cycle, self.K, t);
-                let row_index = global_index / row_len;
-                let col_index = global_index % row_len;
+                let scaled_index = if layout == DoryLayout::AddressMajor {
+                    cycle * dense_stride + (*k as usize) * one_hot_stride
+                } else {
+                    layout.address_cycle_to_index(*k as usize, cycle, self.K, effective_t)
+                };
+                let row_index = scaled_index / row_len;
+                let col_index = scaled_index % row_len;
                 if row_index < num_rows {
                     row_indices[row_index].push(col_index);
                 }
@@ -211,12 +223,13 @@ impl<F: JoltField> OneHotPolynomial<F> {
     pub fn vector_matrix_product(&self, left_vec: &[F], coeff: F, result: &mut [F]) {
         let layout = DoryGlobals::get_layout();
         let t = self.nonzero_indices.len();
+        let effective_t = DoryGlobals::get_T();
         let num_columns = DoryGlobals::get_num_columns();
         debug_assert_eq!(result.len(), num_columns);
 
         // CycleMajor optimization for T >= row_len (typical case where T >= K)
         if layout == DoryLayout::CycleMajor && t >= num_columns {
-            let rows_per_k = t / num_columns;
+            let rows_per_k = effective_t / num_columns;
             result
                 .par_iter_mut()
                 .enumerate()
@@ -234,11 +247,17 @@ impl<F: JoltField> OneHotPolynomial<F> {
         }
 
         // General path: iterate through nonzero indices and compute contributions
+        let dense_stride = DoryGlobals::dense_stride();
+        let one_hot_stride = DoryGlobals::one_hot_stride();
         for (cycle, k) in self.nonzero_indices.iter().enumerate() {
             if let Some(k) = k {
-                let global_index = layout.address_cycle_to_index(*k as usize, cycle, self.K, t);
-                let row_index = global_index / num_columns;
-                let col_index = global_index % num_columns;
+                let scaled_index = if layout == DoryLayout::AddressMajor {
+                    cycle * dense_stride + (*k as usize) * one_hot_stride
+                } else {
+                    layout.address_cycle_to_index(*k as usize, cycle, self.K, effective_t)
+                };
+                let row_index = scaled_index / num_columns;
+                let col_index = scaled_index % num_columns;
                 if row_index < left_vec.len() && col_index < result.len() {
                     result[col_index] += coeff * left_vec[row_index];
                 }

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -7,7 +7,10 @@
 
 use crate::{
     poly::rlc_polynomial::{RLCPolynomial, RLCStreamingData, TraceSource},
-    zkvm::{claim_reductions::AdviceKind, config::OneHotParams},
+    zkvm::{
+        claim_reductions::{AdviceKind, PrecommittedPolynomial},
+        config::OneHotParams,
+    },
 };
 use allocative::Allocative;
 use num_derive::FromPrimitive;
@@ -151,10 +154,16 @@ pub enum SumcheckId {
     RegistersClaimReduction,
     RegistersReadWriteChecking,
     RegistersValEvaluation,
+    BytecodeReadRafAddressPhase,
     BytecodeReadRaf,
+    BooleanityAddressPhase,
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
@@ -327,7 +336,7 @@ pub struct DoryOpeningState<F: JoltField> {
 impl<F: JoltField> DoryOpeningState<F> {
     /// Build streaming RLC polynomial from this state.
     /// Streams directly from trace - no witness regeneration needed.
-    /// Advice polynomials are passed separately (not streamed from trace).
+    /// Precommitted polynomials are passed separately (not streamed from trace).
     #[tracing::instrument(skip_all)]
     pub fn build_streaming_rlc<PCS: CommitmentScheme<Field = F>>(
         &self,
@@ -335,7 +344,7 @@ impl<F: JoltField> DoryOpeningState<F> {
         trace_source: TraceSource,
         rlc_streaming_data: Arc<RLCStreamingData>,
         mut opening_hints: HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
-        advice_polys: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
+        precommitted_polys: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>>,
     ) -> (MultilinearPolynomial<F>, PCS::OpeningProofHint) {
         // Accumulate gamma coefficients per polynomial
         let mut rlc_map = BTreeMap::new();
@@ -352,7 +361,7 @@ impl<F: JoltField> DoryOpeningState<F> {
             trace_source,
             poly_ids.clone(),
             &coeffs,
-            advice_polys,
+            precommitted_polys,
         ));
 
         let hints: Vec<PCS::OpeningProofHint> = rlc_map
@@ -621,6 +630,10 @@ where
     pub fn take_pending_claim_ids(&mut self) -> Vec<OpeningId> {
         std::mem::take(&mut self.pending_claim_ids)
     }
+
+    pub fn pending_claim_ids_debug(&self) -> &[OpeningId] {
+        &self.pending_claim_ids
+    }
 }
 
 impl<F> Default for VerifierOpeningAccumulator<F>
@@ -851,39 +864,43 @@ where
     pub fn take_pending_claim_ids(&mut self) -> Vec<OpeningId> {
         std::mem::take(&mut self.pending_claim_ids)
     }
+
+    pub fn pending_claim_ids_debug(&self) -> &[OpeningId] {
+        &self.pending_claim_ids
+    }
 }
 
-/// Computes the Lagrange factor for embedding a smaller "advice" polynomial into the top-left
-/// block of the main Dory matrix.
+/// Computes the Lagrange factor for embedding a smaller polynomial into the top-left block of
+/// the main Dory matrix.
 ///
-/// Advice polynomials have fewer variables than main polynomials. To batch them together,
-/// we embed advice in the top-left corner of the larger matrix and multiply by a Lagrange
+/// Embedded polynomials can have fewer variables than main polynomials. To batch them together,
+/// we embed them in the top-left corner of the larger matrix and multiply by a Lagrange
 /// selector that is 1 on that block and 0 elsewhere:
 ///
 /// ```text
-/// Lagrange factor = ∏_{r ∈ opening_point, r ∉ advice_opening_point} (1 - r)
+/// Lagrange factor = ∏_{r ∈ opening_point, r ∉ embedded_opening_point} (1 - r)
 /// ```
 ///
 /// # Arguments
 /// - `opening_point`: The unified opening point for the Dory opening proof
-/// - `advice_opening_point`: The opening point for the advice polynomial
+/// - `embedded_opening_point`: The opening point for the embedded polynomial
 ///
 /// # Returns
 /// The Lagrange factor as a field element
-pub fn compute_advice_lagrange_factor<F: JoltField>(
+pub fn compute_lagrange_factor<F: JoltField>(
     opening_point: &[F::Challenge],
-    advice_opening_point: &[F::Challenge],
+    embedded_opening_point: &[F::Challenge],
 ) -> F {
     #[cfg(test)]
     {
-        for r in advice_opening_point.iter() {
+        for r in embedded_opening_point.iter() {
             assert!(opening_point.contains(r));
         }
     }
     opening_point
         .iter()
         .map(|r| {
-            if advice_opening_point.contains(r) {
+            if embedded_opening_point.contains(r) {
                 F::one()
             } else {
                 F::one() - r

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -4,10 +4,17 @@ use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::utils::accumulation::MedAccumS;
 use crate::utils::math::{s64_from_diff_u64s, Math};
 use crate::utils::thread::unsafe_allocate_zero_vec;
+use crate::zkvm::claim_reductions::PrecommittedPolynomial;
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::instruction::LookupQuery;
 use crate::zkvm::ram::remap_address;
-use crate::zkvm::{bytecode::BytecodePreprocessing, witness::CommittedPolynomial};
+use crate::zkvm::{
+    bytecode::{
+        chunks::{committed_lanes, for_each_active_lane_value, ActiveLaneValue},
+        get_pc_for_cycle, BytecodePreprocessing,
+    },
+    witness::CommittedPolynomial,
+};
 use allocative::Allocative;
 use common::constants::XLEN;
 use common::jolt_device::MemoryLayout;
@@ -56,9 +63,9 @@ impl TraceSource {
 pub struct StreamingRLCContext<F: JoltField> {
     pub dense_polys: Vec<(CommittedPolynomial, F)>,
     pub onehot_polys: Vec<(CommittedPolynomial, F)>,
-    /// Advice polynomials with their RLC coefficients.
+    /// Precommitted polynomials with their RLC coefficients.
     /// These are NOT streamed from trace - they're passed in directly.
-    pub advice_polys: Vec<(F, MultilinearPolynomial<F>)>,
+    pub precommitted_polys: Vec<(F, PrecommittedPolynomial<F>)>,
     pub trace_source: TraceSource,
     pub preprocessing: Arc<RLCStreamingData>,
     pub one_hot_params: OneHotParams,
@@ -165,7 +172,7 @@ impl<F: JoltField> RLCPolynomial<F> {
     /// * `trace_source` - Either materialized trace (default) or lazy trace (experimental)
     /// * `poly_ids` - List of polynomial identifiers
     /// * `coefficients` - RLC coefficients for each polynomial
-    /// * `advice_poly_map` - Map of advice polynomial IDs to their actual polynomials
+    /// * `precommitted_poly_map` - Map of precommitted polynomial IDs to their actual polynomials
     #[tracing::instrument(skip_all)]
     pub fn new_streaming(
         one_hot_params: OneHotParams,
@@ -173,13 +180,13 @@ impl<F: JoltField> RLCPolynomial<F> {
         trace_source: TraceSource,
         poly_ids: Vec<CommittedPolynomial>,
         coefficients: &[F],
-        mut advice_poly_map: HashMap<CommittedPolynomial, MultilinearPolynomial<F>>,
+        mut precommitted_poly_map: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>>,
     ) -> Self {
         debug_assert_eq!(poly_ids.len(), coefficients.len());
 
         let mut dense_polys = Vec::new();
         let mut onehot_polys = Vec::new();
-        let mut advice_polys = Vec::new();
+        let mut precommitted_polys = Vec::new();
 
         for (poly_id, coeff) in poly_ids.iter().zip(coefficients.iter()) {
             match poly_id {
@@ -191,14 +198,15 @@ impl<F: JoltField> RLCPolynomial<F> {
                 | CommittedPolynomial::RamRa(_) => {
                     onehot_polys.push((*poly_id, *coeff));
                 }
-                CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                    // Advice polynomials are passed in directly (not streamed from trace)
-                    if advice_poly_map.contains_key(poly_id) {
-                        advice_polys.push((*coeff, advice_poly_map.remove(poly_id).unwrap()));
+                CommittedPolynomial::TrustedAdvice
+                | CommittedPolynomial::UntrustedAdvice
+                | CommittedPolynomial::BytecodeChunk(_)
+                | CommittedPolynomial::ProgramImageInit => {
+                    // Precommitted polynomials are passed in directly (not streamed from trace).
+                    if precommitted_poly_map.contains_key(poly_id) {
+                        precommitted_polys
+                            .push((*coeff, precommitted_poly_map.remove(poly_id).unwrap()));
                     }
-                }
-                CommittedPolynomial::BytecodeChunk(_) | CommittedPolynomial::ProgramImageInit => {
-                    panic!("committed program precommitments are not wired into Stage 8 yet")
                 }
             }
         }
@@ -209,7 +217,7 @@ impl<F: JoltField> RLCPolynomial<F> {
             streaming_context: Some(Arc::new(StreamingRLCContext {
                 dense_polys,
                 onehot_polys,
-                advice_polys,
+                precommitted_polys,
                 trace_source,
                 preprocessing,
                 one_hot_params,
@@ -298,21 +306,31 @@ impl<F: JoltField> RLCPolynomial<F> {
                         });
                 }
                 DoryLayout::AddressMajor => {
-                    let cycles_per_row = DoryGlobals::address_major_cycles_per_row();
-                    dense_result
-                        .par_iter_mut()
-                        .step_by(num_columns / cycles_per_row)
+                    let dense_stride = DoryGlobals::dense_stride();
+                    dense_result = self
+                        .dense_rlc
+                        .par_iter()
                         .enumerate()
-                        .for_each(|(offset, dot_product_result)| {
-                            *dot_product_result = self
-                                .dense_rlc
-                                .par_iter()
-                                .skip(offset)
-                                .step_by(cycles_per_row)
-                                .zip(left_vec.par_iter())
-                                .map(|(&a, &b)| -> F { a * b })
-                                .sum::<F>();
-                        });
+                        .fold(
+                            || unsafe_allocate_zero_vec(num_columns),
+                            |mut acc, (cycle, coeff)| {
+                                let scaled_index = cycle.saturating_mul(dense_stride);
+                                let row_index = scaled_index / num_columns;
+                                if row_index >= left_vec.len() {
+                                    return acc;
+                                }
+                                let col_index = scaled_index % num_columns;
+                                acc[col_index] += *coeff * left_vec[row_index];
+                                acc
+                            },
+                        )
+                        .reduce(
+                            || unsafe_allocate_zero_vec(num_columns),
+                            |mut a, b| {
+                                a.iter_mut().zip(b.iter()).for_each(|(x, y)| *x += *y);
+                                a
+                            },
+                        );
                 }
             }
             dense_result
@@ -331,74 +349,177 @@ impl<F: JoltField> RLCPolynomial<F> {
         result
     }
 
-    /// Adds the advice polynomial contribution to the vector-matrix-vector product result.
+    /// Adds the precommitted polynomial contribution to the vector-matrix-vector product result.
     ///
-    /// In Dory's batch opening, advice polynomials are embedded as the top-left block of the
+    /// In Dory's batch opening, precommitted polynomials are embedded as the top-left block of the
     /// main matrix. This function computes their contribution to the VMV product:
     /// ```text
-    /// result[col] += left_vec[row] * (coeff * advice[row, col])
+    /// result[col] += left_vec[row] * (coeff * precommitted[row, col])
     /// ```
-    /// for rows and columns within the advice block.
+    /// for rows and columns within the precommitted block.
     ///
-    /// The advice block occupies:
-    /// - `sigma_a = ceil(advice_vars/2)`, `nu_a = advice_vars - sigma_a`
-    /// - `advice` occupies rows `[0 .. 2^{nu_a})` and cols `[0 .. 2^{sigma_a})`
+    /// The precommitted block occupies:
+    /// - `sigma_a = ceil(poly_vars/2)`, `nu_a = poly_vars - sigma_a`
+    /// - each precommitted polynomial occupies rows `[0 .. 2^{nu_a})` and cols `[0 .. 2^{sigma_a})`
     ///
     /// # Complexity
     /// It uses O(m + a) space where m is the number of rows
-    /// and a is the advice size, so even though it is linear it is negl space overall.
-    fn vmp_advice_contribution(
+    /// and a is the precommitted size, so even though it is linear it is negl space overall.
+    fn vmp_precommitted_contribution(
         result: &mut [F],
         left_vec: &[F],
         num_columns: usize,
         ctx: &StreamingRLCContext<F>,
     ) {
-        // For each advice polynomial, compute its contribution to the result
-        ctx.advice_polys
+        // For each precommitted polynomial, compute its contribution to the result
+        ctx.precommitted_polys
             .iter()
-            .filter(|(_, advice_poly)| advice_poly.original_len() > 0)
-            .for_each(|(coeff, advice_poly)| {
-                let advice_len = advice_poly.original_len();
-                let advice_vars = advice_len.log_2();
-                let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(advice_vars);
-                let advice_cols = 1usize << sigma_a;
-                let advice_rows = 1usize << nu_a;
+            .filter(|(_, precommitted_poly)| precommitted_poly.original_len() > 0)
+            .for_each(|(coeff, precommitted_poly)| {
+                match precommitted_poly {
+                    PrecommittedPolynomial::Dense(poly) => {
+                        let precommitted_len = poly.original_len();
+                        let precommitted_vars = precommitted_len.log_2();
+                        let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(precommitted_vars);
+                        let precommitted_cols = 1usize << sigma_a;
+                        let precommitted_rows = 1usize << nu_a;
 
-                debug_assert!(
-                    advice_cols <= num_columns,
-                    "Advice columns (2^{{sigma_a}}={advice_cols}) must fit in main num_columns={num_columns}; \
+                        debug_assert!(
+                            precommitted_cols <= num_columns,
+                            "Precommitted columns (2^{{sigma_a}}={precommitted_cols}) must fit in main num_columns={num_columns}; \
 guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
-                );
+                        );
 
-                // Only the top-left block contributes: rows [0..advice_rows), cols [0..advice_cols)
-                let effective_rows = advice_rows.min(left_vec.len());
-
-                // Compute column contributions: for each column, sum contributions from all rows
-                // Note: advice_len is always advice_cols * advice_rows (advice size must be power of 2)
-                let column_contributions: Vec<F> = (0..advice_cols)
-                    .into_par_iter()
-                    .map(|col_idx| {
-                        // For this column, sum contributions from all non-zero rows
-                        left_vec[..effective_rows]
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, &left)| !left.is_zero())
-                            .map(|(row_idx, &left)| {
-                                let coeff_idx = row_idx * advice_cols + col_idx;
-                                let advice_val = advice_poly.get_coeff(coeff_idx);
-                                left * *coeff * advice_val
+                        let effective_rows = precommitted_rows.min(left_vec.len());
+                        let column_contributions: Vec<F> = (0..precommitted_cols)
+                            .into_par_iter()
+                            .map(|col_idx| {
+                                left_vec[..effective_rows]
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(_, &left)| !left.is_zero())
+                                    .map(|(row_idx, &left)| {
+                                        let coeff_idx = row_idx * precommitted_cols + col_idx;
+                                        let precommitted_val = poly.get_coeff(coeff_idx);
+                                        left * *coeff * precommitted_val
+                                    })
+                                    .sum()
                             })
-                            .sum()
-                    })
-                    .collect();
+                            .collect();
 
-                // Add column contributions to result in parallel
-                result[..advice_cols]
-                    .par_iter_mut()
-                    .zip(column_contributions.par_iter())
-                    .for_each(|(res, &contrib)| {
-                        *res += contrib;
-                    });
+                        result[..precommitted_cols]
+                            .par_iter_mut()
+                            .zip(column_contributions.par_iter())
+                            .for_each(|(res, &contrib)| {
+                                *res += contrib;
+                            });
+                    }
+                    PrecommittedPolynomial::BytecodeChunk {
+                        chunk_index,
+                        chunk_cycle_len,
+                    } => {
+                        let precommitted_len = committed_lanes() * *chunk_cycle_len;
+                        let precommitted_vars = precommitted_len.log_2();
+                        let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(precommitted_vars);
+                        let precommitted_cols = 1usize << sigma_a;
+                        let effective_rows = (1usize << nu_a).min(left_vec.len());
+                        let chunk_start = chunk_index * chunk_cycle_len;
+                        let chunk_end = chunk_start + chunk_cycle_len;
+                        let layout = DoryGlobals::get_layout();
+                        let column_contributions = ctx.preprocessing.bytecode.bytecode
+                            [chunk_start..chunk_end]
+                            .par_iter()
+                            .enumerate()
+                            .fold(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut acc, (chunk_cycle, instr)| {
+                                    for_each_active_lane_value::<F>(instr, |global_lane, lane_val| {
+                                        let coeff_idx = layout.address_cycle_to_index(
+                                            global_lane,
+                                            chunk_cycle,
+                                            committed_lanes(),
+                                            *chunk_cycle_len,
+                                        );
+                                        let row_idx = coeff_idx / precommitted_cols;
+                                        if row_idx >= effective_rows {
+                                            return;
+                                        }
+                                        let left = left_vec[row_idx];
+                                        if left.is_zero() {
+                                            return;
+                                        }
+                                        let lane_value = match lane_val {
+                                            ActiveLaneValue::One => F::one(),
+                                            ActiveLaneValue::Scalar(v) => v,
+                                        };
+                                        let col_idx = coeff_idx % precommitted_cols;
+                                        acc[col_idx] += left * *coeff * lane_value;
+                                    });
+                                    acc
+                                },
+                            )
+                            .reduce(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut a, b| {
+                                    a.iter_mut().zip(b.iter()).for_each(|(x, y)| *x += *y);
+                                    a
+                                },
+                            );
+
+                        result[..precommitted_cols]
+                            .par_iter_mut()
+                            .zip(column_contributions.par_iter())
+                            .for_each(|(res, &contrib)| {
+                                *res += contrib;
+                            });
+                    }
+                    PrecommittedPolynomial::ProgramImage {
+                        words,
+                        padded_len,
+                    } => {
+                        let precommitted_vars = padded_len.log_2();
+                        let (sigma_a, nu_a) = DoryGlobals::balanced_sigma_nu(precommitted_vars);
+                        let precommitted_cols = 1usize << sigma_a;
+                        let effective_rows = (1usize << nu_a).min(left_vec.len());
+                        let column_contributions = words
+                            .par_iter()
+                            .enumerate()
+                            .fold(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut acc, (offset, &word)| {
+                                    if word == 0 {
+                                        return acc;
+                                    }
+                                    let coeff_idx = offset;
+                                    let row_idx = coeff_idx / precommitted_cols;
+                                    if row_idx >= effective_rows {
+                                        return acc;
+                                    }
+                                    let left = left_vec[row_idx];
+                                    if left.is_zero() {
+                                        return acc;
+                                    }
+                                    let col_idx = coeff_idx % precommitted_cols;
+                                    acc[col_idx] += left * coeff.mul_u64(word);
+                                    acc
+                                },
+                            )
+                            .reduce(
+                                || unsafe_allocate_zero_vec(precommitted_cols),
+                                |mut a, b| {
+                                    a.iter_mut().zip(b.iter()).for_each(|(x, y)| *x += *y);
+                                    a
+                                },
+                            );
+
+                        result[..precommitted_cols]
+                            .par_iter_mut()
+                            .zip(column_contributions.par_iter())
+                            .for_each(|(res, &contrib)| {
+                                *res += contrib;
+                            });
+                    }
+                }
             });
     }
 
@@ -418,7 +539,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
             return self.address_major_vector_matrix_product(left_vec, num_columns, &ctx);
         }
 
-        let T = DoryGlobals::get_T();
+        let T = DoryGlobals::get_embedded_t();
         match &ctx.trace_source {
             TraceSource::Materialized(trace) => {
                 self.materialized_vector_matrix_product(left_vec, num_columns, trace, &ctx, T)
@@ -452,7 +573,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         // Use the regular vector_matrix_product on the materialized polynomial
         let mut result = materialized.vector_matrix_product(left_vec);
 
-        Self::vmp_advice_contribution(&mut result, left_vec, num_columns, ctx);
+        Self::vmp_precommitted_contribution(&mut result, left_vec, num_columns, ctx);
 
         result
     }
@@ -519,8 +640,13 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         let num_rows = T / num_columns;
         let trace_len = trace.len();
 
-        // Setup: precompute coefficients, row factors, and folded one-hot tables.
-        let setup = VmvSetup::new(ctx, left_vec, num_rows);
+        let main_embedding_mode =
+            DoryGlobals::get_layout() == DoryLayout::CycleMajor && trace_len < T;
+
+        // When the dominant Stage-8 matrix is larger than the trace-backed prefix, one-hot
+        // witnesses still live on the exact trace prefix rather than the expanded matrix T.
+        let onehot_rows_per_k = trace_len.div_ceil(num_columns).min(num_rows);
+        let setup = VmvSetup::new(ctx, left_vec, num_rows, onehot_rows_per_k);
 
         // Divide rows evenly among threads using par_chunks on left_vec
         // Only use first num_rows elements (left_vec may be longer due to padding)
@@ -541,7 +667,6 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
                     let scaled_rd_inc = row_weight * setup.rd_inc_coeff;
                     let scaled_ram_inc = row_weight * setup.ram_inc_coeff;
-                    let row_factor = setup.row_factors[row_idx];
 
                     // Split into valid trace range vs padding range.
                     let valid_end = std::cmp::min(chunk_start + num_columns, trace_len);
@@ -553,14 +678,33 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
                     // Process valid trace elements.
                     for (col_idx, cycle) in row_cycles.iter().enumerate() {
-                        setup.process_cycle(
-                            cycle,
-                            scaled_rd_inc,
-                            scaled_ram_inc,
-                            row_factor,
-                            &mut dense_accs[col_idx],
-                            &mut onehot_accs[col_idx],
-                        );
+                        if main_embedding_mode {
+                            setup.process_cycle_dense(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                &mut dense_accs[col_idx],
+                            );
+                            setup.process_cycle_onehot_prefix(
+                                cycle,
+                                chunk_start + col_idx,
+                                trace_len,
+                                num_columns,
+                                left_vec,
+                                &ctx.onehot_polys,
+                                &mut onehot_accs,
+                            );
+                        } else {
+                            let row_factor = setup.row_factors[row_idx];
+                            setup.process_cycle(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                row_factor,
+                                &mut dense_accs[col_idx],
+                                &mut onehot_accs[col_idx],
+                            );
+                        }
                     }
                 }
 
@@ -573,8 +717,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
 
         let mut result = VmvSetup::<F>::finalize(dense_accs, onehot_accs, num_columns);
 
-        // Advice contribution is small and independent of the trace; add it after the streamed pass.
-        Self::vmp_advice_contribution(&mut result, left_vec, num_columns, ctx);
+        // Precommitted contribution is small and independent of the trace; add it after the streamed pass.
+        Self::vmp_precommitted_contribution(&mut result, left_vec, num_columns, ctx);
         result
     }
 
@@ -589,9 +733,13 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
         T: usize,
     ) -> Vec<F> {
         let num_rows = T / num_columns;
+        let trace_len = DoryGlobals::main_t();
+        let main_embedding_mode =
+            DoryGlobals::get_layout() == DoryLayout::CycleMajor && trace_len < T;
 
         // Setup: precompute coefficients, row factors, and folded one-hot tables.
-        let setup = VmvSetup::new(ctx, left_vec, num_rows);
+        let onehot_rows_per_k = trace_len.div_ceil(num_columns).min(num_rows);
+        let setup = VmvSetup::new(ctx, left_vec, num_rows, onehot_rows_per_k);
 
         let (dense_accs, onehot_accs) = lazy_trace
             .pad_using(T, |_| Cycle::NoOp)
@@ -604,18 +752,37 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
                     let row_weight = left_vec[row_idx];
                     let scaled_rd_inc = row_weight * setup.rd_inc_coeff;
                     let scaled_ram_inc = row_weight * setup.ram_inc_coeff;
-                    let row_factor = setup.row_factors[row_idx];
 
                     // Process columns within chunk sequentially.
                     for (col_idx, cycle) in chunk.iter().enumerate() {
-                        setup.process_cycle(
-                            cycle,
-                            scaled_rd_inc,
-                            scaled_ram_inc,
-                            row_factor,
-                            &mut dense_accs[col_idx],
-                            &mut onehot_accs[col_idx],
-                        );
+                        let cycle_idx = row_idx * num_columns + col_idx;
+                        if main_embedding_mode && cycle_idx < trace_len {
+                            setup.process_cycle_dense(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                &mut dense_accs[col_idx],
+                            );
+                            setup.process_cycle_onehot_prefix(
+                                cycle,
+                                cycle_idx,
+                                trace_len,
+                                num_columns,
+                                left_vec,
+                                &ctx.onehot_polys,
+                                &mut onehot_accs,
+                            );
+                        } else {
+                            let row_factor = setup.row_factors[row_idx];
+                            setup.process_cycle(
+                                cycle,
+                                scaled_rd_inc,
+                                scaled_ram_inc,
+                                row_factor,
+                                &mut dense_accs[col_idx],
+                                &mut onehot_accs[col_idx],
+                            );
+                        }
                     }
 
                     (dense_accs, onehot_accs)
@@ -627,8 +794,8 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
             );
         let mut result = VmvSetup::<F>::finalize(dense_accs, onehot_accs, num_columns);
 
-        // Advice contribution is small and independent of the trace; add it after the streamed pass.
-        Self::vmp_advice_contribution(&mut result, left_vec, num_columns, ctx);
+        // Precommitted contribution is small and independent of the trace; add it after the streamed pass.
+        Self::vmp_precommitted_contribution(&mut result, left_vec, num_columns, ctx);
         result
     }
 }
@@ -662,19 +829,29 @@ struct VmvSetup<'a, F: JoltField> {
 }
 
 impl<'a, F: JoltField> VmvSetup<'a, F> {
-    fn new(ctx: &'a StreamingRLCContext<F>, left_vec: &[F], num_rows: usize) -> Self {
+    fn new(
+        ctx: &'a StreamingRLCContext<F>,
+        left_vec: &[F],
+        matrix_rows_per_k: usize,
+        active_onehot_rows_per_k: usize,
+    ) -> Self {
         let one_hot_params = &ctx.one_hot_params;
         let k_chunk = one_hot_params.k_chunk;
 
         debug_assert!(
-            left_vec.len() >= k_chunk * num_rows,
+            left_vec.len() >= k_chunk * matrix_rows_per_k,
             "left_vec too short for one-hot VMV: len={} need_at_least={}",
             left_vec.len(),
-            k_chunk * num_rows
+            k_chunk * matrix_rows_per_k
         );
 
         // Compute row_factors and eq_k from left vector
-        let (row_factors, eq_k) = Self::compute_row_factors_and_eq_k(left_vec, num_rows, k_chunk);
+        let (row_factors, eq_k) = Self::compute_row_factors_and_eq_k(
+            left_vec,
+            matrix_rows_per_k,
+            active_onehot_rows_per_k,
+            k_chunk,
+        );
 
         // Extract dense coefficients
         let mut rd_inc_coeff = F::zero();
@@ -706,16 +883,17 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
     #[inline]
     fn compute_row_factors_and_eq_k(
         left_vec: &[F],
-        rows_per_k: usize,
+        matrix_rows_per_k: usize,
+        active_onehot_rows_per_k: usize,
         k_chunk: usize,
     ) -> (Vec<F>, Vec<F>) {
-        let mut row_factors: Vec<F> = unsafe_allocate_zero_vec(rows_per_k);
+        let mut row_factors: Vec<F> = unsafe_allocate_zero_vec(matrix_rows_per_k);
         let mut eq_k: Vec<F> = unsafe_allocate_zero_vec(k_chunk);
 
         for k in 0..k_chunk {
-            let base = k * rows_per_k;
+            let base = k * matrix_rows_per_k;
             let mut sum_k = F::zero();
-            for row in 0..rows_per_k {
+            for row in 0..active_onehot_rows_per_k {
                 let v = left_vec[base + row];
                 sum_k += v;
                 row_factors[row] += v;
@@ -724,6 +902,71 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         }
 
         (row_factors, eq_k)
+    }
+
+    #[inline(always)]
+    fn process_cycle_dense(
+        &self,
+        cycle: &Cycle,
+        scaled_rd_inc: F,
+        scaled_ram_inc: F,
+        dense_acc: &mut MedAccumS<F>,
+    ) {
+        let (_, pre_value, post_value) = cycle.rd_write().unwrap_or_default();
+        let diff = s64_from_diff_u64s(post_value, pre_value);
+        dense_acc.fmadd(&scaled_rd_inc, &diff);
+
+        if let tracer::instruction::RAMAccess::Write(write) = cycle.ram_access() {
+            let diff = s64_from_diff_u64s(write.post_value, write.pre_value);
+            dense_acc.fmadd(&scaled_ram_inc, &diff);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[inline(always)]
+    fn process_cycle_onehot_prefix(
+        &self,
+        cycle: &Cycle,
+        cycle_idx: usize,
+        trace_len: usize,
+        num_columns: usize,
+        left_vec: &[F],
+        onehot_polys: &[(CommittedPolynomial, F)],
+        onehot_accs: &mut [F::UnreducedProductAccum],
+    ) {
+        let lookup_index = LookupQuery::<XLEN>::to_lookup_index(cycle);
+        let pc = get_pc_for_cycle(self.bytecode, cycle);
+        let remapped_address =
+            remap_address(cycle.ram_access().address() as u64, self.memory_layout);
+
+        for (poly_id, coeff) in onehot_polys.iter() {
+            if coeff.is_zero() {
+                continue;
+            }
+
+            let k = match poly_id {
+                CommittedPolynomial::InstructionRa(idx) => {
+                    self.one_hot_params.lookup_index_chunk(lookup_index, *idx) as usize
+                }
+                CommittedPolynomial::BytecodeRa(idx) => {
+                    self.one_hot_params.bytecode_pc_chunk(pc, *idx) as usize
+                }
+                CommittedPolynomial::RamRa(idx) => {
+                    let Some(addr) = remapped_address else {
+                        continue;
+                    };
+                    self.one_hot_params.ram_address_chunk(addr, *idx) as usize
+                }
+                _ => unreachable!("dense polynomial found in onehot_polys"),
+            };
+
+            let global_index = k * trace_len + cycle_idx;
+            let row_index = global_index / num_columns;
+            let col_index = global_index % num_columns;
+            if row_index < left_vec.len() && col_index < onehot_accs.len() {
+                onehot_accs[col_index] += left_vec[row_index].mul_to_product_accum(*coeff);
+            }
+        }
     }
 
     /// Build per-polynomial folded one-hot tables (non-flattened).
@@ -791,15 +1034,7 @@ impl<'a, F: JoltField> VmvSetup<'a, F> {
         dense_acc: &mut MedAccumS<F>,
         onehot_acc: &mut F::UnreducedProductAccum,
     ) {
-        // Dense polynomials: accumulate scaled_coeff * (post - pre)
-        let (_, pre_value, post_value) = cycle.rd_write().unwrap_or_default();
-        let diff = s64_from_diff_u64s(post_value, pre_value);
-        dense_acc.fmadd(&scaled_rd_inc, &diff);
-
-        if let tracer::instruction::RAMAccess::Write(write) = cycle.ram_access() {
-            let diff = s64_from_diff_u64s(write.post_value, write.pre_value);
-            dense_acc.fmadd(&scaled_ram_inc, &diff);
-        }
+        self.process_cycle_dense(cycle, scaled_rd_inc, scaled_ram_inc, dense_acc);
 
         // One-hot polynomials: accumulate using pre-folded K tables (unreduced)
         let mut inner_sum = F::UnreducedMulU64::default();

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -2,6 +2,7 @@ pub mod advice;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction_lookups;
+mod precommitted;
 pub mod ram_ra;
 pub mod registers;
 
@@ -20,6 +21,11 @@ pub use increments::{
 pub use instruction_lookups::{
     InstructionLookupsClaimReductionSumcheckParams, InstructionLookupsClaimReductionSumcheckProver,
     InstructionLookupsClaimReductionSumcheckVerifier,
+};
+pub use precommitted::{
+    permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
+    precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction, PrecommittedPhase,
+    PrecommittedPolynomial, PrecommittedSchedulingReference,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -1,0 +1,647 @@
+use allocative::Allocative;
+use rayon::prelude::*;
+use std::sync::Arc;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN, LITTLE_ENDIAN};
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::committed_lanes;
+
+#[derive(Clone, Debug)]
+pub enum PrecommittedPolynomial<F: JoltField> {
+    Dense(MultilinearPolynomial<F>),
+    BytecodeChunk {
+        chunk_index: usize,
+        chunk_cycle_len: usize,
+    },
+    ProgramImage {
+        words: Arc<Vec<u64>>,
+        padded_len: usize,
+    },
+}
+
+impl<F: JoltField> PrecommittedPolynomial<F> {
+    pub(crate) fn original_len(&self) -> usize {
+        match self {
+            Self::Dense(poly) => poly.original_len(),
+            Self::BytecodeChunk {
+                chunk_cycle_len, ..
+            } => committed_lanes() * *chunk_cycle_len,
+            Self::ProgramImage { padded_len, .. } => *padded_len,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
+pub enum PrecommittedPhase {
+    CycleVariables,
+    AddressVariables,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
+pub struct PrecommittedSchedulingReference {
+    pub main_total_vars: usize,
+    pub reference_total_vars: usize,
+    pub cycle_alignment_rounds: usize,
+    pub address_rounds: usize,
+    pub joint_col_vars: usize,
+}
+
+#[derive(Debug, Clone, Allocative)]
+pub struct PrecommittedClaimReduction<F: JoltField> {
+    pub scheduling_reference: PrecommittedSchedulingReference,
+    pub cycle_var_challenges: Vec<F::Challenge>,
+    poly_opening_round_permutation_be: Vec<usize>,
+    cycle_phase_rounds: Vec<usize>,
+    cycle_phase_total_rounds: usize,
+    address_phase_rounds: Vec<usize>,
+    address_phase_total_rounds: usize,
+}
+
+impl<F: JoltField> PrecommittedClaimReduction<F> {
+    /// Compute shared scheduling dimensions from Main and precommitted candidates.
+    ///
+    /// `reference_total_vars` is the largest total var count across Main and candidates.
+    pub fn scheduling_reference(
+        main_total_vars: usize,
+        candidates: &[usize],
+    ) -> PrecommittedSchedulingReference {
+        let address_rounds = DoryGlobals::main_k().log_2();
+        let max_precommitted = candidates.iter().copied().max().unwrap_or(0);
+        let reference_total_vars = std::cmp::max(main_total_vars, max_precommitted);
+        let cycle_alignment_rounds = reference_total_vars.saturating_sub(address_rounds);
+        let (reference_sigma, _) = DoryGlobals::balanced_sigma_nu(reference_total_vars);
+        let joint_col_vars = std::cmp::max(
+            DoryGlobals::configured_main_num_columns().log_2(),
+            reference_sigma,
+        );
+        PrecommittedSchedulingReference {
+            main_total_vars,
+            reference_total_vars,
+            cycle_alignment_rounds,
+            address_rounds,
+            joint_col_vars,
+        }
+    }
+
+    #[inline]
+    pub fn new(
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+    ) -> Self {
+        let has_precommitted_dominance =
+            scheduling_reference.reference_total_vars > scheduling_reference.main_total_vars;
+        let dense_cycle_prefix_rounds = if has_precommitted_dominance {
+            DoryGlobals::main_t().log_2()
+        } else {
+            0
+        };
+        let dory_opening_round_permutation_be = Self::reference_dory_opening_round_permutation_be(
+            &scheduling_reference,
+            has_precommitted_dominance,
+            dense_cycle_prefix_rounds,
+        );
+        let poly_opening_round_permutation_be = Self::project_dory_round_permutation_for_poly(
+            &dory_opening_round_permutation_be,
+            &scheduling_reference,
+            poly_row_vars,
+            poly_col_vars,
+        );
+        let (cycle_phase_rounds, address_phase_rounds) = Self::active_rounds_from_poly_permutation(
+            &poly_opening_round_permutation_be,
+            scheduling_reference.cycle_alignment_rounds,
+        );
+        Self {
+            scheduling_reference,
+            cycle_var_challenges: vec![],
+            poly_opening_round_permutation_be,
+            cycle_phase_rounds,
+            cycle_phase_total_rounds: scheduling_reference.cycle_alignment_rounds,
+            address_phase_rounds,
+            address_phase_total_rounds: scheduling_reference.address_rounds,
+        }
+    }
+
+    fn reference_dory_opening_round_permutation_be(
+        reference: &PrecommittedSchedulingReference,
+        has_precommitted_dominance: bool,
+        dense_cycle_prefix_rounds: usize,
+    ) -> Vec<usize> {
+        let cycle_rounds = reference.cycle_alignment_rounds;
+        let address_rounds = reference.address_rounds;
+        let total_rounds = cycle_rounds + address_rounds;
+        if has_precommitted_dominance {
+            let address_rev = (cycle_rounds..total_rounds).rev();
+            match DoryGlobals::get_layout() {
+                DoryLayout::CycleMajor => {
+                    let t = dense_cycle_prefix_rounds.min(cycle_rounds);
+                    let prefix_rev = (0..cycle_rounds.saturating_sub(t)).rev();
+                    let dense_rev = (cycle_rounds.saturating_sub(t)..cycle_rounds).rev();
+                    return prefix_rev.chain(address_rev).chain(dense_rev).collect();
+                }
+                DoryLayout::AddressMajor => {
+                    let t = dense_cycle_prefix_rounds.min(cycle_rounds);
+                    let prefix_rev = (0..cycle_rounds.saturating_sub(t)).rev();
+                    let dense_rev = (cycle_rounds.saturating_sub(t)..cycle_rounds).rev();
+                    return dense_rev.chain(address_rev).chain(prefix_rev).collect();
+                }
+            }
+        }
+
+        match DoryGlobals::get_layout() {
+            DoryLayout::CycleMajor => (0..total_rounds).rev().collect(),
+            DoryLayout::AddressMajor => {
+                let cycle_rev = (0..cycle_rounds).rev();
+                let address_rev = (cycle_rounds..total_rounds).rev();
+                cycle_rev.chain(address_rev).collect()
+            }
+        }
+    }
+
+    fn project_dory_round_permutation_for_poly(
+        dory_opening_round_permutation_be: &[usize],
+        reference: &PrecommittedSchedulingReference,
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+    ) -> Vec<usize> {
+        let total_full = reference.reference_total_vars;
+        let sigma_full = reference.joint_col_vars;
+        let nu_full = total_full.saturating_sub(sigma_full);
+        assert_eq!(
+            dory_opening_round_permutation_be.len(),
+            total_full,
+            "reference dory round permutation length mismatch",
+        );
+        assert!(
+            poly_row_vars <= nu_full && poly_col_vars <= sigma_full,
+            "top-left projection requires poly dims <= full dims (poly row/col vars={poly_row_vars}/{poly_col_vars}, full row/col vars={nu_full}/{sigma_full})"
+        );
+        let row_be = &dory_opening_round_permutation_be[..nu_full];
+        let col_be = &dory_opening_round_permutation_be[nu_full..nu_full + sigma_full];
+        let row_tail = &row_be[nu_full - poly_row_vars..];
+        let col_tail = &col_be[sigma_full - poly_col_vars..];
+        [row_tail, col_tail].concat()
+    }
+
+    fn active_rounds_from_poly_permutation(
+        poly_opening_round_permutation_be: &[usize],
+        cycle_alignment_rounds: usize,
+    ) -> (Vec<usize>, Vec<usize>) {
+        let mut cycle_phase_rounds = Vec::new();
+        let mut address_phase_rounds = Vec::new();
+        for &global_round in poly_opening_round_permutation_be.iter() {
+            if global_round < cycle_alignment_rounds {
+                cycle_phase_rounds.push(global_round);
+            } else {
+                address_phase_rounds.push(global_round - cycle_alignment_rounds);
+            }
+        }
+        cycle_phase_rounds.sort_unstable();
+        cycle_phase_rounds.dedup();
+        address_phase_rounds.sort_unstable();
+        address_phase_rounds.dedup();
+        (cycle_phase_rounds, address_phase_rounds)
+    }
+
+    #[inline]
+    pub fn num_address_phase_rounds(&self) -> usize {
+        self.address_phase_rounds.len()
+    }
+
+    #[inline]
+    pub fn is_cycle_phase_round(&self, round: usize) -> bool {
+        self.cycle_phase_rounds.contains(&round)
+    }
+
+    /// Indices of the cycle-phase rounds that this poly actively participates
+    /// in (i.e. rounds where the verifier evaluates the poly rather than
+    /// scaling by 1/2). The vector is sorted ascending and deduplicated.
+    pub fn cycle_phase_rounds(&self) -> &[usize] {
+        &self.cycle_phase_rounds
+    }
+
+    /// Indices of the address-phase rounds that this poly actively
+    /// participates in. Same conventions as [`Self::cycle_phase_rounds`].
+    pub fn address_phase_rounds(&self) -> &[usize] {
+        &self.address_phase_rounds
+    }
+
+    /// Big-endian round-permutation projected onto this poly's
+    /// `(poly_row_vars, poly_col_vars)` rectangle.
+    ///
+    /// The slice is `poly_row_vars + poly_col_vars` long: the first
+    /// `poly_row_vars` entries describe the row-side rounds, the rest the
+    /// column-side rounds. Pair this with
+    /// [`precommitted_sumcheck_inverse_index_permutation`] to permute a
+    /// length-`2^len` coefficient vector into opening order, instead of
+    /// re-deriving it from `scheduling_reference`.
+    pub fn poly_opening_round_permutation_be(&self) -> &[usize] {
+        &self.poly_opening_round_permutation_be
+    }
+
+    /// The `(1/2)^cycle_gap` factor that "non-active" cycle-phase rounds
+    /// contribute to the running scale. Returns `F::one()` when there are
+    /// no inactive cycle-phase rounds.
+    ///
+    /// This is the cycle-only counterpart of
+    /// [`precommitted_skip_round_scale`], intended for callers that need
+    /// the scale strictly at the cycle-to-address handoff (e.g. when
+    /// constructing the address-phase prover).
+    #[inline]
+    pub fn cycle_phase_skip_scale(&self) -> F {
+        let cycle_gap_len = self.cycle_phase_total_rounds - self.cycle_phase_rounds.len();
+        if cycle_gap_len == 0 {
+            return F::one();
+        }
+        let two_inv = F::from_u64(2).inverse().unwrap();
+        (0..cycle_gap_len).fold(F::one(), |acc, _| acc * two_inv)
+    }
+
+    pub fn is_address_phase_active_round(&self, round: usize) -> bool {
+        self.address_phase_rounds.contains(&round)
+    }
+
+    #[inline]
+    pub fn is_address_phase_round(&self, round: usize) -> bool {
+        self.address_phase_rounds.contains(&round)
+    }
+
+    #[inline]
+    pub fn cycle_alignment_rounds(&self) -> usize {
+        self.scheduling_reference.cycle_alignment_rounds
+    }
+
+    #[inline]
+    pub fn address_alignment_rounds(&self) -> usize {
+        self.scheduling_reference.address_rounds
+    }
+
+    #[inline]
+    pub fn num_rounds_for_phase(&self, is_cycle_phase: bool) -> usize {
+        if is_cycle_phase {
+            self.cycle_phase_total_rounds
+        } else {
+            self.address_phase_total_rounds
+        }
+    }
+
+    pub fn round_offset(&self, is_cycle_phase: bool, max_num_rounds: usize) -> usize {
+        let _ = (is_cycle_phase, max_num_rounds);
+        0
+    }
+
+    fn cycle_challenge_for_round(&self, round: usize) -> F::Challenge {
+        let idx = self
+            .cycle_phase_rounds
+            .iter()
+            .position(|&scheduled_round| scheduled_round == round)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing recorded cycle challenge for round={} (active rounds={:?})",
+                    round, self.cycle_phase_rounds
+                )
+            });
+        assert!(
+            idx < self.cycle_var_challenges.len(),
+            "cycle challenge vector too short: idx={} len={}",
+            idx,
+            self.cycle_var_challenges.len()
+        );
+        self.cycle_var_challenges[idx]
+    }
+
+    pub fn normalize_opening_point(
+        &self,
+        is_cycle_phase: bool,
+        challenges: &[F::Challenge],
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        if is_cycle_phase {
+            let local_cycle_challenges: Vec<F::Challenge> = self
+                .cycle_phase_rounds
+                .iter()
+                .map(|&round| {
+                    assert!(
+                        round < challenges.len(),
+                        "cycle round index out of local bounds: round={} local_len={}",
+                        round,
+                        challenges.len()
+                    );
+                    challenges[round]
+                })
+                .collect();
+            return OpeningPoint::<LITTLE_ENDIAN, F>::new(local_cycle_challenges)
+                .match_endianness();
+        }
+
+        let cycle_round_limit = self.cycle_alignment_rounds();
+        let opening_rounds = &self.poly_opening_round_permutation_be;
+        let mut opening_point_be = Vec::with_capacity(opening_rounds.len());
+        for &global_round in opening_rounds.iter() {
+            if global_round < cycle_round_limit {
+                opening_point_be.push(self.cycle_challenge_for_round(global_round));
+            } else {
+                let address_round = global_round - cycle_round_limit;
+                assert!(
+                    address_round < challenges.len(),
+                    "address round index out of local bounds: round={} local_len={}",
+                    address_round,
+                    challenges.len()
+                );
+                opening_point_be.push(challenges[address_round]);
+            }
+        }
+        OpeningPoint::<BIG_ENDIAN, F>::new(opening_point_be)
+    }
+
+    #[inline]
+    pub fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
+        self.cycle_var_challenges.push(challenge);
+    }
+
+    #[inline]
+    pub fn set_cycle_var_challenges(&mut self, challenges: Vec<F::Challenge>) {
+        self.cycle_var_challenges = challenges;
+    }
+}
+
+pub fn permute_precommitted_polys<V: Copy + Send + Sync, F: JoltField>(
+    coeffs_by_poly: Vec<Vec<V>>,
+    precommitted: &PrecommittedClaimReduction<F>,
+) -> Vec<MultilinearPolynomial<F>>
+where
+    MultilinearPolynomial<F>: From<Vec<V>>,
+{
+    if coeffs_by_poly.is_empty() {
+        return Vec::new();
+    }
+    let coeffs_len = coeffs_by_poly[0].len();
+    assert!(
+        coeffs_by_poly
+            .iter()
+            .all(|coeffs| coeffs.len() == coeffs_len),
+        "all precommitted polynomials must have equal coefficient lengths",
+    );
+    let inverse_permutation = precommitted_sumcheck_inverse_index_permutation(
+        coeffs_len,
+        &precommitted.poly_opening_round_permutation_be,
+    );
+    let permuted_coeffs_by_poly: Vec<Vec<V>> =
+        if let Some(inverse_permutation) = inverse_permutation {
+            coeffs_by_poly
+                .into_iter()
+                .map(|coeffs| {
+                    (0..coeffs_len)
+                        .into_par_iter()
+                        .map(|new_idx| {
+                            let old_idx = inverse_permutation[new_idx];
+                            coeffs[old_idx]
+                        })
+                        .collect()
+                })
+                .collect()
+        } else {
+            coeffs_by_poly
+        };
+    permuted_coeffs_by_poly
+        .into_iter()
+        .map(Into::into)
+        .collect()
+}
+
+pub fn precommitted_eq_evals_with_scaling<F, C>(
+    challenges_be: &[C],
+    scaling_factor: Option<F>,
+    precommitted: &PrecommittedClaimReduction<F>,
+) -> Vec<F>
+where
+    C: Copy + Send + Sync + Into<F>,
+    F: JoltField + std::ops::Mul<C, Output = F> + std::ops::SubAssign<F>,
+{
+    let permuted_challenges = precommitted_permute_eq_challenges(
+        challenges_be,
+        &precommitted.poly_opening_round_permutation_be,
+    );
+    if let Some(permuted_challenges) = permuted_challenges {
+        EqPolynomial::evals_with_scaling(&permuted_challenges, scaling_factor)
+    } else {
+        EqPolynomial::evals_with_scaling(challenges_be, scaling_factor)
+    }
+}
+
+fn precommitted_permute_eq_challenges<C: Copy>(
+    challenges_be: &[C],
+    poly_opening_round_permutation_be: &[usize],
+) -> Option<Vec<C>> {
+    let old_lsb_to_new_lsb =
+        precommitted_sumcheck_lsb_permutation(poly_opening_round_permutation_be)?;
+    assert_eq!(
+        challenges_be.len(),
+        old_lsb_to_new_lsb.len(),
+        "challenge vector length mismatch for precommitted eq permutation",
+    );
+    let num_vars = challenges_be.len();
+    let mut permuted_challenges = challenges_be.to_vec();
+    for old_be in 0..num_vars {
+        let old_lsb = num_vars - 1 - old_be;
+        let new_lsb = old_lsb_to_new_lsb[old_lsb];
+        let new_be = num_vars - 1 - new_lsb;
+        permuted_challenges[new_be] = challenges_be[old_be];
+    }
+    Some(permuted_challenges)
+}
+
+fn precommitted_sumcheck_lsb_permutation(
+    poly_opening_round_permutation_be: &[usize],
+) -> Option<Vec<usize>> {
+    let num_vars = poly_opening_round_permutation_be.len();
+    let mut be_var_by_round: Vec<usize> = (0..num_vars).collect();
+    be_var_by_round.sort_unstable_by_key(|&be_idx| poly_opening_round_permutation_be[be_idx]);
+
+    let mut old_lsb_to_new_lsb = vec![0usize; num_vars];
+    for (new_lsb, be_var_idx) in be_var_by_round.into_iter().enumerate() {
+        let old_lsb = num_vars - 1 - be_var_idx;
+        old_lsb_to_new_lsb[old_lsb] = new_lsb;
+    }
+
+    if old_lsb_to_new_lsb
+        .iter()
+        .enumerate()
+        .all(|(old_lsb, &new_lsb)| old_lsb == new_lsb)
+    {
+        return None;
+    }
+    Some(old_lsb_to_new_lsb)
+}
+
+/// Inverse index permutation for permuting a precommitted polynomial's
+/// coefficient vector into the order implied by `poly_opening_round_permutation_be`.
+///
+/// Returns `Some(perm)` such that `perm[new_idx] = old_idx`, suitable for
+/// driving an out-of-place permute of a length-`coeffs_len` vector. Returns
+/// `None` when the requested permutation is the identity, so callers can
+/// short-circuit and skip the permute entirely.
+///
+/// `coeffs_len` must equal `1 << poly_opening_round_permutation_be.len()`;
+/// asserts otherwise.
+pub fn precommitted_sumcheck_inverse_index_permutation(
+    coeffs_len: usize,
+    poly_opening_round_permutation_be: &[usize],
+) -> Option<Vec<usize>> {
+    let num_vars = poly_opening_round_permutation_be.len();
+    assert_eq!(
+        coeffs_len,
+        1usize << num_vars,
+        "precommitted coeff vector length mismatch: len={} expected=2^{}",
+        coeffs_len,
+        num_vars
+    );
+    let old_lsb_to_new_lsb =
+        precommitted_sumcheck_lsb_permutation(poly_opening_round_permutation_be)?;
+
+    let mut new_lsb_to_old_lsb = vec![0usize; num_vars];
+    for (old_lsb, &new_lsb) in old_lsb_to_new_lsb.iter().enumerate() {
+        new_lsb_to_old_lsb[new_lsb] = old_lsb;
+    }
+
+    let inverse_permutation: Vec<usize> = (0..coeffs_len)
+        .into_par_iter()
+        .map(|new_idx| {
+            let mut old_idx = 0usize;
+            for new_lsb in 0..num_vars {
+                let bit = (new_idx >> new_lsb) & 1usize;
+                let old_lsb = new_lsb_to_old_lsb[new_lsb];
+                old_idx |= bit << old_lsb;
+            }
+            old_idx
+        })
+        .collect();
+    Some(inverse_permutation)
+}
+
+pub fn precommitted_skip_round_scale<F: JoltField>(
+    precommitted: &PrecommittedClaimReduction<F>,
+) -> F {
+    let cycle_gap_len =
+        precommitted.cycle_phase_total_rounds - precommitted.cycle_phase_rounds.len();
+    let address_gap_len =
+        precommitted.address_phase_total_rounds - precommitted.address_phase_rounds.len();
+    let gap_len = cycle_gap_len + address_gap_len;
+    let two_inv = F::from_u64(2).inverse().unwrap();
+    (0..gap_len).fold(F::one(), |acc, _| acc * two_inv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::JoltField;
+    use ark_bn254::Fr;
+    use num_traits::One;
+
+    fn make_reduction(
+        poly_opening_round_permutation_be: Vec<usize>,
+        cycle_phase_rounds: Vec<usize>,
+        cycle_phase_total_rounds: usize,
+        address_phase_rounds: Vec<usize>,
+        address_phase_total_rounds: usize,
+    ) -> PrecommittedClaimReduction<Fr> {
+        let scheduling_reference = PrecommittedSchedulingReference {
+            main_total_vars: cycle_phase_total_rounds + address_phase_total_rounds,
+            reference_total_vars: cycle_phase_total_rounds + address_phase_total_rounds,
+            cycle_alignment_rounds: cycle_phase_total_rounds,
+            address_rounds: address_phase_total_rounds,
+            joint_col_vars: 0,
+        };
+        PrecommittedClaimReduction {
+            scheduling_reference,
+            cycle_var_challenges: vec![],
+            poly_opening_round_permutation_be,
+            cycle_phase_rounds,
+            cycle_phase_total_rounds,
+            address_phase_rounds,
+            address_phase_total_rounds,
+        }
+    }
+
+    #[test]
+    fn poly_opening_round_permutation_be_returns_stored_field() {
+        let perm = vec![3usize, 0, 1, 2];
+        let r = make_reduction(perm.clone(), vec![0, 1], 2, vec![0, 1], 2);
+        assert_eq!(r.poly_opening_round_permutation_be(), perm.as_slice());
+    }
+
+    #[test]
+    fn cycle_and_address_phase_rounds_accessors_match_internal_storage() {
+        let cycle = vec![0usize, 2, 3];
+        let address = vec![1usize];
+        let r = make_reduction(vec![0, 1, 2, 3], cycle.clone(), 4, address.clone(), 2);
+        assert_eq!(r.cycle_phase_rounds(), cycle.as_slice());
+        assert_eq!(r.address_phase_rounds(), address.as_slice());
+    }
+
+    #[test]
+    fn cycle_phase_skip_scale_is_one_when_no_gap() {
+        let r = make_reduction(vec![0, 1], vec![0, 1], 2, vec![], 0);
+        assert_eq!(r.cycle_phase_skip_scale(), Fr::one());
+    }
+
+    #[test]
+    fn cycle_phase_skip_scale_is_two_inverse_per_inactive_round() {
+        let two_inv = Fr::from_u64(2).inverse().unwrap();
+        // 1 inactive cycle round
+        let r1 = make_reduction(vec![0], vec![0], 2, vec![], 0);
+        assert_eq!(r1.cycle_phase_skip_scale(), two_inv);
+        // 3 inactive cycle rounds
+        let r3 = make_reduction(vec![0], vec![0], 4, vec![], 0);
+        assert_eq!(r3.cycle_phase_skip_scale(), two_inv * two_inv * two_inv);
+        // address-phase gap must NOT contribute (this is the cycle-only flavour)
+        let r_ignore = make_reduction(vec![0], vec![0], 1, vec![], 5);
+        assert_eq!(r_ignore.cycle_phase_skip_scale(), Fr::one());
+    }
+
+    #[test]
+    fn cycle_phase_skip_scale_agrees_with_full_skip_when_address_gap_is_zero() {
+        let r = make_reduction(vec![0, 1], vec![0], 3, vec![0, 1], 2);
+        // cycle_gap = 3 - 1 = 2, address_gap = 2 - 2 = 0
+        // full = (1/2)^2; cycle_only = (1/2)^2; they should agree.
+        let full = precommitted_skip_round_scale(&r);
+        assert_eq!(r.cycle_phase_skip_scale(), full);
+    }
+
+    #[test]
+    fn inverse_index_permutation_returns_none_for_identity() {
+        // BE descending = identity LSB permutation (no reordering).
+        let identity_be: Vec<usize> = (0..4).rev().collect();
+        let perm = precommitted_sumcheck_inverse_index_permutation(1 << 4, &identity_be);
+        assert!(
+            perm.is_none(),
+            "identity permutation should be reported as None, got Some(len={})",
+            perm.map(|p| p.len()).unwrap_or(0),
+        );
+    }
+
+    #[test]
+    fn inverse_index_permutation_is_a_genuine_permutation_when_nontrivial() {
+        // Swap the two LSBs by reversing the BE round order partially.
+        let poly_perm_be: Vec<usize> = vec![0, 1, 3, 2];
+        let coeffs_len = 1usize << poly_perm_be.len();
+        let perm = precommitted_sumcheck_inverse_index_permutation(coeffs_len, &poly_perm_be)
+            .expect("non-identity permutation expected for this input");
+        assert_eq!(perm.len(), coeffs_len);
+        let mut seen = vec![false; coeffs_len];
+        for (new_idx, &old_idx) in perm.iter().enumerate() {
+            assert!(
+                old_idx < coeffs_len,
+                "perm[{new_idx}] = {old_idx} is out of bounds for coeffs_len={coeffs_len}",
+            );
+            assert!(
+                !seen[old_idx],
+                "perm contains duplicate old_idx={old_idx} (at new_idx={new_idx})",
+            );
+            seen[old_idx] = true;
+        }
+    }
+}

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -37,11 +37,10 @@ use crate::{
             commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment},
             dory::{DoryGlobals, DoryLayout},
         },
-        eq_poly::EqPolynomial,
         multilinear_polynomial::MultilinearPolynomial,
         opening_proof::{
-            compute_advice_lagrange_factor, DoryOpeningState, OpeningAccumulator,
-            ProverOpeningAccumulator, SumcheckId,
+            compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningPoint,
+            ProverOpeningAccumulator, SumcheckId, BIG_ENDIAN,
         },
         rlc_polynomial::{RLCStreamingData, TraceSource},
     },
@@ -62,9 +61,9 @@ use crate::{
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
-            InstructionLookupsClaimReductionSumcheckProver, RaReductionParams,
-            RamRaClaimReductionSumcheckProver, RegistersClaimReductionSumcheckParams,
-            RegistersClaimReductionSumcheckProver,
+            InstructionLookupsClaimReductionSumcheckProver, PrecommittedPolynomial,
+            RaReductionParams, RamRaClaimReductionSumcheckProver,
+            RegistersClaimReductionSumcheckParams, RegistersClaimReductionSumcheckProver,
         },
         config::OneHotParams,
         instruction_lookups::{
@@ -275,6 +274,96 @@ impl<
             trusted_advice_hint,
             final_memory_state,
         )
+    }
+
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.trace.len().log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
+            trace_log_t + log_k_chunk,
+            self.preprocessing.shared.precommitted_candidate_total_vars(
+                false,
+                !self.program_io.trusted_advice.is_empty(),
+                !self.program_io.untrusted_advice.is_empty(),
+            ),
+        )
+    }
+
+    fn stage8_opening_point(&self) -> OpeningPoint<BIG_ENDIAN, F> {
+        let native_main_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
+        let mut opening_candidates: Vec<(&'static str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("trusted_advice", point));
+        }
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("untrusted_advice", point));
+        }
+
+        let max_len = opening_candidates
+            .iter()
+            .map(|(_, point)| point.r.len())
+            .max()
+            .unwrap_or(0);
+        if max_len > native_main_vars {
+            let dominant = opening_candidates
+                .iter()
+                .find(|(_, point)| point.r.len() == max_len)
+                .expect("at least one dominant precommitted candidate expected");
+            for (name, point) in opening_candidates
+                .iter()
+                .filter(|(_, point)| point.r.len() == max_len)
+            {
+                assert_eq!(
+                    point.r, dominant.1.r,
+                    "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
+                    dominant.0, name, max_len
+                );
+            }
+            return OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone());
+        }
+
+        let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::InstructionRa(0),
+            SumcheckId::HammingWeightClaimReduction,
+        );
+        let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+        let r_cycle_stage6 = self
+            .opening_accumulator
+            .get_committed_polynomial_opening(
+                CommittedPolynomial::RamInc,
+                SumcheckId::IncClaimReduction,
+            )
+            .0
+            .r;
+
+        match DoryGlobals::get_layout() {
+            DoryLayout::AddressMajor => OpeningPoint::<BIG_ENDIAN, F>::new(
+                [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+            ),
+            DoryLayout::CycleMajor => {
+                let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                assert!(
+                    r_cycle_stage6.len() >= native_cycle.len(),
+                    "stage6 cycle challenges shorter than native cycle vars"
+                );
+                assert!(
+                    r_cycle_stage6[..native_cycle.len()] == *native_cycle,
+                    "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars"
+                );
+                let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat(),
+                )
+            }
+        }
     }
 
     /// Adjusts the padded trace length to ensure the main Dory matrix is large enough
@@ -673,29 +762,27 @@ impl<
         Vec<PCS::Commitment>,
         HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
     ) {
-        let _guard = DoryGlobals::initialize_context(
+        let main_total_vars = self.main_total_vars();
+        let trace = Arc::clone(&self.trace);
+        let _guard = DoryGlobals::initialize_main_with_log_embedding(
             1 << self.one_hot_params.log_k_chunk,
-            self.padded_trace_len,
-            DoryContext::Main,
+            trace.len(),
+            main_total_vars,
             Some(DoryGlobals::get_layout()),
         );
 
         let polys = all_committed_polynomials(&self.one_hot_params);
-        let T = DoryGlobals::get_T();
+        let T = DoryGlobals::get_embedded_t();
 
-        // For AddressMajor, use non-streaming commit path since streaming assumes CycleMajor layout
-        let (commitments, hint_map) = if DoryGlobals::get_layout() == DoryLayout::AddressMajor {
+        // AddressMajor uses non-streaming commit path, and we also use non-streaming when
+        // the Stage 8 embedding domain exceeds the trace domain.
+        let use_materialized_commit =
+            DoryGlobals::get_layout() == DoryLayout::AddressMajor || self.trace.len() != T;
+        let (commitments, hint_map) = if use_materialized_commit {
             tracing::debug!(
-                "Using non-streaming commit path for AddressMajor layout with {} polynomials",
+                "Using non-streaming commit path with {} polynomials",
                 polys.len()
             );
-
-            // Materialize the trace for non-streaming commit
-            let trace: Vec<Cycle> = self
-                .lazy_trace
-                .clone()
-                .pad_using(T, |_| Cycle::NoOp)
-                .collect();
 
             // Generate witnesses and commit using the regular (non-streaming) path
             let (commitments, hints): (Vec<_>, Vec<_>) = polys
@@ -1938,70 +2025,71 @@ impl<
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
-        let _guard = DoryGlobals::initialize_context(
+        let _guard = DoryGlobals::initialize_main_with_log_embedding(
             self.one_hot_params.k_chunk,
             self.padded_trace_len,
-            DoryContext::Main,
+            self.main_total_vars(),
             Some(DoryGlobals::get_layout()),
         );
 
-        // Get the unified opening point from HammingWeightClaimReduction
-        // This contains (r_address_stage7 || r_cycle_stage6) in big-endian
-        let (opening_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::InstructionRa(0),
-            SumcheckId::HammingWeightClaimReduction,
-        );
-
-        let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let r_address_stage7 = &opening_point.r[..log_k_chunk];
+        let opening_point = self.stage8_opening_point();
 
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();
+        let mut precommitted_polys: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>> =
+            HashMap::new();
 
         // Dense polynomials: RamInc and RdInc (from IncClaimReduction in Stage 6)
         // at r_cycle_stage6 only (length log_T)
-        let (_, ram_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RamInc,
-            SumcheckId::IncClaimReduction,
-        );
-        let (_, rd_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RdInc,
-            SumcheckId::IncClaimReduction,
-        );
+        let (ram_inc_point, ram_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RamInc,
+                SumcheckId::IncClaimReduction,
+            );
+        let (rd_inc_point, rd_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RdInc,
+                SumcheckId::IncClaimReduction,
+            );
 
-        // Dense polynomials are zero-padded in the Dory matrix, so their evaluation
-        // includes a factor eq(r_addr, 0) = ∏(1 − r_addr_i).
-        let lagrange_factor: F = EqPolynomial::zero_selector(r_address_stage7);
-        polynomial_claims.push((CommittedPolynomial::RamInc, ram_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
-        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
+        let ram_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ram_inc_point.r);
+        let rd_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &rd_inc_point.r);
+        polynomial_claims.push((
+            CommittedPolynomial::RamInc,
+            ram_inc_claim * ram_inc_lagrange,
+        ));
+        scaling_factors.push(ram_inc_lagrange);
+        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * rd_inc_lagrange));
+        scaling_factors.push(rd_inc_lagrange);
 
         // Sparse polynomials: all RA polys (from HammingWeightClaimReduction)
         // These are at (r_address_stage7, r_cycle_stage6)
         for i in 0..self.one_hot_params.instruction_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::InstructionRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.bytecode_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::BytecodeRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.ram_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RamRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
 
         // Advice polynomials: TrustedAdvice and UntrustedAdvice (from AdviceClaimReduction in Stage 6)
@@ -2016,8 +2104,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::TrustedAdvice,
                 advice_claim * lagrange_factor,
@@ -2033,8 +2120,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::UntrustedAdvice,
                 advice_claim * lagrange_factor,
@@ -2084,13 +2170,18 @@ impl<
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 
-        // Build advice polynomials map for RLC
-        let mut advice_polys = HashMap::new();
+        // Add advice polynomials to precommitted polynomials map for RLC.
         if let Some(poly) = self.advice.trusted_advice_polynomial.take() {
-            advice_polys.insert(CommittedPolynomial::TrustedAdvice, poly);
+            precommitted_polys.insert(
+                CommittedPolynomial::TrustedAdvice,
+                PrecommittedPolynomial::Dense(poly),
+            );
         }
         if let Some(poly) = self.advice.untrusted_advice_polynomial.take() {
-            advice_polys.insert(CommittedPolynomial::UntrustedAdvice, poly);
+            precommitted_polys.insert(
+                CommittedPolynomial::UntrustedAdvice,
+                PrecommittedPolynomial::Dense(poly),
+            );
         }
 
         // Build streaming RLC polynomial directly (no witness poly regeneration!)
@@ -2100,7 +2191,7 @@ impl<
             TraceSource::Materialized(Arc::clone(&self.trace)),
             streaming_data,
             opening_proof_hints,
-            advice_polys,
+            precommitted_polys,
         );
 
         let (proof, _y_blinding) = PCS::prove(

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryGlobals, DoryLayout};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -80,12 +80,9 @@ use crate::zkvm::{
 };
 use crate::{
     field::JoltField,
-    poly::{
-        eq_poly::EqPolynomial,
-        opening_proof::{
-            compute_advice_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId,
-            SumcheckId, VerifierOpeningAccumulator,
-        },
+    poly::opening_proof::{
+        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, OpeningPoint,
+        SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN,
     },
     pprof_scope,
     subprotocols::{
@@ -260,6 +257,99 @@ impl<
         ProofTranscript: Transcript,
     > JoltVerifier<'a, F, C, PCS, ProofTranscript>
 {
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.proof.trace_length.log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
+            trace_log_t + log_k_chunk,
+            self.preprocessing.shared.precommitted_candidate_total_vars(
+                false,
+                self.trusted_advice_commitment.is_some(),
+                self.proof.untrusted_advice_commitment.is_some(),
+            ),
+        )
+    }
+
+    fn stage8_opening_point(&self) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
+        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("trusted_advice", point));
+        }
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("untrusted_advice", point));
+        }
+
+        let max_len = opening_candidates
+            .iter()
+            .map(|(_, point)| point.r.len())
+            .max()
+            .unwrap_or(0);
+        if max_len > native_main_vars {
+            let dominant = opening_candidates
+                .iter()
+                .find(|(_, point)| point.r.len() == max_len)
+                .expect("at least one dominant precommitted candidate expected");
+            for (name, point) in opening_candidates
+                .iter()
+                .filter(|(_, point)| point.r.len() == max_len)
+            {
+                if point.r != dominant.1.r {
+                    return Err(ProofVerifyError::DoryError(format!(
+                        "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
+                        dominant.0, name, max_len
+                    )));
+                }
+            }
+            return Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()));
+        }
+
+        let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::InstructionRa(0),
+            SumcheckId::HammingWeightClaimReduction,
+        );
+        let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+        let r_cycle_stage6 = self
+            .opening_accumulator
+            .get_committed_polynomial_opening(
+                CommittedPolynomial::RamInc,
+                SumcheckId::IncClaimReduction,
+            )
+            .0
+            .r;
+
+        match self.proof.dory_layout {
+            DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
+                [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+            )),
+            DoryLayout::CycleMajor => {
+                let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                if r_cycle_stage6.len() < native_cycle.len() {
+                    return Err(ProofVerifyError::DoryError(
+                        "stage6 cycle challenges shorter than native cycle vars".to_string(),
+                    ));
+                }
+                if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
+                    return Err(ProofVerifyError::DoryError(
+                        "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars"
+                            .to_string(),
+                    ));
+                }
+                let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat(),
+                ))
+            }
+        }
+    }
+
     pub fn new(
         preprocessing: &'a JoltVerifierPreprocessing<F, C, PCS>,
         proof: JoltProof<F, C, PCS, ProofTranscript>,
@@ -424,10 +514,10 @@ impl<
 
         // Initialize DoryGlobals with the layout from the proof
         // This ensures the verifier uses the same layout as the prover
-        let _guard = DoryGlobals::initialize_context(
+        let _guard = DoryGlobals::initialize_main_with_log_embedding(
             1 << self.one_hot_params.log_k_chunk,
             self.proof.trace_length.next_power_of_two(),
-            DoryContext::Main,
+            self.main_total_vars(),
             Some(self.proof.dory_layout),
         );
 
@@ -1503,61 +1593,61 @@ impl<
 
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        // Get the unified opening point from HammingWeightClaimReduction
-        // This contains (r_address_stage7 || r_cycle_stage6) in big-endian
-        let (opening_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::InstructionRa(0),
-            SumcheckId::HammingWeightClaimReduction,
-        );
-        let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let r_address_stage7 = &opening_point.r[..log_k_chunk];
+        let opening_point = self.stage8_opening_point()?;
 
         // 1. Collect all (polynomial, claim) pairs
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();
 
         // Dense polynomials: RamInc and RdInc (from IncClaimReduction in Stage 6)
-        let (_, ram_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RamInc,
-            SumcheckId::IncClaimReduction,
-        );
-        let (_, rd_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RdInc,
-            SumcheckId::IncClaimReduction,
-        );
+        let (ram_inc_point, ram_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RamInc,
+                SumcheckId::IncClaimReduction,
+            );
+        let (rd_inc_point, rd_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RdInc,
+                SumcheckId::IncClaimReduction,
+            );
 
-        // Dense polynomials are zero-padded in the Dory matrix, so their evaluation
-        // includes a factor eq(r_addr, 0) = ∏(1 − r_addr_i).
-        let lagrange_factor: F = EqPolynomial::zero_selector(r_address_stage7);
-        polynomial_claims.push((CommittedPolynomial::RamInc, ram_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
-        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
+        let ram_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ram_inc_point.r);
+        let rd_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &rd_inc_point.r);
+        polynomial_claims.push((
+            CommittedPolynomial::RamInc,
+            ram_inc_claim * ram_inc_lagrange,
+        ));
+        scaling_factors.push(ram_inc_lagrange);
+        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * rd_inc_lagrange));
+        scaling_factors.push(rd_inc_lagrange);
 
         // Sparse polynomials: all RA polys (from HammingWeightClaimReduction)
         for i in 0..self.one_hot_params.instruction_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::InstructionRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.bytecode_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::BytecodeRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.ram_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RamRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
 
         // Advice polynomials: TrustedAdvice and UntrustedAdvice (from AdviceClaimReduction in Stage 6)
@@ -1570,8 +1660,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::TrustedAdvice,
                 advice_claim * lagrange_factor,
@@ -1584,8 +1673,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::UntrustedAdvice,
                 advice_claim * lagrange_factor,
@@ -1949,6 +2037,18 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
         candidates
     }
 
+    #[inline]
+    pub(crate) fn max_total_vars_from_candidates(
+        main_total_vars: usize,
+        candidates: impl IntoIterator<Item = usize>,
+    ) -> usize {
+        let mut max_total_vars = main_total_vars;
+        for total_vars in candidates {
+            max_total_vars = max_total_vars.max(total_vars);
+        }
+        max_total_vars
+    }
+
     pub(crate) fn compute_max_total_vars(&self, include_committed: bool) -> (usize, usize) {
         use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
 
@@ -1959,16 +2059,12 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
         } else {
             8
         };
-        let main_total_vars = max_log_k_chunk + max_log_T;
-        let precommitted_total_vars = self
-            .precommitted_candidate_total_vars(include_committed, true, true)
-            .into_iter()
-            .max()
-            .unwrap_or(0);
-        (
-            main_total_vars.max(precommitted_total_vars),
-            max_log_k_chunk,
-        )
+        let max_total_vars = Self::max_total_vars_from_candidates(
+            max_log_k_chunk + max_log_T,
+            self.precommitted_candidate_total_vars(include_committed, true, true),
+        );
+
+        (max_total_vars, max_log_k_chunk)
     }
 }
 

--- a/jolt-sdk/src/host_utils.rs
+++ b/jolt-sdk/src/host_utils.rs
@@ -27,7 +27,7 @@ pub use jolt_core::AdviceTape;
 
 // Re-exports needed by the provable macro
 pub use jolt_core::poly::commitment::commitment_scheme::CommitmentScheme;
-pub use jolt_core::poly::commitment::dory::{DoryContext, DoryGlobals};
+pub use jolt_core::poly::commitment::dory::{DoryContext, DoryGlobals, DoryLayout};
 pub use jolt_core::poly::multilinear_polynomial::MultilinearPolynomial;
 pub use jolt_core::zkvm::ram::populate_memory_states;
 pub use jolt_core::zkvm::verifier::BlindfoldSetup;


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.

Stack position: `03`
Base branch: `stack/02-committed-preprocessing-model`
Source implementation reference: `LayerZero-Research/amir/bytecode-commitment-merged@a351d5078b83577db8f3264fa53dfaddcf5ed687`

Owned paths:
```
jolt-core/src/poly/commitment/dory jolt-core/src/poly/opening_proof.rs jolt-core/src/poly/rlc_polynomial.rs jolt-core/src/poly/one_hot_polynomial.rs jolt-core/src/zkvm/claim_reductions/precommitted.rs jolt-core/src/zkvm/claim_reductions/mod.rs jolt-core/src/zkvm/prover.rs jolt-core/src/zkvm/verifier.rs jolt-sdk/src/host_utils.rs
```

See `specs/1344-committed-bytecode-program-image.md` for the slice checklist and verification expectations.
