### PR TITLE
refactor: split stage 6 into full-mode phases

### DIFF
--- a/jolt-core/src/subprotocols/booleanity.rs
+++ b/jolt-core/src/subprotocols/booleanity.rs
@@ -1,12 +1,11 @@
-//! Booleanity Sumcheck
+//! Booleanity Sumcheck (split into address/cycle phases)
 //!
-//! This module implements a single booleanity sumcheck that handles all three families:
-//! - Instruction RA polynomials
-//! - Bytecode RA polynomials  
-//! - RAM RA polynomials
+//! This module implements Stage 6 booleanity as two explicit sumcheck instances:
+//! - Address phase (`log_k_chunk` rounds)
+//! - Cycle phase (`log_t` rounds)
 //!
-//! By combining them into a single sumcheck, all families share the same `r_address` and `r_cycle`,
-//! which is required by the HammingWeightClaimReduction sumcheck in Stage 7.
+//! Both phases still batch all three families together (InstructionRA, BytecodeRA, RAMRA),
+//! so they share the same `r_address` and `r_cycle`, matching what Stage 7 claim reductions expect.
 //!
 //! ## Sumcheck Relation
 //!
@@ -42,7 +41,7 @@ use crate::{
             AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint,
             ProverOpeningAccumulator, SumcheckId, BIG_ENDIAN,
         },
-        shared_ra_polys::{compute_all_G_and_ra_indices, RaIndices, SharedRaPolynomials},
+        shared_ra_polys::{compute_all_G, compute_ra_indices, SharedRaPolynomials},
         split_eq_poly::GruenSplitEqPolynomial,
         unipoly::UniPoly,
     },
@@ -51,7 +50,7 @@ use crate::{
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{expanding_table::ExpandingTable, thread::drop_in_background_thread},
+    utils::expanding_table::ExpandingTable,
     zkvm::{
         bytecode::BytecodePreprocessing,
         config::OneHotParams,
@@ -82,82 +81,6 @@ pub struct BooleanitySumcheckParams<F: JoltField> {
     pub polynomial_types: Vec<CommittedPolynomial>,
     /// OneHotParams for SharedRaPolynomials
     pub one_hot_params: OneHotParams,
-}
-
-impl<F: JoltField> SumcheckInstanceParams<F> for BooleanitySumcheckParams<F> {
-    fn degree(&self) -> usize {
-        DEGREE_BOUND
-    }
-
-    fn num_rounds(&self) -> usize {
-        self.log_k_chunk + self.log_t
-    }
-
-    fn input_claim(&self, _accumulator: &dyn OpeningAccumulator<F>) -> F {
-        F::zero()
-    }
-
-    fn normalize_opening_point(
-        &self,
-        sumcheck_challenges: &[F::Challenge],
-    ) -> OpeningPoint<BIG_ENDIAN, F> {
-        let mut opening_point = sumcheck_challenges.to_vec();
-        opening_point[..self.log_k_chunk].reverse();
-        opening_point[self.log_k_chunk..].reverse();
-        opening_point.into()
-    }
-
-    #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> InputClaimConstraint {
-        InputClaimConstraint::default()
-    }
-
-    #[cfg(feature = "zk")]
-    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
-        Vec::new()
-    }
-
-    #[cfg(feature = "zk")]
-    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        let n = self.polynomial_types.len();
-
-        let mut terms = Vec::with_capacity(2 * n);
-        for (i, poly_type) in self.polynomial_types.iter().enumerate() {
-            let opening = OpeningId::committed(*poly_type, SumcheckId::Booleanity);
-
-            terms.push(ProductTerm::scaled(
-                ValueSource::Challenge(2 * i),
-                vec![ValueSource::Opening(opening), ValueSource::Opening(opening)],
-            ));
-            terms.push(ProductTerm::scaled(
-                ValueSource::Challenge(2 * i + 1),
-                vec![ValueSource::Opening(opening)],
-            ));
-        }
-
-        Some(OutputClaimConstraint::sum_of_products(terms))
-    }
-
-    #[cfg(feature = "zk")]
-    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        let combined_r: Vec<F::Challenge> = self
-            .r_address
-            .iter()
-            .cloned()
-            .rev()
-            .chain(self.r_cycle.iter().cloned().rev())
-            .collect();
-
-        let eq_eval: F = EqPolynomial::<F>::mle(sumcheck_challenges, &combined_r);
-
-        let mut challenges = Vec::with_capacity(2 * self.polynomial_types.len());
-        for gamma_2i in &self.gamma_powers_square {
-            let coeff = eq_eval * *gamma_2i;
-            challenges.push(coeff);
-            challenges.push(-coeff);
-        }
-        challenges
-    }
 }
 
 impl<F: JoltField> BooleanitySumcheckParams<F> {
@@ -191,19 +114,9 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
         // NOTE: `stage5_point.r` is stored in BIG_ENDIAN format (each segment was reversed by
         // `normalize_opening_point`). For internal eq evaluations we want LowToHigh (LE) order
         // because `GruenSplitEqPolynomial` is instantiated with `BindingOrder::LowToHigh`.
-        debug_assert!(
-            stage5_point.r.len() == log_k_instruction + log_t,
-            "InstructionReadRaf opening point length mismatch: got {}, expected {} (= log_k_instruction {} + log_t {})",
-            stage5_point.r.len(),
-            log_k_instruction + log_t,
-            log_k_instruction,
-            log_t
-        );
-
         // Address segment: BE -> LE
         let mut stage5_addr = stage5_point.r[..log_k_instruction].to_vec();
         stage5_addr.reverse();
-
         // Cycle segment: BE -> LE
         let mut r_cycle = stage5_point.r[log_k_instruction..].to_vec();
         r_cycle.reverse();
@@ -261,105 +174,102 @@ impl<F: JoltField> BooleanitySumcheckParams<F> {
             one_hot_params: one_hot_params.clone(),
         }
     }
+
+    fn combined_r_big_endian(&self) -> Vec<F::Challenge> {
+        self.r_address
+            .iter()
+            .cloned()
+            .rev()
+            .chain(self.r_cycle.iter().cloned().rev())
+            .collect()
+    }
 }
 
-/// Booleanity Sumcheck Prover.
+fn compute_gamma_powers<F: JoltField>(gamma: F::Challenge, count: usize) -> (Vec<F>, Vec<F>) {
+    let gamma_f: F = gamma.into();
+    let mut powers = Vec::with_capacity(count);
+    let mut powers_inv = Vec::with_capacity(count);
+    let mut rho_i = F::one();
+    for _ in 0..count {
+        powers.push(rho_i);
+        powers_inv.push(rho_i.inverse().expect("gamma powers are nonzero"));
+        rho_i *= gamma_f;
+    }
+    (powers, powers_inv)
+}
+
+/// Booleanity address-phase prover.
 #[derive(Allocative)]
-pub struct BooleanitySumcheckProver<F: JoltField> {
-    /// Per-polynomial powers γ^i (in the base field).
-    /// Used to pre-scale the address eq tables for phase 2.
-    gamma_powers: Vec<F>,
-    /// Per-polynomial inverse powers γ^{-i} (in the base field).
-    /// Used to unscale cached committed-polynomial openings.
-    gamma_powers_inv: Vec<F>,
+pub struct BooleanityAddressSumcheckProver<F: JoltField> {
     /// B: split-eq over address-chunk variables (phase 1, LowToHigh).
     B: GruenSplitEqPolynomial<F>,
-    /// D: split-eq over time/cycle variables (phase 2, LowToHigh).
-    D: GruenSplitEqPolynomial<F>,
-    /// G[i][k] = Σ_j eq(r_cycle, j) · ra_i(k, j) for all RA polynomials
+    /// G[i][k] = Σ_j eq(r_cycle, j) · ra_i(k, j) for all RA polynomials.
     G: Vec<Vec<F>>,
-    /// Shared H polynomials for phase 2 (initialized at transition)
-    H: Option<SharedRaPolynomials<F>>,
-    /// F: Expanding table for phase 1
+    /// F: Expanding table over address bits for phase 1.
     F: ExpandingTable<F>,
-    /// eq(r_address, r_address) at end of phase 1
-    eq_r_r: F,
-    /// RA indices (non-transposed, one per cycle)
-    ra_indices: Vec<RaIndices>,
-    pub params: BooleanitySumcheckParams<F>,
+    /// Most recent round polynomial, used to cache the address-phase output claim.
+    last_round_poly: Option<UniPoly<F>>,
+    /// Output claim after the final address round (input claim for cycle phase).
+    address_claim: Option<F>,
+    /// Address-only `SumcheckInstanceParams` wrapper.
+    params: BooleanityAddressPhaseParams<F>,
 }
 
-impl<F: JoltField> BooleanitySumcheckProver<F> {
-    /// Initialize a BooleanitySumcheckProver with all three families.
+impl<F: JoltField> BooleanityAddressSumcheckProver<F> {
+    /// Initialize the address-phase prover.
     ///
-    /// All heavy computation is done here:
-    /// - Compute G polynomials and RA indices in a single pass over the trace
-    /// - Initialize split-eq polynomials for address (B) and cycle (D) variables
-    /// - Initialize expanding table for phase 1
-    #[tracing::instrument(skip_all, name = "BooleanitySumcheckProver::initialize")]
+    /// Heavy precomputation for this phase happens here:
+    /// - Compute all G-polynomial slices from the trace
+    /// - Initialize the address split-eq polynomial (`B`)
+    /// - Initialize the address expanding table (`F`)
     pub fn initialize(
         params: BooleanitySumcheckParams<F>,
         trace: &[Cycle],
         bytecode: &BytecodePreprocessing,
         memory_layout: &MemoryLayout,
     ) -> Self {
-        // Compute G and RA indices in a single pass over the trace
-        let (G, ra_indices) = compute_all_G_and_ra_indices::<F>(
+        let G = compute_all_G::<F>(
             trace,
             bytecode,
             memory_layout,
             &params.one_hot_params,
             &params.r_cycle,
         );
-
-        // Initialize split-eq polynomials for address and cycle variables
         let B = GruenSplitEqPolynomial::new(&params.r_address, BindingOrder::LowToHigh);
-        let D = GruenSplitEqPolynomial::new(&params.r_cycle, BindingOrder::LowToHigh);
-
-        // Initialize expanding table for phase 1
         let k_chunk = 1 << params.log_k_chunk;
         let mut F_table = ExpandingTable::new(k_chunk, BindingOrder::LowToHigh);
         F_table.reset(F::one());
 
-        // Compute prover-only fields: gamma_powers (γ^i) and gamma_powers_inv (γ^{-i})
-        let num_polys = params.polynomial_types.len();
-        let gamma_f: F = params.gamma.into();
-        let mut gamma_powers = Vec::with_capacity(num_polys);
-        let mut gamma_powers_inv = Vec::with_capacity(num_polys);
-        let mut rho_i = F::one();
-        for _ in 0..num_polys {
-            gamma_powers.push(rho_i);
-            gamma_powers_inv.push(
-                rho_i
-                    .inverse()
-                    .expect("gamma_powers[i] is nonzero (gamma != 0)"),
-            );
-            rho_i *= gamma_f;
-        }
-
         Self {
-            gamma_powers,
-            gamma_powers_inv,
             B,
-            D,
             G,
-            ra_indices,
-            H: None,
             F: F_table,
-            eq_r_r: F::zero(),
-            params,
+            last_round_poly: None,
+            address_claim: None,
+            params: BooleanityAddressPhaseParams::new(params),
         }
     }
 
-    fn compute_phase1_message(&self, round: usize, previous_claim: F) -> UniPoly<F> {
-        let m = round + 1;
-        let B = &self.B;
-        let N = self.params.polynomial_types.len();
+    pub fn into_params(self) -> BooleanitySumcheckParams<F> {
+        self.params.into_inner()
+    }
+}
 
-        // Compute quadratic coefficients via generic split-eq fold
-        let quadratic_coeffs: [F; DEGREE_BOUND - 1] = B
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for BooleanityAddressSumcheckProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        let m = round + 1;
+        let n = self.params.common.polynomial_types.len();
+        // Compute quadratic coefficients via split-eq folding over the unbound address suffix.
+        let quadratic_coeffs: [F; DEGREE_BOUND - 1] = self
+            .B
             .par_fold_out_in_unreduced::<{ DEGREE_BOUND - 1 }>(&|k_prime| {
-                let coeffs = (0..N)
+                (0..n)
                     .into_par_iter()
                     .map(|i| {
                         let G_i = &self.G[i];
@@ -370,7 +280,6 @@ impl<F: JoltField> BooleanitySumcheckProver<F> {
                                 let k_m = k >> (m - 1);
                                 let F_k = self.F[k & ((1 << (m - 1)) - 1)];
                                 let G_times_F = G_k * F_k;
-
                                 let eval_infty = G_times_F * F_k;
                                 let eval_0 = if k_m == 0 {
                                     eval_infty - G_times_F
@@ -393,7 +302,7 @@ impl<F: JoltField> BooleanitySumcheckProver<F> {
                                 |running, new| [running[0] + new[0], running[1] + new[1]],
                             );
 
-                        let gamma_2i = self.params.gamma_powers_square[i];
+                        let gamma_2i = self.params.common.gamma_powers_square[i];
                         [
                             gamma_2i * F::reduce_mul_u64(inner_sum[0]),
                             gamma_2i * F::reduce_mul_u64(inner_sum[1]),
@@ -402,29 +311,135 @@ impl<F: JoltField> BooleanitySumcheckProver<F> {
                     .reduce(
                         || [F::zero(); DEGREE_BOUND - 1],
                         |running, new| [running[0] + new[0], running[1] + new[1]],
-                    );
-                coeffs
+                    )
             });
 
-        B.gruen_poly_deg_3(quadratic_coeffs[0], quadratic_coeffs[1], previous_claim)
+        let poly =
+            self.B
+                .gruen_poly_deg_3(quadratic_coeffs[0], quadratic_coeffs[1], previous_claim);
+        self.last_round_poly = Some(poly.clone());
+        poly
     }
 
-    fn compute_phase2_message(&self, _round: usize, previous_claim: F) -> UniPoly<F> {
-        let D = &self.D;
-        let H = self.H.as_ref().expect("H should be initialized in phase 2");
-        let num_polys = H.num_polys();
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        if let Some(poly) = self.last_round_poly.take() {
+            let claim = poly.evaluate(&r_j);
+            if round == self.params.common.log_k_chunk - 1 {
+                self.address_claim = Some(claim);
+            }
+        }
+        self.B.bind(r_j);
+        self.F.update(r_j);
+    }
 
-        // Compute quadratic coefficients via generic split-eq fold (handles both E_in cases).
-        let quadratic_coeffs: [F; DEGREE_BOUND - 1] = D
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        // Cache the intermediate address-phase claim used as input to cycle phase.
+        let mut r_address = sumcheck_challenges.to_vec();
+        r_address.reverse();
+        accumulator.append_virtual(
+            VirtualPolynomial::BooleanityAddrClaim,
+            SumcheckId::BooleanityAddressPhase,
+            OpeningPoint::<BIG_ENDIAN, F>::new(r_address),
+            self.address_claim
+                .expect("Booleanity address-phase claim missing"),
+        );
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+/// Booleanity cycle-phase prover.
+#[derive(Allocative)]
+pub struct BooleanityCycleSumcheckProver<F: JoltField> {
+    /// D: split-eq over cycle variables (phase 2, LowToHigh).
+    D: GruenSplitEqPolynomial<F>,
+    /// Shared RA polynomials, pre-scaled for batched cycle-phase accumulation.
+    H: SharedRaPolynomials<F>,
+    /// eq(r_address, r_address), carried from address-phase binding.
+    eq_r_r: F,
+    /// Per-polynomial powers γ^i used for pre-scaling.
+    gamma_powers: Vec<F>,
+    /// Per-polynomial inverse powers γ^{-i} used to unscale cached openings.
+    gamma_powers_inv: Vec<F>,
+    /// Cycle-only `SumcheckInstanceParams` wrapper.
+    params: BooleanityCyclePhaseParams<F>,
+}
+
+impl<F: JoltField> BooleanityCycleSumcheckProver<F> {
+    /// Initialize cycle-phase state from the cached address-phase opening.
+    pub fn initialize(
+        params: BooleanityCyclePhaseParams<F>,
+        trace: &[Cycle],
+        bytecode: &BytecodePreprocessing,
+        memory_layout: &MemoryLayout,
+    ) -> Self {
+        let (eq_r_r, base_eq) = Self::compute_bound_address_eq_and_table(&params);
+
+        let ra_indices = compute_ra_indices(
+            trace,
+            bytecode,
+            memory_layout,
+            &params.common.one_hot_params,
+        );
+        let num_polys = params.common.polynomial_types.len();
+        let (gamma_powers, gamma_powers_inv) = compute_gamma_powers(params.common.gamma, num_polys);
+        let tables: Vec<Vec<F>> = (0..num_polys)
+            .into_par_iter()
+            .map(|i| {
+                let rho = gamma_powers[i];
+                base_eq.iter().map(|v| rho * *v).collect()
+            })
+            .collect();
+
+        Self {
+            D: GruenSplitEqPolynomial::new(&params.common.r_cycle, BindingOrder::LowToHigh),
+            H: SharedRaPolynomials::new(tables, ra_indices, params.common.one_hot_params.clone()),
+            eq_r_r,
+            gamma_powers,
+            gamma_powers_inv,
+            params,
+        }
+    }
+
+    fn compute_bound_address_eq_and_table(params: &BooleanityCyclePhaseParams<F>) -> (F, Vec<F>) {
+        let mut B = GruenSplitEqPolynomial::new(&params.common.r_address, BindingOrder::LowToHigh);
+        let k_chunk = 1 << params.common.log_k_chunk;
+        let mut F_table = ExpandingTable::new(k_chunk, BindingOrder::LowToHigh);
+        F_table.reset(F::one());
+        for r_j in params.r_address_low_to_high.iter().copied() {
+            B.bind(r_j);
+            F_table.update(r_j);
+        }
+        (B.get_current_scalar(), F_table.clone_values())
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for BooleanityCycleSumcheckProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn compute_message(&mut self, _round: usize, previous_claim: F) -> UniPoly<F> {
+        let num_polys = self.H.num_polys();
+        let quadratic_coeffs: [F; DEGREE_BOUND - 1] = self
+            .D
             .par_fold_out_in_unreduced::<{ DEGREE_BOUND - 1 }>(&|j_prime| {
-                // Accumulate in unreduced form to minimize per-term reductions
+                // Accumulate in unreduced form to minimize per-term reductions.
                 let mut acc_c = F::UnreducedProductAccum::zero();
                 let mut acc_e = F::UnreducedProductAccum::zero();
                 for i in 0..num_polys {
-                    let h_0 = H.get_bound_coeff(i, 2 * j_prime);
-                    let h_1 = H.get_bound_coeff(i, 2 * j_prime + 1);
+                    let h_0 = self.H.get_bound_coeff(i, 2 * j_prime);
+                    let h_1 = self.H.get_bound_coeff(i, 2 * j_prime + 1);
                     let b = h_1 - h_0;
-
                     // Phase-2 optimization: H is pre-scaled by rho_i = gamma^i, so gamma^{2i}
                     // factors are already accounted for:
                     //   gamma^{2i}*h0*(h0-1) = (rho*h0) * (rho*h0 - rho)
@@ -438,76 +453,17 @@ impl<F: JoltField> BooleanitySumcheckProver<F> {
                     F::reduce_product_accum(acc_e),
                 ]
             });
-
         // previous_claim is s(0)+s(1) of the scaled polynomial; divide out eq_r_r to get inner claim
         let adjusted_claim = previous_claim * self.eq_r_r.inverse().unwrap();
         let gruen_poly =
-            D.gruen_poly_deg_3(quadratic_coeffs[0], quadratic_coeffs[1], adjusted_claim);
-
+            self.D
+                .gruen_poly_deg_3(quadratic_coeffs[0], quadratic_coeffs[1], adjusted_claim);
         gruen_poly * self.eq_r_r
     }
-}
 
-impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BooleanitySumcheckProver<F> {
-    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        &self.params
-    }
-
-    #[tracing::instrument(skip_all, name = "BooleanitySumcheckProver::compute_message")]
-    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
-        if round < self.params.log_k_chunk {
-            self.compute_phase1_message(round, previous_claim)
-        } else {
-            self.compute_phase2_message(round, previous_claim)
-        }
-    }
-
-    #[tracing::instrument(skip_all, name = "BooleanitySumcheckProver::ingest_challenge")]
-    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
-        if round < self.params.log_k_chunk {
-            // Phase 1: Bind B and update F
-            self.B.bind(r_j);
-            self.F.update(r_j);
-
-            // Transition to phase 2
-            if round == self.params.log_k_chunk - 1 {
-                self.eq_r_r = self.B.get_current_scalar();
-
-                // Initialize SharedRaPolynomials with per-poly pre-scaled eq tables (by rho_i)
-                let F_table = std::mem::take(&mut self.F);
-                let ra_indices = std::mem::take(&mut self.ra_indices);
-                let base_eq = F_table.clone_values();
-                let num_polys = self.params.polynomial_types.len();
-                debug_assert!(
-                    num_polys == self.gamma_powers.len(),
-                    "gamma_powers length mismatch: got {}, expected {}",
-                    self.gamma_powers.len(),
-                    num_polys
-                );
-                let tables: Vec<Vec<F>> = (0..num_polys)
-                    .into_par_iter()
-                    .map(|i| {
-                        let rho = self.gamma_powers[i];
-                        base_eq.iter().map(|v| rho * *v).collect()
-                    })
-                    .collect();
-                self.H = Some(SharedRaPolynomials::new(
-                    tables,
-                    ra_indices,
-                    self.params.one_hot_params.clone(),
-                ));
-
-                // Drop G arrays
-                let g = std::mem::take(&mut self.G);
-                drop_in_background_thread(g);
-            }
-        } else {
-            // Phase 2: Bind D and H
-            self.D.bind(r_j);
-            if let Some(ref mut h) = self.H {
-                h.bind_in_place(r_j, BindingOrder::LowToHigh);
-            }
-        }
+    fn ingest_challenge(&mut self, r_j: F::Challenge, _round: usize) {
+        self.D.bind(r_j);
+        self.H.bind_in_place(r_j, BindingOrder::LowToHigh);
     }
 
     fn cache_openings(
@@ -516,19 +472,15 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BooleanitySum
         sumcheck_challenges: &[F::Challenge],
     ) {
         let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
-        let H = self.H.as_ref().expect("H should be initialized");
         // H is scaled by rho_i; unscale so cached openings match the committed polynomials.
-        let claims: Vec<F> = (0..H.num_polys())
-            .map(|i| H.final_sumcheck_claim(i) * self.gamma_powers_inv[i])
+        let claims: Vec<F> = (0..self.H.num_polys())
+            .map(|i| self.H.final_sumcheck_claim(i) * self.gamma_powers_inv[i])
             .collect();
-
-        // All polynomials share the same opening point (r_address, r_cycle)
-        // Use a single SumcheckId for all
         accumulator.append_sparse(
-            self.params.polynomial_types.clone(),
+            self.params.common.polynomial_types.clone(),
             SumcheckId::Booleanity,
-            opening_point.r[..self.params.log_k_chunk].to_vec(),
-            opening_point.r[self.params.log_k_chunk..].to_vec(),
+            opening_point.r[..self.params.common.log_k_chunk].to_vec(),
+            opening_point.r[self.params.common.log_k_chunk..].to_vec(),
             claims,
         );
     }
@@ -539,27 +491,78 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BooleanitySum
     }
 }
 
-/// Booleanity Sumcheck Verifier.
-pub struct BooleanitySumcheckVerifier<F: JoltField> {
-    params: BooleanitySumcheckParams<F>,
+/// Booleanity address-phase verifier.
+pub struct BooleanityAddressSumcheckVerifier<F: JoltField> {
+    params: BooleanityAddressPhaseParams<F>,
 }
 
-impl<F: JoltField> BooleanitySumcheckVerifier<F> {
+impl<F: JoltField> BooleanityAddressSumcheckVerifier<F> {
     pub fn new(params: BooleanitySumcheckParams<F>) -> Self {
-        Self { params }
+        Self {
+            params: BooleanityAddressPhaseParams::new(params),
+        }
+    }
+
+    pub fn into_params(self) -> BooleanitySumcheckParams<F> {
+        self.params.into_inner()
     }
 }
 
 impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
-    SumcheckInstanceVerifier<F, T, A> for BooleanitySumcheckVerifier<F>
+    SumcheckInstanceVerifier<F, T, A> for BooleanityAddressSumcheckVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, _sumcheck_challenges: &[F::Challenge]) -> F {
+        accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::BooleanityAddrClaim,
+                SumcheckId::BooleanityAddressPhase,
+            )
+            .1
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let mut r_address = sumcheck_challenges.to_vec();
+        r_address.reverse();
+        accumulator.append_virtual(
+            VirtualPolynomial::BooleanityAddrClaim,
+            SumcheckId::BooleanityAddressPhase,
+            OpeningPoint::<BIG_ENDIAN, F>::new(r_address),
+        );
+    }
+}
+
+/// Booleanity cycle-phase verifier.
+pub struct BooleanityCycleSumcheckVerifier<F: JoltField> {
+    params: BooleanityCyclePhaseParams<F>,
+}
+
+impl<F: JoltField> BooleanityCycleSumcheckVerifier<F> {
+    pub fn new(
+        params: BooleanitySumcheckParams<F>,
+        opening_accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Self {
+        Self {
+            params: BooleanityCyclePhaseParams::new(params, opening_accumulator),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for BooleanityCycleSumcheckVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params
     }
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let full_challenges = self.params.full_challenges(sumcheck_challenges);
         let ra_claims: Vec<F> = self
             .params
+            .common
             .polynomial_types
             .iter()
             .map(|poly_type| {
@@ -568,28 +571,183 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                     .1
             })
             .collect();
-
-        let combined_r: Vec<F::Challenge> = self
-            .params
-            .r_address
-            .iter()
-            .cloned()
-            .rev()
-            .chain(self.params.r_cycle.iter().cloned().rev())
-            .collect();
-
-        EqPolynomial::<F>::mle(sumcheck_challenges, &combined_r)
-            * zip(&self.params.gamma_powers_square, ra_claims)
-                .map(|(gamma_2i, ra)| (ra.square() - ra) * gamma_2i)
-                .sum::<F>()
+        EqPolynomial::<F>::mle(
+            &full_challenges,
+            &self.params.common.combined_r_big_endian(),
+        ) * zip(&self.params.common.gamma_powers_square, ra_claims)
+            .map(|(gamma_2i, ra)| (ra.square() - ra) * gamma_2i)
+            .sum::<F>()
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
         accumulator.append_sparse(
-            self.params.polynomial_types.clone(),
+            self.params.common.polynomial_types.clone(),
             SumcheckId::Booleanity,
             opening_point.r,
         );
+    }
+}
+
+#[derive(Allocative, Clone)]
+struct BooleanityAddressPhaseParams<F: JoltField> {
+    common: BooleanitySumcheckParams<F>,
+}
+
+impl<F: JoltField> BooleanityAddressPhaseParams<F> {
+    fn new(common: BooleanitySumcheckParams<F>) -> Self {
+        Self { common }
+    }
+
+    fn into_inner(self) -> BooleanitySumcheckParams<F> {
+        self.common
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BooleanityAddressPhaseParams<F> {
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.common.log_k_chunk
+    }
+
+    fn input_claim(&self, _accumulator: &dyn OpeningAccumulator<F>) -> F {
+        F::zero()
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        let mut r = challenges.to_vec();
+        r.reverse();
+        OpeningPoint::new(r)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::default()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        Some(OutputClaimConstraint::direct(OpeningId::virt(
+            VirtualPolynomial::BooleanityAddrClaim,
+            SumcheckId::BooleanityAddressPhase,
+        )))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        Vec::new()
+    }
+}
+#[derive(Allocative, Clone)]
+pub struct BooleanityCyclePhaseParams<F: JoltField> {
+    common: BooleanitySumcheckParams<F>,
+    r_address_low_to_high: Vec<F::Challenge>,
+}
+
+impl<F: JoltField> BooleanityCyclePhaseParams<F> {
+    pub fn new(
+        common: BooleanitySumcheckParams<F>,
+        opening_accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Self {
+        let (r_address_point, _) = opening_accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BooleanityAddrClaim,
+            SumcheckId::BooleanityAddressPhase,
+        );
+        let mut r_address_low_to_high = r_address_point.r;
+        r_address_low_to_high.reverse();
+
+        Self {
+            common,
+            r_address_low_to_high,
+        }
+    }
+
+    fn full_challenges(&self, cycle_challenges: &[F::Challenge]) -> Vec<F::Challenge> {
+        let mut full = self.r_address_low_to_high.clone();
+        full.extend_from_slice(cycle_challenges);
+        full
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BooleanityCyclePhaseParams<F> {
+    fn degree(&self) -> usize {
+        DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.common.log_t
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::BooleanityAddrClaim,
+                SumcheckId::BooleanityAddressPhase,
+            )
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        let mut opening_point = self.full_challenges(challenges);
+        opening_point[..self.common.log_k_chunk].reverse();
+        opening_point[self.common.log_k_chunk..].reverse();
+        opening_point.into()
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::direct(OpeningId::virt(
+            VirtualPolynomial::BooleanityAddrClaim,
+            SumcheckId::BooleanityAddressPhase,
+        ))
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let mut terms = Vec::with_capacity(2 * self.common.polynomial_types.len());
+        for (i, poly_type) in self.common.polynomial_types.iter().enumerate() {
+            let opening = OpeningId::committed(*poly_type, SumcheckId::Booleanity);
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(2 * i),
+                vec![ValueSource::Opening(opening), ValueSource::Opening(opening)],
+            ));
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(2 * i + 1),
+                vec![ValueSource::Opening(opening)],
+            ));
+        }
+        Some(OutputClaimConstraint::sum_of_products(terms))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let full = self.full_challenges(sumcheck_challenges);
+        let eq_eval: F = EqPolynomial::<F>::mle(&full, &self.common.combined_r_big_endian());
+        let mut challenges = Vec::with_capacity(2 * self.common.polynomial_types.len());
+        for gamma_2i in &self.common.gamma_powers_square {
+            let coeff = eq_eval * *gamma_2i;
+            challenges.push(coeff);
+            challenges.push(-coeff);
+        }
+        challenges
     }
 }

--- a/jolt-core/src/subprotocols/mod.rs
+++ b/jolt-core/src/subprotocols/mod.rs
@@ -10,7 +10,3 @@ pub mod sumcheck_claim;
 pub mod sumcheck_prover;
 pub mod sumcheck_verifier;
 pub mod univariate_skip;
-
-pub use booleanity::{
-    BooleanitySumcheckParams, BooleanitySumcheckProver, BooleanitySumcheckVerifier,
-};

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -124,11 +124,6 @@ impl BatchedSumcheck {
             let r_j = transcript.challenge_scalar_optimized::<F>();
             r_sumcheck.push(r_j);
 
-            individual_claims
-                .iter_mut()
-                .zip(univariate_polys)
-                .for_each(|(claim, poly)| *claim = poly.evaluate(&r_j));
-
             #[cfg(test)]
             {
                 // Sanity check
@@ -141,6 +136,11 @@ impl BatchedSumcheck {
                 );
                 batched_claim = batched_univariate_poly.evaluate(&r_j);
             }
+
+            individual_claims
+                .iter_mut()
+                .zip(univariate_polys)
+                .for_each(|(claim, poly)| *claim = poly.evaluate(&r_j));
 
             for sumcheck in sumcheck_instances.iter_mut() {
                 let num_rounds = sumcheck.num_rounds();

--- a/jolt-core/src/zkvm/bytecode/chunks.rs
+++ b/jolt-core/src/zkvm/bytecode/chunks.rs
@@ -30,31 +30,24 @@ pub const fn committed_lanes() -> usize {
 pub const DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 1;
 pub const MAX_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 256;
 
-#[inline]
-pub fn validate_committed_bytecode_chunk_count(chunk_count: usize) {
-    assert!(chunk_count > 0, "bytecode chunk count must be non-zero");
-    assert!(
-        chunk_count <= MAX_COMMITTED_BYTECODE_CHUNK_COUNT,
-        "bytecode chunk count must be at most {MAX_COMMITTED_BYTECODE_CHUNK_COUNT}"
-    );
-    assert!(
-        chunk_count.is_power_of_two(),
-        "bytecode chunk count must be a power of two"
-    );
-}
-
 #[inline(always)]
-pub fn validate_committed_bytecode_chunking_for_len(bytecode_len: usize, chunk_count: usize) {
-    validate_committed_bytecode_chunk_count(chunk_count);
-    assert!(
-        bytecode_len.is_multiple_of(chunk_count),
-        "bytecode length ({bytecode_len}) must be divisible by chunk count ({chunk_count})"
-    );
+pub fn is_valid_committed_bytecode_chunking_for_len(
+    bytecode_len: usize,
+    chunk_count: usize,
+) -> bool {
+    chunk_count > 0
+        && chunk_count <= MAX_COMMITTED_BYTECODE_CHUNK_COUNT
+        && chunk_count.is_power_of_two()
+        && bytecode_len.is_multiple_of(chunk_count)
 }
 
 #[inline(always)]
 pub fn committed_bytecode_chunk_cycle_len(bytecode_len: usize, chunk_count: usize) -> usize {
-    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
+    assert!(
+        is_valid_committed_bytecode_chunking_for_len(bytecode_len, chunk_count),
+        "bytecode chunk count ({chunk_count}) must be non-zero, a power of two, at most \
+         {MAX_COMMITTED_BYTECODE_CHUNK_COUNT}, and divide bytecode length ({bytecode_len})"
+    );
     bytecode_len / chunk_count
 }
 
@@ -161,8 +154,6 @@ pub fn build_committed_bytecode_chunk_coeffs<F: JoltField>(
     chunk_count: usize,
 ) -> Vec<Vec<F>> {
     let bytecode_len = instructions.len();
-    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
-
     let chunk_cycle_len = committed_bytecode_chunk_cycle_len(bytecode_len, chunk_count);
     let lane_capacity = committed_lanes();
     let mut chunk_coeffs: Vec<Vec<F>> = (0..chunk_count)

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -5,8 +5,7 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
 use crate::utils::math::Math;
 use crate::zkvm::bytecode::chunks::{
-    build_committed_bytecode_chunk_polynomials, committed_bytecode_chunk_cycle_len,
-    committed_lanes, validate_committed_bytecode_chunking_for_len,
+    build_committed_bytecode_chunk_polynomials, committed_bytecode_chunk_cycle_len, committed_lanes,
 };
 
 pub mod chunks;
@@ -38,7 +37,6 @@ impl<PCS: CommitmentScheme> TrustedBytecodeCommitments<PCS> {
         bytecode_chunk_count: usize,
     ) -> (Self, TrustedBytecodeHints<PCS>) {
         let bytecode_len = bytecode.code_size;
-        validate_committed_bytecode_chunking_for_len(bytecode_len, bytecode_chunk_count);
         let bytecode_T = committed_bytecode_chunk_cycle_len(bytecode_len, bytecode_chunk_count);
 
         let total_vars = bytecode_T.log_2() + committed_lanes().log_2();

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -1,4 +1,9 @@
-use std::{array, iter::once, sync::Arc};
+use std::{
+    array,
+    iter::once,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use num_traits::Zero;
 
@@ -10,6 +15,7 @@ use crate::subprotocols::blindfold::{
 };
 use crate::{
     field::JoltField,
+    poly::commitment::commitment_scheme::CommitmentScheme,
     poly::{
         eq_poly::EqPolynomial,
         identity_poly::IdentityPolynomial,
@@ -30,15 +36,19 @@ use crate::{
         sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier},
     },
     transcripts::Transcript,
-    utils::{math::Math, small_scalar::SmallScalar, thread::unsafe_allocate_zero_vec},
+    utils::{
+        errors::ProofVerifyError, math::Math, small_scalar::SmallScalar,
+        thread::unsafe_allocate_zero_vec,
+    },
     zkvm::{
         bytecode::BytecodePreprocessing,
-        config::OneHotParams,
+        config::{OneHotParams, ProgramMode},
         instruction::{
             CircuitFlags, Flags, InstructionFlags, InstructionLookup, InterleavedBitsMarker,
             NUM_CIRCUIT_FLAGS,
         },
         lookup_table::{LookupTables, NUM_LOOKUP_TABLES},
+        program::ProgramPreprocessing,
         witness::{CommittedPolynomial, VirtualPolynomial},
     },
 };
@@ -117,46 +127,26 @@ const N_STAGES: usize = 5;
 ///   in the Stage3 per-stage claim, then the stage itself is folded with an outer factor `γ^2`,
 ///   yielding the advertised `γ^6` overall.
 #[derive(Allocative)]
-pub struct BytecodeReadRafSumcheckProver<F: JoltField> {
+pub struct BytecodeReadRafAddressSumcheckProver<F: JoltField> {
     /// Per-stage address MLEs F_i(k) built from eq(r_cycle_stage_i, (chunk_index, j)),
     /// bound low-to-high during the address-binding phase.
     F: [MultilinearPolynomial<F>; N_STAGES],
-    /// Chunked RA polynomials over address variables (one per dimension `d`), used to form
-    /// the product ∏_i ra_i during the cycle-binding phase.
-    ra: Vec<RaPolynomial<u8, F>>,
-    /// Binding challenges for the first log_K variables of the sumcheck
-    r_address_prime: Vec<F::Challenge>,
-    /// Per-stage Gruen-split eq polynomials over cycle vars (low-to-high binding order).
-    gruen_eq_polys: [GruenSplitEqPolynomial<F>; N_STAGES],
     /// Previous-round claims s_i(0)+s_i(1) per stage, needed for degree-(d+1) univariate recovery.
     prev_round_claims: [F; N_STAGES],
     /// Round polynomials per stage for advancing to the next claim at r_j.
     prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
-    /// Final sumcheck claims of stage Val polynomials (with RAF Int folded where applicable).
-    bound_val_evals: Option<[F; N_STAGES]>,
     /// f_entry_trace[k] = Ra(k, 0): one-hot at PC of cycle 0 (from trace).
     f_entry_trace: MultilinearPolynomial<F>,
     /// f_entry_expected[k] = C(k): one-hot at entry_bytecode_index (from preprocessing).
     /// Product f_entry_trace * f_entry_expected = Ra(k,0) * C(k); sums to 1 iff PC[0] = entry_bytecode_index.
     f_entry_expected: MultilinearPolynomial<F>,
-    /// eq_zero(j) indicator (r_cycle = all zeros), used in the cycle phase.
-    gruen_eq_entry: GruenSplitEqPolynomial<F>,
-    /// f_entry_expected bound at r_addr after the address phase (cached for output claim).
-    bound_f_entry: Option<F>,
     /// Running entry claim over remaining free variables.
     prev_entry_claim: F,
     prev_entry_poly: Option<UniPoly<F>>,
-    /// Trace for computing PCs on the fly in init_log_t_rounds.
-    #[allocative(skip)]
-    trace: Arc<Vec<Cycle>>,
-    /// Bytecode preprocessing for computing PCs.
-    #[allocative(skip)]
-    bytecode_preprocessing: Arc<BytecodePreprocessing>,
-    pub params: BytecodeReadRafSumcheckParams<F>,
+    params: BytecodeReadRafAddressPhaseParams<F>,
 }
 
-impl<F: JoltField> BytecodeReadRafSumcheckProver<F> {
-    #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckProver::initialize")]
+impl<F: JoltField> BytecodeReadRafAddressSumcheckProver<F> {
     pub fn initialize(
         params: BytecodeReadRafSumcheckParams<F>,
         trace: Arc<Vec<Cycle>>,
@@ -305,11 +295,6 @@ impl<F: JoltField> BytecodeReadRafSumcheckProver<F> {
 
         let F = F.map(MultilinearPolynomial::from);
 
-        let gruen_eq_polys = params
-            .r_cycles
-            .each_ref()
-            .map(|r_cycle| GruenSplitEqPolynomial::new(r_cycle, BindingOrder::LowToHigh));
-
         let pc_0 = super::get_pc_for_cycle(&bytecode_preprocessing, &trace[0]);
         assert!(
             pc_0 < params.K,
@@ -330,120 +315,54 @@ impl<F: JoltField> BytecodeReadRafSumcheckProver<F> {
         f_entry_expected_vec[entry_bytecode_index] = F::one();
         let f_entry_expected = MultilinearPolynomial::from(f_entry_expected_vec);
 
-        // eq_zero(j) = ∏(1 - j_i): indicator for cycle j = 0. r_cycle = all zeros.
-        let r_cycle_zero = vec![F::Challenge::default(); params.log_T];
-        let gruen_eq_entry = GruenSplitEqPolynomial::new(&r_cycle_zero, BindingOrder::LowToHigh);
-
         Self {
             F,
             f_entry_trace,
             f_entry_expected,
-            gruen_eq_entry,
-            bound_f_entry: None,
             // Initial entry claim = Σ_k f_entry_trace[k] * f_entry_expected[k] = 1 for honest prover
             // (both one-hots at same index when PC[0] = entry_bytecode_index).
             prev_entry_claim: F::one(),
             prev_entry_poly: None,
-            ra: Vec::with_capacity(params.d),
-            r_address_prime: Vec::with_capacity(params.log_K),
-            gruen_eq_polys,
             prev_round_claims: claim_per_stage,
             prev_round_polys: None,
-            bound_val_evals: None,
-            trace,
-            bytecode_preprocessing,
-            params,
+            params: BytecodeReadRafAddressPhaseParams::new(params),
         }
     }
 
-    fn init_log_t_rounds(&mut self) {
-        let int_poly = self.params.int_poly.final_sumcheck_claim();
-
-        // We have a separate Val polynomial for each stage
-        // Additionally, for stages 1 and 3 we have an Int polynomial for RAF
-        // So we would have:
-        // Stage 1: gamma^0 * (Val_1 + gamma^5 * Int)
-        // Stage 2: gamma^1 * (Val_2)
-        // Stage 3: gamma^2 * (Val_3 + gamma^4 * Int)
-        // Stage 4: gamma^3 * (Val_4)
-        // Stage 5: gamma^4 * (Val_5)
-        // Which matches with the input claim:
-        // rv_1 + gamma * rv_2 + gamma^2 * rv_3 + gamma^3 * rv_4 + gamma^4 * rv_5 + gamma^5 * raf_1 + gamma^6 * raf_3
-        let bound_val_evals: [F; N_STAGES] = self
-            .params
-            .val_polys
-            .iter()
-            .zip([
-                int_poly * self.params.gamma_powers[5],
-                F::zero(),
-                int_poly * self.params.gamma_powers[4],
-                F::zero(),
-                F::zero(),
-            ])
-            .map(|(poly, int_poly)| poly.final_sumcheck_claim() + int_poly)
-            .collect::<Vec<F>>()
-            .try_into()
-            .unwrap();
-        self.bound_val_evals = Some(bound_val_evals);
-        self.params.bound_val_polys = Some(bound_val_evals);
-        self.params.bound_int_poly = Some(int_poly);
-
-        let bound_f_entry = self.f_entry_expected.final_sumcheck_claim();
-        self.bound_f_entry = Some(bound_f_entry);
-        self.params.bound_f_entry = Some(bound_f_entry);
-
-        // Reverse r_address_prime to get the correct order (it was built low-to-high)
-        let mut r_address = std::mem::take(&mut self.r_address_prime);
-        r_address.reverse();
-
-        self.F = array::from_fn(|_| MultilinearPolynomial::default());
-        self.f_entry_trace = MultilinearPolynomial::default();
-        self.f_entry_expected = MultilinearPolynomial::default();
-        self.params.val_polys = array::from_fn(|_| MultilinearPolynomial::default());
-        self.params.int_poly = IdentityPolynomial::new(0);
-
-        let r_address_chunks = self
-            .params
-            .one_hot_params
-            .compute_r_address_chunks::<F>(&r_address);
-
-        // Build RA polynomials by iterating over trace and computing PCs on the fly
-        self.ra = r_address_chunks
-            .iter()
-            .enumerate()
-            .map(|(i, r_address_chunk)| {
-                let ra_i: Vec<Option<u8>> = self
-                    .trace
-                    .par_iter()
-                    .map(|cycle| {
-                        let pc = super::get_pc_for_cycle(&self.bytecode_preprocessing, cycle);
-                        Some(self.params.one_hot_params.bytecode_pc_chunk(pc, i))
-                    })
-                    .collect();
-                RaPolynomial::new(Arc::new(ra_i), EqPolynomial::evals(r_address_chunk))
-            })
-            .collect();
-
-        // Drop trace and preprocessing - no longer needed after this
-        self.trace = Arc::new(Vec::new());
+    pub fn into_params(self) -> BytecodeReadRafSumcheckParams<F> {
+        let mut params = self.params.into_inner();
+        params.cycle_initial_round_claims = Some(self.prev_round_claims);
+        params.cycle_initial_entry_claim = Some(self.prev_entry_claim);
+        params
     }
 }
 
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
-    for BytecodeReadRafSumcheckProver<F>
+    for BytecodeReadRafAddressSumcheckProver<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params
     }
 
-    #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckProver::compute_message")]
-    fn compute_message(&mut self, round: usize, _previous_claim: F) -> UniPoly<F> {
-        if round < self.params.log_K {
-            const DEGREE: usize = 2;
+    fn degree(&self) -> usize {
+        self.params.degree()
+    }
 
-            // Evaluation at [0, 2] for each stage plus the entry term.
-            let (eval_per_stage, entry_evals): ([[F; DEGREE]; N_STAGES], [F; DEGREE]) =
-                (0..self.params.val_polys[0].len() / 2)
+    fn num_rounds(&self) -> usize {
+        self.params.log_K
+    }
+
+    fn input_claim(&self, accumulator: &ProverOpeningAccumulator<F>) -> F {
+        self.params.input_claim(accumulator)
+    }
+
+    fn compute_message(&mut self, round: usize, _previous_claim: F) -> UniPoly<F> {
+        debug_assert!(round < self.params.log_K);
+        const DEGREE: usize = 2;
+
+        // Evaluation at [0, 2] for each stage plus the entry term.
+        let (eval_per_stage, entry_evals): ([[F; DEGREE]; N_STAGES], [F; DEGREE]) =
+            (0..self.params.val_polys[0].len() / 2)
                 .into_par_iter()
                 .map(|i| {
                     let ra_evals = self.F.each_ref().map(|poly| {
@@ -501,135 +420,30 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
                     ),
                 );
 
-            let mut round_polys: [_; N_STAGES] = array::from_fn(|_| UniPoly::zero());
-            let mut agg_round_poly = UniPoly::zero();
+        let mut round_polys: [_; N_STAGES] = array::from_fn(|_| UniPoly::zero());
+        let mut agg_round_poly = UniPoly::zero();
 
-            for (stage, evals) in eval_per_stage.into_iter().enumerate() {
-                let [eval_at_0, eval_at_2] = evals;
-                let eval_at_1 = self.prev_round_claims[stage] - eval_at_0;
-                let round_poly = UniPoly::from_evals(&[eval_at_0, eval_at_1, eval_at_2]);
-                agg_round_poly += &(&round_poly * self.params.gamma_powers[stage]);
-                round_polys[stage] = round_poly;
-            }
-
-            let [entry_at_0, entry_at_2] = entry_evals;
-            let entry_at_1 = self.prev_entry_claim - entry_at_0;
-            let entry_round_poly = UniPoly::from_evals(&[entry_at_0, entry_at_1, entry_at_2]);
-            agg_round_poly += &(&entry_round_poly * self.params.entry_gamma);
-            self.prev_entry_poly = Some(entry_round_poly);
-
-            self.prev_round_polys = Some(round_polys);
-
-            agg_round_poly
-        } else {
-            let degree = <Self as SumcheckInstanceProver<F, T>>::degree(self);
-
-            let out_len = self.gruen_eq_polys[0].E_out_current().len();
-            let in_len = self.gruen_eq_polys[0].E_in_current().len();
-            let in_n_vars = in_len.log_2();
-
-            // Evaluations on [1, ..., degree - 2, inf] (for each stage + entry term).
-            let (mut evals_per_stage, mut entry_evals_raw): ([Vec<F>; N_STAGES], Vec<F>) = (0
-                ..out_len)
-                .into_par_iter()
-                .map(|j_hi| {
-                    let mut ra_eval_pairs = vec![(F::zero(), F::zero()); self.ra.len()];
-                    let mut ra_prod_evals = vec![F::zero(); degree - 1];
-                    let mut evals_per_stage: [_; N_STAGES] =
-                        array::from_fn(|_| vec![F::UnreducedProductAccum::zero(); degree - 1]);
-                    let mut entry_accum = vec![F::UnreducedProductAccum::zero(); degree - 1];
-
-                    for j_lo in 0..in_len {
-                        let j = j_lo + (j_hi << in_n_vars);
-
-                        for (i, ra_i) in self.ra.iter().enumerate() {
-                            let ra_i_eval_at_j_0 = ra_i.get_bound_coeff(j * 2);
-                            let ra_i_eval_at_j_1 = ra_i.get_bound_coeff(j * 2 + 1);
-                            ra_eval_pairs[i] = (ra_i_eval_at_j_0, ra_i_eval_at_j_1);
-                        }
-                        eval_linear_prod_assign(&ra_eval_pairs, &mut ra_prod_evals);
-
-                        for stage in 0..N_STAGES {
-                            let eq_in_eval = self.gruen_eq_polys[stage].E_in_current()[j_lo];
-                            for i in 0..degree - 1 {
-                                evals_per_stage[stage][i] +=
-                                    eq_in_eval.mul_to_product_accum(ra_prod_evals[i]);
-                            }
-                        }
-
-                        let eq_in_entry = self.gruen_eq_entry.E_in_current()[j_lo];
-                        for i in 0..degree - 1 {
-                            entry_accum[i] += eq_in_entry.mul_to_product_accum(ra_prod_evals[i]);
-                        }
-                    }
-
-                    let stage_evals = array::from_fn(|stage| {
-                        let eq_out_eval = self.gruen_eq_polys[stage].E_out_current()[j_hi];
-                        evals_per_stage[stage]
-                            .iter()
-                            .map(|v| eq_out_eval * F::reduce_product_accum(*v))
-                            .collect()
-                    });
-                    let eq_out_entry = self.gruen_eq_entry.E_out_current()[j_hi];
-                    let entry_evals: Vec<F> = entry_accum
-                        .iter()
-                        .map(|v| eq_out_entry * F::reduce_product_accum(*v))
-                        .collect();
-
-                    (stage_evals, entry_evals)
-                })
-                .reduce(
-                    || {
-                        (
-                            array::from_fn(|_| vec![F::zero(); degree - 1]),
-                            vec![F::zero(); degree - 1],
-                        )
-                    },
-                    |(a_stages, a_entry), (b_stages, b_entry)| {
-                        let stages = array::from_fn(|i| {
-                            zip_eq(&a_stages[i], &b_stages[i])
-                                .map(|(a, b)| *a + *b)
-                                .collect()
-                        });
-                        let entry: Vec<F> =
-                            zip_eq(&a_entry, &b_entry).map(|(a, b)| *a + *b).collect();
-                        (stages, entry)
-                    },
-                );
-
-            // Multiply by bound values.
-            let bound_val_evals = self.bound_val_evals.as_ref().unwrap();
-            for (stage, evals) in evals_per_stage.iter_mut().enumerate() {
-                evals.iter_mut().for_each(|v| *v *= bound_val_evals[stage]);
-            }
-            let bound_f_entry = self.bound_f_entry.unwrap();
-            entry_evals_raw.iter_mut().for_each(|v| *v *= bound_f_entry);
-
-            let mut round_polys: [_; N_STAGES] = array::from_fn(|_| UniPoly::zero());
-            let mut agg_round_poly = UniPoly::zero();
-
-            // Obtain round poly for each stage and perform RLC.
-            for (stage, evals) in evals_per_stage.iter().enumerate() {
-                let claim = self.prev_round_claims[stage];
-                let round_poly = self.gruen_eq_polys[stage].gruen_poly_from_evals(evals, claim);
-                agg_round_poly += &(&round_poly * self.params.gamma_powers[stage]);
-                round_polys[stage] = round_poly;
-            }
-
-            let entry_round_poly = self
-                .gruen_eq_entry
-                .gruen_poly_from_evals(&entry_evals_raw, self.prev_entry_claim);
-            agg_round_poly += &(&entry_round_poly * self.params.entry_gamma);
-            self.prev_entry_poly = Some(entry_round_poly);
-
-            self.prev_round_polys = Some(round_polys);
-
-            agg_round_poly
+        for (stage, evals) in eval_per_stage.into_iter().enumerate() {
+            let [eval_at_0, eval_at_2] = evals;
+            let eval_at_1 = self.prev_round_claims[stage] - eval_at_0;
+            let round_poly = UniPoly::from_evals(&[eval_at_0, eval_at_1, eval_at_2]);
+            agg_round_poly += &(&round_poly * self.params.gamma_powers[stage]);
+            round_polys[stage] = round_poly;
         }
+
+        let [entry_at_0, entry_at_2] = entry_evals;
+        let entry_at_1 = self.prev_entry_claim - entry_at_0;
+        let entry_round_poly = UniPoly::from_evals(&[entry_at_0, entry_at_1, entry_at_2]);
+        agg_round_poly += &(&entry_round_poly * self.params.entry_gamma);
+        self.prev_entry_poly = Some(entry_round_poly);
+
+        self.prev_round_polys = Some(round_polys);
+
+        agg_round_poly
     }
 
-    #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckProver::ingest_challenge")]
     fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        debug_assert!(round < self.params.log_K);
         if let Some(prev_round_polys) = self.prev_round_polys.take() {
             self.prev_round_claims = prev_round_polys.map(|poly| poly.evaluate(&r_j));
         }
@@ -637,34 +451,342 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
             self.prev_entry_claim = entry_poly.evaluate(&r_j);
         }
 
-        if round < self.params.log_K {
-            self.params
+        self.params
+            .val_polys
+            .iter_mut()
+            .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
+        self.params
+            .int_poly
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.F
+            .iter_mut()
+            .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
+        self.f_entry_trace
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.f_entry_expected
+            .bind_parallel(r_j, BindingOrder::LowToHigh);
+        if round == self.params.log_K - 1 {
+            let int_poly = self.params.int_poly.final_sumcheck_claim();
+            let staged_val_claims: [F; N_STAGES] = self
+                .params
                 .val_polys
-                .iter_mut()
-                .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
-            self.params
-                .int_poly
-                .bind_parallel(r_j, BindingOrder::LowToHigh);
-            self.F
-                .iter_mut()
-                .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
-            self.f_entry_trace
-                .bind_parallel(r_j, BindingOrder::LowToHigh);
-            self.f_entry_expected
-                .bind_parallel(r_j, BindingOrder::LowToHigh);
-            self.r_address_prime.push(r_j);
-            if round == self.params.log_K - 1 {
-                self.init_log_t_rounds();
-            }
-        } else {
-            self.ra
-                .iter_mut()
-                .for_each(|ra| ra.bind_parallel(r_j, BindingOrder::LowToHigh));
-            self.gruen_eq_polys
-                .iter_mut()
-                .for_each(|poly| poly.bind(r_j));
-            self.gruen_eq_entry.bind(r_j);
+                .iter()
+                .map(MultilinearPolynomial::final_sumcheck_claim)
+                .collect::<Vec<F>>()
+                .try_into()
+                .unwrap();
+
+            let bound_val_evals: [F; N_STAGES] = self
+                .params
+                .val_polys
+                .iter()
+                .zip([
+                    int_poly * self.params.gamma_powers[5],
+                    F::zero(),
+                    int_poly * self.params.gamma_powers[4],
+                    F::zero(),
+                    F::zero(),
+                ])
+                .map(|(poly, int_poly)| poly.final_sumcheck_claim() + int_poly)
+                .collect::<Vec<F>>()
+                .try_into()
+                .unwrap();
+            self.params.bound_val_polys = Some(bound_val_evals);
+            self.params.staged_val_claims = Some(staged_val_claims);
+            self.params.bound_f_entry = Some(self.f_entry_expected.final_sumcheck_claim());
         }
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let mut r_address = sumcheck_challenges.to_vec();
+        r_address.reverse();
+        let opening_point = OpeningPoint::<BIG_ENDIAN, F>::new(r_address);
+        let address_claim = self
+            .prev_round_claims
+            .iter()
+            .zip(self.params.gamma_powers.iter())
+            .take(N_STAGES)
+            .map(|(claim, gamma)| *claim * *gamma)
+            .sum::<F>()
+            + self.params.entry_gamma * self.prev_entry_claim;
+        accumulator.append_virtual(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+            opening_point.clone(),
+            address_claim,
+        );
+        if self.params.use_staged_val_claims {
+            let staged_val_claims = self
+                .params
+                .staged_val_claims
+                .as_ref()
+                .expect("staged val claims must be present in committed mode");
+            for stage in 0..N_STAGES {
+                accumulator.append_virtual(
+                    VirtualPolynomial::BytecodeValStage(stage),
+                    SumcheckId::BytecodeReadRafAddressPhase,
+                    opening_point.clone(),
+                    staged_val_claims[stage],
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+#[derive(Allocative)]
+pub struct BytecodeReadRafCycleSumcheckProver<F: JoltField> {
+    /// Chunked RA polynomials over address variables (one per dimension `d`), used to form
+    /// the product ∏_i ra_i during the cycle-binding phase.
+    ra: Vec<RaPolynomial<u8, F>>,
+    /// Per-stage Gruen-split eq polynomials over cycle vars (low-to-high binding order).
+    gruen_eq_polys: [GruenSplitEqPolynomial<F>; N_STAGES],
+    /// Previous-round claims s_i(0)+s_i(1) per stage, needed for degree-(d+1) univariate recovery.
+    prev_round_claims: [F; N_STAGES],
+    /// Round polynomials per stage for advancing to the next claim at r_j.
+    prev_round_polys: Option<[UniPoly<F>; N_STAGES]>,
+    /// Final sumcheck claims of stage Val polynomials (with RAF Int folded where applicable).
+    bound_val_evals: [F; N_STAGES],
+    /// eq_zero(j) indicator (r_cycle = all zeros), used in the cycle phase.
+    gruen_eq_entry: GruenSplitEqPolynomial<F>,
+    /// f_entry_expected bound at r_addr after the address phase.
+    bound_f_entry: F,
+    /// Running entry claim over remaining free variables.
+    prev_entry_claim: F,
+    prev_entry_poly: Option<UniPoly<F>>,
+    params: BytecodeReadRafCyclePhaseParams<F>,
+}
+
+impl<F: JoltField> BytecodeReadRafCycleSumcheckProver<F> {
+    #[tracing::instrument(skip_all, name = "BytecodeReadRafCycleSumcheckProver::initialize")]
+    pub fn initialize(
+        mut params: BytecodeReadRafSumcheckParams<F>,
+        trace: Arc<Vec<Cycle>>,
+        bytecode_preprocessing: Arc<BytecodePreprocessing>,
+        accumulator: &ProverOpeningAccumulator<F>,
+    ) -> Self {
+        let (r_address_point, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        );
+        let r_address = r_address_point.r;
+        let mut r_address_low_to_high = r_address.clone();
+        r_address_low_to_high.reverse();
+
+        let r_address_chunks = params
+            .one_hot_params
+            .compute_r_address_chunks::<F>(&r_address);
+        let ra = r_address_chunks
+            .iter()
+            .enumerate()
+            .map(|(i, r_address_chunk)| {
+                let ra_i: Vec<Option<u8>> = trace
+                    .par_iter()
+                    .map(|cycle| {
+                        let pc = super::get_pc_for_cycle(&bytecode_preprocessing, cycle);
+                        Some(params.one_hot_params.bytecode_pc_chunk(pc, i))
+                    })
+                    .collect();
+                RaPolynomial::new(Arc::new(ra_i), EqPolynomial::evals(r_address_chunk))
+            })
+            .collect::<Vec<_>>();
+
+        let gruen_eq_polys = params
+            .r_cycles
+            .each_ref()
+            .map(|r_cycle| GruenSplitEqPolynomial::new(r_cycle, BindingOrder::LowToHigh));
+
+        let r_cycle_zero = vec![F::Challenge::default(); params.log_T];
+        let gruen_eq_entry = GruenSplitEqPolynomial::new(&r_cycle_zero, BindingOrder::LowToHigh);
+
+        let bound_val_evals = params
+            .bound_val_polys
+            .take()
+            .expect("address phase must cache bound Val claims before cycle phase");
+        let bound_f_entry = params
+            .bound_f_entry
+            .take()
+            .expect("address phase must cache bound entry claim before cycle phase");
+        params.bound_val_polys = Some(bound_val_evals);
+        params.bound_f_entry = Some(bound_f_entry);
+        let prev_round_claims = params
+            .cycle_initial_round_claims
+            .take()
+            .expect("address phase must transfer cycle initial round claims before cycle phase");
+        let prev_entry_claim = params
+            .cycle_initial_entry_claim
+            .take()
+            .expect("address phase must transfer cycle initial entry claim before cycle phase");
+
+        Self {
+            ra,
+            gruen_eq_polys,
+            prev_round_claims,
+            prev_round_polys: None,
+            bound_val_evals,
+            gruen_eq_entry,
+            bound_f_entry,
+            prev_entry_claim,
+            prev_entry_poly: None,
+            params: BytecodeReadRafCyclePhaseParams::new(params, r_address_low_to_high),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for BytecodeReadRafCycleSumcheckProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn degree(&self) -> usize {
+        self.params.degree()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.params.log_T
+    }
+
+    fn input_claim(&self, accumulator: &ProverOpeningAccumulator<F>) -> F {
+        accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::BytecodeReadRafAddrClaim,
+                SumcheckId::BytecodeReadRafAddressPhase,
+            )
+            .1
+    }
+
+    fn compute_message(&mut self, _round: usize, _previous_claim: F) -> UniPoly<F> {
+        let degree = <Self as SumcheckInstanceProver<F, T>>::degree(self);
+
+        let out_len = self.gruen_eq_polys[0].E_out_current().len();
+        let in_len = self.gruen_eq_polys[0].E_in_current().len();
+        let in_n_vars = in_len.log_2();
+
+        // Evaluations on [1, ..., degree - 2, inf] (for each stage + entry term).
+        let (mut evals_per_stage, mut entry_evals_raw): ([Vec<F>; N_STAGES], Vec<F>) = (0..out_len)
+            .into_par_iter()
+            .map(|j_hi| {
+                let mut ra_eval_pairs = vec![(F::zero(), F::zero()); self.ra.len()];
+                let mut ra_prod_evals = vec![F::zero(); degree - 1];
+                let mut evals_per_stage: [_; N_STAGES] =
+                    array::from_fn(|_| vec![F::UnreducedProductAccum::zero(); degree - 1]);
+                let mut entry_accum = vec![F::UnreducedProductAccum::zero(); degree - 1];
+
+                for j_lo in 0..in_len {
+                    let j = j_lo + (j_hi << in_n_vars);
+
+                    for (i, ra_i) in self.ra.iter().enumerate() {
+                        let ra_i_eval_at_j_0 = ra_i.get_bound_coeff(j * 2);
+                        let ra_i_eval_at_j_1 = ra_i.get_bound_coeff(j * 2 + 1);
+                        ra_eval_pairs[i] = (ra_i_eval_at_j_0, ra_i_eval_at_j_1);
+                    }
+                    eval_linear_prod_assign(&ra_eval_pairs, &mut ra_prod_evals);
+
+                    for stage in 0..N_STAGES {
+                        let eq_in_eval = self.gruen_eq_polys[stage].E_in_current()[j_lo];
+                        for i in 0..degree - 1 {
+                            evals_per_stage[stage][i] +=
+                                eq_in_eval.mul_to_product_accum(ra_prod_evals[i]);
+                        }
+                    }
+
+                    let eq_in_entry = self.gruen_eq_entry.E_in_current()[j_lo];
+                    for i in 0..degree - 1 {
+                        entry_accum[i] += eq_in_entry.mul_to_product_accum(ra_prod_evals[i]);
+                    }
+                }
+
+                let stage_evals = array::from_fn(|stage| {
+                    let eq_out_eval = self.gruen_eq_polys[stage].E_out_current()[j_hi];
+                    evals_per_stage[stage]
+                        .iter()
+                        .map(|v| eq_out_eval * F::reduce_product_accum(*v))
+                        .collect()
+                });
+                let eq_out_entry = self.gruen_eq_entry.E_out_current()[j_hi];
+                let entry_evals: Vec<F> = entry_accum
+                    .iter()
+                    .map(|v| eq_out_entry * F::reduce_product_accum(*v))
+                    .collect();
+
+                (stage_evals, entry_evals)
+            })
+            .reduce(
+                || {
+                    (
+                        array::from_fn(|_| vec![F::zero(); degree - 1]),
+                        vec![F::zero(); degree - 1],
+                    )
+                },
+                |(a_stages, a_entry), (b_stages, b_entry)| {
+                    let stages = array::from_fn(|i| {
+                        zip_eq(&a_stages[i], &b_stages[i])
+                            .map(|(a, b)| *a + *b)
+                            .collect()
+                    });
+                    let entry: Vec<F> = zip_eq(&a_entry, &b_entry).map(|(a, b)| *a + *b).collect();
+                    (stages, entry)
+                },
+            );
+
+        // Multiply by bound values.
+        for (stage, evals) in evals_per_stage.iter_mut().enumerate() {
+            evals
+                .iter_mut()
+                .for_each(|v| *v *= self.bound_val_evals[stage]);
+        }
+        entry_evals_raw
+            .iter_mut()
+            .for_each(|v| *v *= self.bound_f_entry);
+
+        let mut round_polys: [_; N_STAGES] = array::from_fn(|_| UniPoly::zero());
+        let mut agg_round_poly = UniPoly::zero();
+
+        // Obtain round poly for each stage and perform RLC.
+        for (stage, evals) in evals_per_stage.iter().enumerate() {
+            let claim = self.prev_round_claims[stage];
+            let round_poly = self.gruen_eq_polys[stage].gruen_poly_from_evals(evals, claim);
+            agg_round_poly += &(&round_poly * self.params.gamma_powers[stage]);
+            round_polys[stage] = round_poly;
+        }
+
+        let entry_round_poly = self
+            .gruen_eq_entry
+            .gruen_poly_from_evals(&entry_evals_raw, self.prev_entry_claim);
+        agg_round_poly += &(&entry_round_poly * self.params.entry_gamma);
+        self.prev_entry_poly = Some(entry_round_poly);
+
+        self.prev_round_polys = Some(round_polys);
+
+        agg_round_poly
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        debug_assert!(round < self.params.log_T);
+        if let Some(prev_round_polys) = self.prev_round_polys.take() {
+            self.prev_round_claims = prev_round_polys.map(|poly| poly.evaluate(&r_j));
+        }
+        if let Some(entry_poly) = self.prev_entry_poly.take() {
+            self.prev_entry_claim = entry_poly.evaluate(&r_j);
+        }
+
+        self.ra
+            .iter_mut()
+            .for_each(|ra| ra.bind_parallel(r_j, BindingOrder::LowToHigh));
+        self.gruen_eq_polys
+            .iter_mut()
+            .for_each(|poly| poly.bind(r_j));
+        self.gruen_eq_entry.bind(r_j);
     }
 
     fn cache_openings(
@@ -698,41 +820,150 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
     }
 }
 
-pub struct BytecodeReadRafSumcheckVerifier<F: JoltField> {
-    params: BytecodeReadRafSumcheckParams<F>,
+pub struct BytecodeReadRafAddressSumcheckVerifier<F: JoltField> {
+    params: BytecodeReadRafAddressPhaseParams<F>,
 }
 
-impl<F: JoltField> BytecodeReadRafSumcheckVerifier<F> {
-    pub fn gen<A: AbstractVerifierOpeningAccumulator<F>>(
-        bytecode_preprocessing: &BytecodePreprocessing,
+impl<F: JoltField> BytecodeReadRafAddressSumcheckVerifier<F> {
+    pub fn new<PCS: CommitmentScheme>(
+        program: Option<&ProgramPreprocessing<PCS>>,
         n_cycle_vars: usize,
         one_hot_params: &OneHotParams,
-        opening_accumulator: &A,
+        opening_accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
-    ) -> Self {
-        Self {
-            params: BytecodeReadRafSumcheckParams::gen(
-                bytecode_preprocessing,
+        program_mode: ProgramMode,
+        entry_bytecode_index: usize,
+    ) -> Result<Self, ProofVerifyError> {
+        let params = match program_mode {
+            ProgramMode::Committed => BytecodeReadRafSumcheckParams::gen(
+                None::<&ProgramPreprocessing<PCS>>,
                 n_cycle_vars,
                 one_hot_params,
+                true,
+                Some(entry_bytecode_index),
                 opening_accumulator,
                 transcript,
             ),
-        }
+            ProgramMode::Full => BytecodeReadRafSumcheckParams::gen(
+                Some(program.ok_or_else(|| {
+                    ProofVerifyError::BytecodeTypeMismatch(
+                        "expected Full program preprocessing, got Committed".to_string(),
+                    )
+                })?),
+                n_cycle_vars,
+                one_hot_params,
+                false,
+                None,
+                opening_accumulator,
+                transcript,
+            ),
+        };
+        Ok(Self {
+            params: BytecodeReadRafAddressPhaseParams::new(params),
+        })
+    }
+
+    pub fn into_params(self) -> BytecodeReadRafSumcheckParams<F> {
+        self.params.into_inner()
     }
 }
 
 impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
-    SumcheckInstanceVerifier<F, T, A> for BytecodeReadRafSumcheckVerifier<F>
+    SumcheckInstanceVerifier<F, T, A> for BytecodeReadRafAddressSumcheckVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         &self.params
     }
 
+    fn degree(&self) -> usize {
+        self.params.degree()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.params.log_K
+    }
+
+    fn input_claim(&self, accumulator: &A) -> F {
+        self.params.input_claim(accumulator)
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, _sumcheck_challenges: &[F::Challenge]) -> F {
+        accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::BytecodeReadRafAddrClaim,
+                SumcheckId::BytecodeReadRafAddressPhase,
+            )
+            .1
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let mut r_address = sumcheck_challenges.to_vec();
+        r_address.reverse();
+        accumulator.append_virtual(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+            OpeningPoint::<BIG_ENDIAN, F>::new(r_address.clone()),
+        );
+        if self.params.use_staged_val_claims {
+            for stage in 0..N_STAGES {
+                accumulator.append_virtual(
+                    VirtualPolynomial::BytecodeValStage(stage),
+                    SumcheckId::BytecodeReadRafAddressPhase,
+                    OpeningPoint::<BIG_ENDIAN, F>::new(r_address.clone()),
+                );
+            }
+        }
+    }
+}
+
+pub struct BytecodeReadRafCycleSumcheckVerifier<F: JoltField> {
+    params: BytecodeReadRafCyclePhaseParams<F>,
+}
+
+impl<F: JoltField> BytecodeReadRafCycleSumcheckVerifier<F> {
+    pub fn new(
+        params: BytecodeReadRafSumcheckParams<F>,
+        opening_accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Self {
+        let (r_address_point, _) = opening_accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        );
+        let mut r_address_low_to_high = r_address_point.r;
+        r_address_low_to_high.reverse();
+        Self {
+            params: BytecodeReadRafCyclePhaseParams::new(params, r_address_low_to_high),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for BytecodeReadRafCycleSumcheckVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn degree(&self) -> usize {
+        self.params.degree()
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.params.log_T
+    }
+
+    fn input_claim(&self, accumulator: &A) -> F {
+        accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::BytecodeReadRafAddrClaim,
+                SumcheckId::BytecodeReadRafAddressPhase,
+            )
+            .1
+    }
+
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
         let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
         let (r_address_prime, r_cycle_prime) = opening_point.split_at(self.params.log_K);
-        // r_cycle is bound LowToHigh, so reverse
 
         let int_poly = self.params.int_poly.evaluate(&r_address_prime.r);
 
@@ -745,64 +976,58 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                 .1
         });
 
-        // We have a separate Val polynomial for each stage
-        // Additionally, for stages 1 and 3 we have an Int polynomial for RAF
-        // So we would have:
-        // Stage 1: gamma^0 * (Val_1 + gamma^5 * Int)
-        // Stage 2: gamma^1 * (Val_2)
-        // Stage 3: gamma^2 * (Val_3 + gamma^4 * Int)
-        // Stage 4: gamma^3 * (Val_4)
-        // Stage 5: gamma^4 * (Val_5)
-        // Which matches with the input claim:
-        // rv_1 + gamma * rv_2 + gamma^2 * rv_3 + gamma^3 * rv_4 + gamma^4 * rv_5 + gamma^5 * raf_1 + gamma^6 * raf_3
+        let stage_val_claim = |stage: usize| {
+            if self.params.use_staged_val_claims {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeValStage(stage),
+                        SumcheckId::BytecodeReadRafAddressPhase,
+                    )
+                    .1
+            } else {
+                self.params.val_polys[stage].evaluate(&r_address_prime.r)
+            }
+        };
+        let int_poly_contrib_by_stage = [
+            int_poly * self.params.gamma_powers[5],
+            F::zero(),
+            int_poly * self.params.gamma_powers[4],
+            F::zero(),
+            F::zero(),
+        ];
+
         let val = self
             .params
-            .val_polys
+            .r_cycles
             .iter()
-            .zip(&self.params.r_cycles)
             .zip(&self.params.gamma_powers)
-            .zip([
-                int_poly * self.params.gamma_powers[5], // RAF for Stage1
-                F::zero(),                              // There's no raf for Stage2
-                int_poly * self.params.gamma_powers[4], // RAF for Stage3
-                F::zero(),                              // There's no raf for Stage4
-                F::zero(),                              // There's no raf for Stage5
-            ])
-            .map(|(((val, r_cycle), gamma), int_poly)| {
-                (val.evaluate(&r_address_prime.r) + int_poly)
+            .zip(int_poly_contrib_by_stage)
+            .enumerate()
+            .map(|(stage, ((r_cycle, gamma), int_poly))| {
+                (stage_val_claim(stage) + int_poly)
                     * EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r)
                     * gamma
             })
             .sum::<F>();
 
-        // Entry constraint: γ_entry · eq(r_addr, entry_bits) · eq_zero(r_cycle).
-        // r_address_prime.r is MSB-first (after normalize_opening_point reversal),
-        // so entry_bits must also be MSB-first: entry_bits[j] = (e >> (log_K-1-j)) & 1.
-        let entry_f_at_r_addr = {
-            let log_k = self.params.log_K;
-            let e = self.params.entry_bytecode_index;
-            let entry_bits: Vec<F> = (0..log_k)
-                .map(|i| F::from_u64(((e >> (log_k - 1 - i)) & 1) as u64))
-                .collect();
-            EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r)
-        };
-        // eq_zero(r_cycle) = ∏_i (1 - r_cycle_prime.r[i])
-        let zeros: Vec<F::Challenge> = vec![F::Challenge::default(); r_cycle_prime.r.len()];
-        let eq_zero_at_r_cycle = EqPolynomial::<F>::mle(&zeros, &r_cycle_prime.r);
-        let entry_contrib = self.params.entry_gamma * entry_f_at_r_addr * eq_zero_at_r_cycle;
+        let entry_bits: Vec<F> = (0..self.params.log_K)
+            .map(|i| {
+                F::from_u64(
+                    ((self.params.entry_bytecode_index >> (self.params.log_K - 1 - i)) & 1) as u64,
+                )
+            })
+            .collect();
+        let entry_contrib = self.params.entry_gamma
+            * EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r)
+            * EqPolynomial::<F>::zero_selector(&r_cycle_prime.r);
 
         ra_claims.fold(val + entry_contrib, |running, ra_claim| running * ra_claim)
     }
 
-    fn cache_openings(
-        &self,
-        accumulator: &mut A,
-        sumcheck_challenges: &[<F as JoltField>::Challenge],
-    ) {
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
         let (r_address, r_cycle) = opening_point.split_at(self.params.log_K);
 
-        // Compute r_address_chunks with proper padding
         let r_address_chunks = self
             .params
             .one_hot_params
@@ -820,7 +1045,561 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 }
 
 #[derive(Allocative, Clone)]
+struct BytecodeReadRafCyclePhaseParams<F: JoltField> {
+    inner: BytecodeReadRafSumcheckParams<F>,
+    r_address_low_to_high: Vec<F::Challenge>,
+}
+
+impl<F: JoltField> BytecodeReadRafCyclePhaseParams<F> {
+    fn new(
+        inner: BytecodeReadRafSumcheckParams<F>,
+        r_address_low_to_high: Vec<F::Challenge>,
+    ) -> Self {
+        Self {
+            inner,
+            r_address_low_to_high,
+        }
+    }
+
+    fn full_challenges(&self, cycle_challenges: &[F::Challenge]) -> Vec<F::Challenge> {
+        let mut full = self.r_address_low_to_high.clone();
+        full.extend_from_slice(cycle_challenges);
+        full
+    }
+}
+
+impl<F: JoltField> Deref for BytecodeReadRafCyclePhaseParams<F> {
+    type Target = BytecodeReadRafSumcheckParams<F>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<F: JoltField> DerefMut for BytecodeReadRafCyclePhaseParams<F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafCyclePhaseParams<F> {
+    fn degree(&self) -> usize {
+        self.d + 1
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.inner.log_T
+    }
+
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        accumulator
+            .get_virtual_polynomial_opening(
+                VirtualPolynomial::BytecodeReadRafAddrClaim,
+                SumcheckId::BytecodeReadRafAddressPhase,
+            )
+            .1
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        let mut r = self.full_challenges(challenges);
+        r[0..self.log_K].reverse();
+        r[self.log_K..].reverse();
+        OpeningPoint::new(r)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        InputClaimConstraint::direct(OpeningId::virt(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        ))
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let ra_factors: Vec<ValueSource> = (0..self.d)
+            .map(|i| {
+                ValueSource::Opening(OpeningId::committed(
+                    CommittedPolynomial::BytecodeRa(i),
+                    SumcheckId::BytecodeReadRaf,
+                ))
+            })
+            .collect();
+
+        if self.use_staged_val_claims {
+            // In committed mode, verifier does not materialize stage Val polynomials.
+            // Encode output as:
+            //   ra_prod * (Σ_stage coeff_stage * ValStage(stage) + const_term)
+            // where coeff_stage / const_term are public challenge values.
+            let mut terms = Vec::with_capacity(N_STAGES + 1);
+            for stage in 0..N_STAGES {
+                let mut factors = ra_factors.clone();
+                factors.push(ValueSource::Opening(OpeningId::virt(
+                    VirtualPolynomial::BytecodeValStage(stage),
+                    SumcheckId::BytecodeReadRafAddressPhase,
+                )));
+                terms.push(ProductTerm::scaled(ValueSource::Challenge(stage), factors));
+            }
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(N_STAGES),
+                ra_factors,
+            ));
+            Some(OutputClaimConstraint::sum_of_products(terms))
+        } else {
+            let terms = vec![ProductTerm::scaled(ValueSource::Challenge(0), ra_factors)];
+            Some(OutputClaimConstraint::sum_of_products(terms))
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let opening_point = self.normalize_opening_point(sumcheck_challenges);
+        let (r_address_prime, r_cycle_prime) = opening_point.split_at(self.log_K);
+
+        if self.use_staged_val_claims {
+            let int_poly = self.int_poly.evaluate(&r_address_prime.r);
+            let eq_cycles: Vec<F> = self
+                .r_cycles
+                .iter()
+                .map(|r_cycle| EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r))
+                .collect();
+
+            let mut coeffs: Vec<F> = (0..N_STAGES)
+                .map(|stage| self.gamma_powers[stage] * eq_cycles[stage])
+                .collect();
+
+            let int_poly_contrib_by_stage = [
+                int_poly * self.gamma_powers[5], // RAF for Stage1
+                F::zero(),
+                int_poly * self.gamma_powers[4], // RAF for Stage3
+                F::zero(),
+                F::zero(),
+            ];
+            let int_contrib: F = (0..N_STAGES)
+                .map(|stage| {
+                    int_poly_contrib_by_stage[stage] * eq_cycles[stage] * self.gamma_powers[stage]
+                })
+                .sum();
+
+            let log_k = self.log_K;
+            let e = self.entry_bytecode_index;
+            let entry_bits: Vec<F> = (0..log_k)
+                .map(|i| F::from_u64(((e >> (log_k - 1 - i)) & 1) as u64))
+                .collect();
+            let f_entry_at_r_addr = EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r);
+            let zeros: Vec<F::Challenge> = vec![F::Challenge::default(); r_cycle_prime.r.len()];
+            let eq_zero_at_r_cycle = EqPolynomial::<F>::mle(&zeros, &r_cycle_prime.r);
+            let entry_contrib = self.entry_gamma * f_entry_at_r_addr * eq_zero_at_r_cycle;
+
+            coeffs.push(int_contrib + entry_contrib);
+            return coeffs;
+        }
+
+        // Prover stores bound values before clearing polys; verifier evaluates directly.
+        let val: F = if let Some(bound_val_polys) = &self.bound_val_polys {
+            bound_val_polys
+                .iter()
+                .zip(&self.r_cycles)
+                .zip(&self.gamma_powers)
+                .map(|((bound_val, r_cycle), gamma)| {
+                    *bound_val * EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r) * gamma
+                })
+                .sum()
+        } else {
+            let int_poly = self.int_poly.evaluate(&r_address_prime.r);
+            self.val_polys
+                .iter()
+                .zip(&self.r_cycles)
+                .zip(&self.gamma_powers)
+                .zip([
+                    int_poly * self.gamma_powers[5],
+                    F::zero(),
+                    int_poly * self.gamma_powers[4],
+                    F::zero(),
+                    F::zero(),
+                ])
+                .map(|(((val, r_cycle), gamma), int_poly_contrib)| {
+                    (val.evaluate(&r_address_prime.r) + int_poly_contrib)
+                        * EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r)
+                        * gamma
+                })
+                .sum()
+        };
+
+        let f_entry_at_r_addr = if let Some(v) = self.bound_f_entry {
+            v
+        } else {
+            let log_k = self.log_K;
+            let e = self.entry_bytecode_index;
+            let entry_bits: Vec<F> = (0..log_k)
+                .map(|i| F::from_u64(((e >> (log_k - 1 - i)) & 1) as u64))
+                .collect();
+            EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r)
+        };
+        // eq_zero(r_cycle) = ∏_i (1 - r_cycle_prime.r[i])
+        let zeros: Vec<F::Challenge> = vec![F::Challenge::default(); r_cycle_prime.r.len()];
+        let eq_zero_at_r_cycle = EqPolynomial::<F>::mle(&zeros, &r_cycle_prime.r);
+        let entry_contrib = self.entry_gamma * f_entry_at_r_addr * eq_zero_at_r_cycle;
+
+        vec![val + entry_contrib]
+    }
+}
+
+#[derive(Allocative, Clone)]
+struct BytecodeReadRafAddressPhaseParams<F: JoltField> {
+    inner: BytecodeReadRafSumcheckParams<F>,
+}
+
+impl<F: JoltField> BytecodeReadRafAddressPhaseParams<F> {
+    fn new(inner: BytecodeReadRafSumcheckParams<F>) -> Self {
+        Self { inner }
+    }
+
+    fn into_inner(self) -> BytecodeReadRafSumcheckParams<F> {
+        self.inner
+    }
+}
+
+impl<F: JoltField> Deref for BytecodeReadRafAddressPhaseParams<F> {
+    type Target = BytecodeReadRafSumcheckParams<F>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<F: JoltField> DerefMut for BytecodeReadRafAddressPhaseParams<F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafAddressPhaseParams<F> {
+    fn degree(&self) -> usize {
+        self.d + 1
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.inner.log_K
+    }
+
+    fn input_claim(&self, _accumulator: &dyn OpeningAccumulator<F>) -> F {
+        self.input_claim
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        let mut r = challenges.to_vec();
+        r.reverse();
+        OpeningPoint::new(r)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        // input_claim = Σᵢ gamma_powers[i] * rv_claim_i + gamma_powers[5]*raf_claim + gamma_powers[6]*raf_shift_claim
+        // Each rv_claim_i = Σⱼ stage_i_gamma[j] * opening_ij
+        let mut terms = Vec::new();
+        let mut challenge_idx = 0;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::UnexpandedPC,
+                SumcheckId::SpartanOuter,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::Imm,
+                SumcheckId::SpartanOuter,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        for flag in CircuitFlags::iter() {
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(challenge_idx),
+                vec![ValueSource::Opening(OpeningId::virt(
+                    VirtualPolynomial::OpFlags(flag),
+                    SumcheckId::SpartanOuter,
+                ))],
+            ));
+            challenge_idx += 1;
+        }
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::OpFlags(CircuitFlags::Jump),
+                SumcheckId::SpartanProductVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionFlags(InstructionFlags::Branch),
+                SumcheckId::SpartanProductVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::OpFlags(CircuitFlags::WriteLookupOutputToRD),
+                SumcheckId::SpartanProductVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::OpFlags(CircuitFlags::VirtualInstruction),
+                SumcheckId::SpartanProductVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::Imm,
+                SumcheckId::InstructionInputVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        // UnexpandedPC is split between SpartanShift and InstructionInputVirtualization.
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::UnexpandedPC,
+                SumcheckId::SpartanShift,
+            ))],
+        ));
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::UnexpandedPC,
+                SumcheckId::InstructionInputVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionFlags(InstructionFlags::LeftOperandIsRs1Value),
+                SumcheckId::InstructionInputVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionFlags(InstructionFlags::LeftOperandIsPC),
+                SumcheckId::InstructionInputVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionFlags(InstructionFlags::RightOperandIsRs2Value),
+                SumcheckId::InstructionInputVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionFlags(InstructionFlags::RightOperandIsImm),
+                SumcheckId::InstructionInputVirtualization,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionFlags(InstructionFlags::IsNoop),
+                SumcheckId::SpartanShift,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::OpFlags(CircuitFlags::VirtualInstruction),
+                SumcheckId::SpartanShift,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::OpFlags(CircuitFlags::IsFirstInSequence),
+                SumcheckId::SpartanShift,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::RdWa,
+                SumcheckId::RegistersReadWriteChecking,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::Rs1Ra,
+                SumcheckId::RegistersReadWriteChecking,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::Rs2Ra,
+                SumcheckId::RegistersReadWriteChecking,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::RdWa,
+                SumcheckId::RegistersValEvaluation,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::InstructionRafFlag,
+                SumcheckId::InstructionReadRaf,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        for i in 0..NUM_LOOKUP_TABLES {
+            terms.push(ProductTerm::scaled(
+                ValueSource::Challenge(challenge_idx),
+                vec![ValueSource::Opening(OpeningId::virt(
+                    VirtualPolynomial::LookupTableFlag(i),
+                    SumcheckId::InstructionReadRaf,
+                ))],
+            ));
+            challenge_idx += 1;
+        }
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::PC,
+                SumcheckId::SpartanOuter,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![ValueSource::Opening(OpeningId::virt(
+                VirtualPolynomial::PC,
+                SumcheckId::SpartanShift,
+            ))],
+        ));
+        challenge_idx += 1;
+
+        // Entry constraint: +γ_entry (constant term, no polynomial factors).
+        terms.push(ProductTerm::scaled(
+            ValueSource::Challenge(challenge_idx),
+            vec![],
+        ));
+
+        InputClaimConstraint::sum_of_products(terms)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(
+        &self,
+        _accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Vec<F> {
+        let mut challenges = Vec::new();
+
+        for g in &self.stage1_gammas {
+            challenges.push(self.gamma_powers[0] * *g);
+        }
+
+        for g in &self.stage2_gammas {
+            challenges.push(self.gamma_powers[1] * *g);
+        }
+
+        challenges.push(self.gamma_powers[2] * self.stage3_gammas[0]);
+        let half = F::from_u64(2).inverse().unwrap();
+        challenges.push(self.gamma_powers[2] * self.stage3_gammas[1] * half);
+        for g in &self.stage3_gammas[2..] {
+            challenges.push(self.gamma_powers[2] * *g);
+        }
+
+        for g in &self.stage4_gammas {
+            challenges.push(self.gamma_powers[3] * *g);
+        }
+
+        for g in &self.stage5_gammas {
+            challenges.push(self.gamma_powers[4] * *g);
+        }
+
+        challenges.push(self.gamma_powers[5]);
+        challenges.push(self.gamma_powers[6]);
+        challenges.push(self.entry_gamma);
+
+        challenges
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        Some(OutputClaimConstraint::direct(OpeningId::virt(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        )))
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, _sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        Vec::new()
+    }
+}
+
+#[derive(Allocative, Clone)]
 pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
+    /// Whether Stage 6a should stage per-stage Val claims for BytecodeClaimReduction.
+    pub use_staged_val_claims: bool,
     /// Index `i` stores `gamma^i`.
     pub gamma_powers: Vec<F>,
     /// Stage-specific gamma powers for input_claim_constraint
@@ -850,28 +1629,33 @@ pub struct BytecodeReadRafSumcheckParams<F: JoltField> {
     pub int_poly: IdentityPolynomial<F>,
     pub r_cycles: [Vec<F::Challenge>; N_STAGES],
     /// Bound values after log_K rounds (set by prover for output_constraint_challenge_values)
-    pub bound_int_poly: Option<F>,
     pub bound_val_polys: Option<[F; N_STAGES]>,
+    /// Val-only claims cached after Stage 6a address binding in committed mode.
+    pub staged_val_claims: Option<[F; N_STAGES]>,
     /// γ_entry = gamma_powers[7]. Weights the entry-point constraint term.
     pub entry_gamma: F,
     /// Bytecode table index of the ELF entry point.
     pub entry_bytecode_index: usize,
     /// Prover-cached f_entry(r_addr) after address phase (None in verifier params).
     pub bound_f_entry: Option<F>,
+    /// Prover-cached per-stage cycle claims after address binding.
+    pub cycle_initial_round_claims: Option<[F; N_STAGES]>,
+    /// Prover-cached entry cycle claim after address binding.
+    pub cycle_initial_entry_claim: Option<F>,
 }
 
 impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
     #[tracing::instrument(skip_all, name = "BytecodeReadRafSumcheckParams::gen")]
-    pub fn gen(
-        bytecode_preprocessing: &BytecodePreprocessing,
+    pub fn gen<PCS: CommitmentScheme>(
+        program: Option<&ProgramPreprocessing<PCS>>,
         n_cycle_vars: usize,
         one_hot_params: &OneHotParams,
+        use_staged_val_claims: bool,
+        entry_bytecode_index: Option<usize>,
         opening_accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
         let gamma_powers = transcript.challenge_scalar_powers(8);
-
-        let bytecode = &bytecode_preprocessing.bytecode;
 
         // Generate all stage-specific gamma powers upfront (order must match verifier)
         let stage1_gammas: Vec<F> = transcript.challenge_scalar_powers(2 + NUM_CIRCUIT_FLAGS);
@@ -888,38 +1672,48 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         let rv_claim_5 = Self::compute_rv_claim_5(opening_accumulator, &stage5_gammas);
         let rv_claims = [rv_claim_1, rv_claim_2, rv_claim_3, rv_claim_4, rv_claim_5];
 
-        // Pre-compute eq_r_register for stages 4 and 5 (they use different r_register points)
-        let r_register_4 = opening_accumulator
-            .get_virtual_polynomial_opening(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersReadWriteChecking,
-            )
-            .0
-            .r;
-        let eq_r_register_4 =
-            EqPolynomial::<F>::evals(&r_register_4[..(REGISTER_COUNT as usize).log_2()]);
+        // Fused pass: compute all val polynomials in a single parallel iteration when the
+        // full bytecode table is available. The proxy committed path only needs staged
+        // `Val_s(r_bc)` openings, so keep the placeholder MLEs tiny instead of allocating
+        // length-K zero buffers that will never be uploaded or evaluated on Rust.
+        let val_polys = if let Some(program) = program.and_then(|program| program.as_full().ok()) {
+            let r_register_4 = opening_accumulator
+                .get_virtual_polynomial_opening(
+                    VirtualPolynomial::RdWa,
+                    SumcheckId::RegistersReadWriteChecking,
+                )
+                .0
+                .r;
+            let eq_r_register_4 =
+                EqPolynomial::<F>::evals(&r_register_4[..(REGISTER_COUNT as usize).log_2()]);
 
-        let r_register_5 = opening_accumulator
-            .get_virtual_polynomial_opening(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersValEvaluation,
-            )
-            .0
-            .r;
-        let eq_r_register_5 =
-            EqPolynomial::<F>::evals(&r_register_5[..(REGISTER_COUNT as usize).log_2()]);
+            let r_register_5 = opening_accumulator
+                .get_virtual_polynomial_opening(
+                    VirtualPolynomial::RdWa,
+                    SumcheckId::RegistersValEvaluation,
+                )
+                .0
+                .r;
+            let eq_r_register_5 =
+                EqPolynomial::<F>::evals(&r_register_5[..(REGISTER_COUNT as usize).log_2()]);
 
-        // Fused pass: compute all val polynomials in a single parallel iteration
-        let val_polys = Self::compute_val_polys(
-            bytecode,
-            &eq_r_register_4,
-            &eq_r_register_5,
-            &stage1_gammas,
-            &stage2_gammas,
-            &stage3_gammas,
-            &stage4_gammas,
-            &stage5_gammas,
-        );
+            Self::compute_val_polys(
+                &program.bytecode.bytecode,
+                &eq_r_register_4,
+                &eq_r_register_5,
+                &stage1_gammas,
+                &stage2_gammas,
+                &stage3_gammas,
+                &stage4_gammas,
+                &stage5_gammas,
+            )
+        } else if use_staged_val_claims {
+            array::from_fn(|_| MultilinearPolynomial::from(vec![F::zero()]))
+        } else {
+            array::from_fn(|_| {
+                MultilinearPolynomial::from(vec![F::zero(); one_hot_params.bytecode_k])
+            })
+        };
 
         let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_k.log_2());
 
@@ -928,11 +1722,13 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         let (_, raf_shift_claim) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::PC, SumcheckId::SpartanShift);
         let entry_gamma = gamma_powers[7];
-        let entry_bytecode_index = super::entry_bytecode_index(bytecode_preprocessing);
+        let entry_bytecode_index = entry_bytecode_index
+            .or_else(|| program.map(|program| program.entry_bytecode_index()))
+            .unwrap_or_default();
         // Both prover and verifier add entry_gamma unconditionally.
         // The security comes from the sumcheck: if ra(entry_index, 0) != 1, the sum
         // won't match input_claim and the sumcheck fails.
-        let input_claim: F = [
+        let mut input_claim: F = [
             rv_claim_1,
             rv_claim_2,
             rv_claim_3,
@@ -944,8 +1740,8 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         .iter()
         .zip(&gamma_powers)
         .map(|(claim, g)| *claim * g)
-        .sum::<F>()
-            + entry_gamma;
+        .sum::<F>();
+        input_claim += entry_gamma;
 
         let (r_cycle_1, _) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::Imm, SumcheckId::SpartanOuter);
@@ -976,6 +1772,7 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         ];
 
         Self {
+            use_staged_val_claims,
             gamma_powers,
             entry_gamma,
             entry_bytecode_index,
@@ -996,9 +1793,11 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             raf_shift_claim,
             int_poly,
             r_cycles,
-            bound_int_poly: None,
             bound_val_polys: None,
+            staged_val_claims: None,
             bound_f_entry: None,
+            cycle_initial_round_claims: None,
+            cycle_initial_entry_claim: None,
         }
     }
 
@@ -1340,420 +2139,5 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
         }
 
         sum
-    }
-}
-
-impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeReadRafSumcheckParams<F> {
-    fn degree(&self) -> usize {
-        self.d + 1
-    }
-
-    fn num_rounds(&self) -> usize {
-        self.log_K + self.log_T
-    }
-
-    fn input_claim(&self, _: &dyn OpeningAccumulator<F>) -> F {
-        self.input_claim
-    }
-
-    fn normalize_opening_point(
-        &self,
-        sumcheck_challenges: &[<F as JoltField>::Challenge],
-    ) -> OpeningPoint<BIG_ENDIAN, F> {
-        let mut r = sumcheck_challenges.to_vec();
-        r[0..self.log_K].reverse();
-        r[self.log_K..].reverse();
-        OpeningPoint::new(r)
-    }
-
-    #[cfg(feature = "zk")]
-    fn input_claim_constraint(&self) -> InputClaimConstraint {
-        // input_claim = Σᵢ gamma_powers[i] * rv_claim_i + gamma_powers[5]*raf_claim + gamma_powers[6]*raf_shift_claim
-        // Each rv_claim_i = Σⱼ stage_i_gamma[j] * opening_ij
-        //
-        // Challenge layout:
-        // - Stage 1 (SpartanOuter): 2 + NUM_CIRCUIT_FLAGS terms
-        // - Stage 2 (SpartanProductVirtualization): 5 terms
-        // - Stage 3 (InstructionInputVirtualization + SpartanShift): 10 terms (9 + 1 for split unexpanded_pc)
-        // - Stage 4 (RegistersReadWriteChecking): 3 terms
-        // - Stage 5 (RegistersValEvaluation + InstructionReadRaf): 2 + NUM_LOOKUP_TABLES terms
-        // - raf_claim (PC @ SpartanOuter): 1 term
-        // - raf_shift_claim (PC @ SpartanShift): 1 term
-
-        let mut terms = Vec::new();
-        let mut challenge_idx = 0;
-
-        // Stage 1: SpartanOuter openings
-        // Order: UnexpandedPC, Imm, then CircuitFlags in order
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::UnexpandedPC,
-                SumcheckId::SpartanOuter,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::Imm,
-                SumcheckId::SpartanOuter,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        for flag in CircuitFlags::iter() {
-            terms.push(ProductTerm::scaled(
-                ValueSource::Challenge(challenge_idx),
-                vec![ValueSource::Opening(OpeningId::virt(
-                    VirtualPolynomial::OpFlags(flag),
-                    SumcheckId::SpartanOuter,
-                ))],
-            ));
-            challenge_idx += 1;
-        }
-
-        // Stage 2: SpartanProductVirtualization openings
-        // Order: Jump, Branch, WriteLookupOutputToRD, VirtualInstruction
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::OpFlags(CircuitFlags::Jump),
-                SumcheckId::SpartanProductVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionFlags(InstructionFlags::Branch),
-                SumcheckId::SpartanProductVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::OpFlags(CircuitFlags::WriteLookupOutputToRD),
-                SumcheckId::SpartanProductVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::OpFlags(CircuitFlags::VirtualInstruction),
-                SumcheckId::SpartanProductVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        // Stage 3: InstructionInputVirtualization + SpartanShift openings
-        // Order: Imm, UnexpandedPC (split), LeftIsRs1, LeftIsPC, RightIsRs2, RightIsImm, IsNoop, IsVirtual, IsFirstInSequence
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::Imm,
-                SumcheckId::InstructionInputVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        // UnexpandedPC: must be equal from SpartanShift and InstructionInputVirtualization
-        // Include both with half coefficient each
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::UnexpandedPC,
-                SumcheckId::SpartanShift,
-            ))],
-        ));
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::UnexpandedPC,
-                SumcheckId::InstructionInputVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionFlags(InstructionFlags::LeftOperandIsRs1Value),
-                SumcheckId::InstructionInputVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionFlags(InstructionFlags::LeftOperandIsPC),
-                SumcheckId::InstructionInputVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionFlags(InstructionFlags::RightOperandIsRs2Value),
-                SumcheckId::InstructionInputVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionFlags(InstructionFlags::RightOperandIsImm),
-                SumcheckId::InstructionInputVirtualization,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionFlags(InstructionFlags::IsNoop),
-                SumcheckId::SpartanShift,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::OpFlags(CircuitFlags::VirtualInstruction),
-                SumcheckId::SpartanShift,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::OpFlags(CircuitFlags::IsFirstInSequence),
-                SumcheckId::SpartanShift,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        // Stage 4: RegistersReadWriteChecking openings
-        // Order: RdWa, Rs1Ra, Rs2Ra
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersReadWriteChecking,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::Rs1Ra,
-                SumcheckId::RegistersReadWriteChecking,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::Rs2Ra,
-                SumcheckId::RegistersReadWriteChecking,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        // Stage 5: RegistersValEvaluation + InstructionReadRaf openings
-        // Order: RdWa@RegistersValEvaluation, InstructionRafFlag, LookupTableFlag(0..NUM_LOOKUP_TABLES)
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::RdWa,
-                SumcheckId::RegistersValEvaluation,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::InstructionRafFlag,
-                SumcheckId::InstructionReadRaf,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        for i in 0..NUM_LOOKUP_TABLES {
-            terms.push(ProductTerm::scaled(
-                ValueSource::Challenge(challenge_idx),
-                vec![ValueSource::Opening(OpeningId::virt(
-                    VirtualPolynomial::LookupTableFlag(i),
-                    SumcheckId::InstructionReadRaf,
-                ))],
-            ));
-            challenge_idx += 1;
-        }
-
-        // raf_claim: PC @ SpartanOuter
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::PC,
-                SumcheckId::SpartanOuter,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        // raf_shift_claim: PC @ SpartanShift
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![ValueSource::Opening(OpeningId::virt(
-                VirtualPolynomial::PC,
-                SumcheckId::SpartanShift,
-            ))],
-        ));
-        challenge_idx += 1;
-
-        // Entry constraint: +γ_entry (constant term, no polynomial factors).
-        terms.push(ProductTerm::scaled(
-            ValueSource::Challenge(challenge_idx),
-            vec![],
-        ));
-
-        InputClaimConstraint::sum_of_products(terms)
-    }
-
-    #[cfg(feature = "zk")]
-    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
-        // Compute coefficients: gamma_powers[stage] * stage_gammas[idx]
-        // The order must match input_claim_constraint terms.
-
-        let mut challenges = Vec::new();
-
-        // Stage 1: gamma_powers[0] * stage1_gammas[i]
-        for g in &self.stage1_gammas {
-            challenges.push(self.gamma_powers[0] * *g);
-        }
-
-        // Stage 2: gamma_powers[1] * stage2_gammas[i]
-        for g in &self.stage2_gammas {
-            challenges.push(self.gamma_powers[1] * *g);
-        }
-
-        // Stage 3: gamma_powers[2] * stage3_gammas[i]
-        // Special handling for index 1 (unexpanded_pc) which is split between two openings
-        challenges.push(self.gamma_powers[2] * self.stage3_gammas[0]); // imm
-                                                                       // unexpanded_pc: split between SpartanShift and InstructionInputVirtualization
-                                                                       // Each gets half the coefficient
-        let half = F::from_u64(2).inverse().unwrap();
-        challenges.push(self.gamma_powers[2] * self.stage3_gammas[1] * half);
-        // Continue with the rest of stage3 (indices 2..9)
-        for g in &self.stage3_gammas[2..] {
-            challenges.push(self.gamma_powers[2] * *g);
-        }
-
-        // Stage 4: gamma_powers[3] * stage4_gammas[i]
-        for g in &self.stage4_gammas {
-            challenges.push(self.gamma_powers[3] * *g);
-        }
-
-        // Stage 5: gamma_powers[4] * stage5_gammas[i]
-        for g in &self.stage5_gammas {
-            challenges.push(self.gamma_powers[4] * *g);
-        }
-
-        // raf_claim: gamma_powers[5]
-        challenges.push(self.gamma_powers[5]);
-
-        // raf_shift_claim: gamma_powers[6]
-        challenges.push(self.gamma_powers[6]);
-
-        // entry constraint
-        challenges.push(self.entry_gamma);
-
-        challenges
-    }
-
-    #[cfg(feature = "zk")]
-    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        let factors: Vec<ValueSource> = (0..self.d)
-            .map(|i| {
-                let opening = OpeningId::committed(
-                    CommittedPolynomial::BytecodeRa(i),
-                    SumcheckId::BytecodeReadRaf,
-                );
-                ValueSource::Opening(opening)
-            })
-            .collect();
-
-        let terms = vec![ProductTerm::scaled(ValueSource::Challenge(0), factors)];
-
-        Some(OutputClaimConstraint::sum_of_products(terms))
-    }
-
-    #[cfg(feature = "zk")]
-    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        let opening_point = self.normalize_opening_point(sumcheck_challenges);
-        let (r_address_prime, r_cycle_prime) = opening_point.split_at(self.log_K);
-
-        // Prover stores bound values before clearing polys; verifier evaluates directly
-        let val: F = if let Some(bound_val_polys) = &self.bound_val_polys {
-            bound_val_polys
-                .iter()
-                .zip(&self.r_cycles)
-                .zip(&self.gamma_powers)
-                .map(|((bound_val, r_cycle), gamma)| {
-                    *bound_val * EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r) * gamma
-                })
-                .sum()
-        } else {
-            let int_poly = self.int_poly.evaluate(&r_address_prime.r);
-            self.val_polys
-                .iter()
-                .zip(&self.r_cycles)
-                .zip(&self.gamma_powers)
-                .zip([
-                    int_poly * self.gamma_powers[5],
-                    F::zero(),
-                    int_poly * self.gamma_powers[4],
-                    F::zero(),
-                    F::zero(),
-                ])
-                .map(|(((val, r_cycle), gamma), int_poly_contrib)| {
-                    (val.evaluate(&r_address_prime.r) + int_poly_contrib)
-                        * EqPolynomial::<F>::mle(r_cycle, &r_cycle_prime.r)
-                        * gamma
-                })
-                .sum()
-        };
-
-        // r_address_prime.r is MSB-first (after normalize_opening_point reversal),
-        // so entry_bits must also be MSB-first: entry_bits[j] = (e >> (log_K-1-j)) & 1.
-        let f_entry_at_r_addr = if let Some(v) = self.bound_f_entry {
-            v
-        } else {
-            let log_k = self.log_K;
-            let e = self.entry_bytecode_index;
-            let entry_bits: Vec<F> = (0..log_k)
-                .map(|i| F::from_u64(((e >> (log_k - 1 - i)) & 1) as u64))
-                .collect();
-            EqPolynomial::<F>::mle(&entry_bits, &r_address_prime.r)
-        };
-        // eq_zero(r_cycle) = ∏_i (1 - r_cycle_prime.r[i])
-        let zeros: Vec<F::Challenge> = vec![F::Challenge::default(); r_cycle_prime.r.len()];
-        let eq_zero_at_r_cycle = EqPolynomial::<F>::mle(&zeros, &r_cycle_prime.r);
-        let entry_contrib = self.entry_gamma * f_entry_at_r_addr * eq_zero_at_r_cycle;
-
-        vec![val + entry_contrib]
     }
 }

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -569,15 +569,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
         }
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
         match self.params.phase {
-            ReductionPhase::CycleVariables => {
-                // Align to the *start* of Booleanity's cycle segment, so local rounds correspond
-                // to low Dory column bits in the unified point ordering.
-                let booleanity_rounds = self.params.log_k_chunk + self.params.log_t;
-                let booleanity_offset = max_num_rounds - booleanity_rounds;
-                booleanity_offset + self.params.log_k_chunk
-            }
+            // Stage 6b starts at the cycle segment after one-hot address binding has
+            // already completed in Stage 6a, so legacy advice cycle rounds are local.
+            ReductionPhase::CycleVariables => 0,
             ReductionPhase::AddressVariables => 0,
         }
     }
@@ -672,14 +668,12 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
         }
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
         let params = self.params.borrow();
         match params.phase {
-            ReductionPhase::CycleVariables => {
-                let booleanity_rounds = params.log_k_chunk + params.log_t;
-                let booleanity_offset = max_num_rounds - booleanity_rounds;
-                booleanity_offset + params.log_k_chunk
-            }
+            // Stage 6b starts at the cycle segment after one-hot address binding has
+            // already completed in Stage 6a, so legacy advice cycle rounds are local.
+            ReductionPhase::CycleVariables => 0,
             ReductionPhase::AddressVariables => 0,
         }
     }

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -48,7 +48,8 @@ pub struct JoltProof<
     pub stage3_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage4_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage5_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
-    pub stage6_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
+    pub stage6a_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
+    pub stage6b_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     pub stage7_sumcheck_proof: SumcheckInstanceProof<F, C, FS>,
     #[cfg(feature = "zk")]
     pub blindfold_proof: BlindFoldProof<F, C>,
@@ -77,7 +78,8 @@ impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>, FS: Tr
             && self.stage3_sumcheck_proof.is_zk() == zk_mode
             && self.stage4_sumcheck_proof.is_zk() == zk_mode
             && self.stage5_sumcheck_proof.is_zk() == zk_mode
-            && self.stage6_sumcheck_proof.is_zk() == zk_mode
+            && self.stage6a_sumcheck_proof.is_zk() == zk_mode
+            && self.stage6b_sumcheck_proof.is_zk() == zk_mode
             && self.stage7_sumcheck_proof.is_zk() == zk_mode;
 
         if !consistent {
@@ -420,6 +422,16 @@ impl CanonicalSerialize for VirtualPolynomial {
                 38u8.serialize_with_mode(&mut writer, compress)?;
                 (u8::try_from(*flag).unwrap()).serialize_with_mode(&mut writer, compress)
             }
+            Self::BytecodeReadRafAddrClaim => 39u8.serialize_with_mode(&mut writer, compress),
+            Self::BooleanityAddrClaim => 40u8.serialize_with_mode(&mut writer, compress),
+            Self::BytecodeValStage(i) => {
+                41u8.serialize_with_mode(&mut writer, compress)?;
+                (u8::try_from(*i).unwrap()).serialize_with_mode(&mut writer, compress)
+            }
+            Self::BytecodeClaimReductionIntermediate => {
+                42u8.serialize_with_mode(&mut writer, compress)
+            }
+            Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(&mut writer, compress),
         }
     }
 
@@ -459,11 +471,16 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamValInit
             | Self::RamValFinal
             | Self::RamHammingWeight
-            | Self::UnivariateSkip => 1,
+            | Self::UnivariateSkip
+            | Self::BytecodeReadRafAddrClaim
+            | Self::BooleanityAddrClaim
+            | Self::BytecodeClaimReductionIntermediate
+            | Self::ProgramImageInitContributionRw => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
-            | Self::LookupTableFlag(_) => 2,
+            | Self::LookupTableFlag(_)
+            | Self::BytecodeValStage(_) => 2,
         }
     }
 }
@@ -537,6 +554,14 @@ impl CanonicalDeserialize for VirtualPolynomial {
                     let flag = u8::deserialize_with_mode(&mut reader, compress, validate)?;
                     Self::LookupTableFlag(flag as usize)
                 }
+                39 => Self::BytecodeReadRafAddrClaim,
+                40 => Self::BooleanityAddrClaim,
+                41 => {
+                    let i = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+                    Self::BytecodeValStage(i as usize)
+                }
+                42 => Self::BytecodeClaimReductionIntermediate,
+                43 => Self::ProgramImageInitContributionRw,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -46,7 +46,10 @@ use crate::{
     },
     pprof_scope,
     subprotocols::{
-        booleanity::{BooleanitySumcheckParams, BooleanitySumcheckProver},
+        booleanity::{
+            BooleanityAddressSumcheckProver, BooleanityCyclePhaseParams,
+            BooleanityCycleSumcheckProver, BooleanitySumcheckParams,
+        },
         streaming_schedule::LinearOnlySchedule,
         sumcheck::{BatchedSumcheck, SumcheckInstanceProof},
         sumcheck_prover::SumcheckInstanceProver,
@@ -98,7 +101,9 @@ use crate::{
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
     zkvm::{
-        bytecode::read_raf_checking::BytecodeReadRafSumcheckProver,
+        bytecode::read_raf_checking::{
+            BytecodeReadRafAddressSumcheckProver, BytecodeReadRafCycleSumcheckProver,
+        },
         fiat_shamir_preamble,
         instruction_lookups::{
             ra_virtual::InstructionRaSumcheckProver as LookupsRaSumcheckProver,
@@ -621,11 +626,14 @@ impl<
         let (stage3_sumcheck_proof, r_stage3) = self.prove_stage3();
         let (stage4_sumcheck_proof, r_stage4) = self.prove_stage4();
         let (stage5_sumcheck_proof, r_stage5) = self.prove_stage5();
-        let (stage6_sumcheck_proof, r_stage6) = self.prove_stage6();
+        let (stage6a_sumcheck_proof, bytecode_read_raf_params, booleanity_params) =
+            self.prove_stage6a();
+        let (stage6b_sumcheck_proof, r_stage6b) =
+            self.prove_stage6b(bytecode_read_raf_params, booleanity_params);
         let (stage7_sumcheck_proof, r_stage7) = self.prove_stage7();
 
         let _sumcheck_challenges = [
-            r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6, r_stage7,
+            r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6b, r_stage7,
         ];
 
         let joint_opening_proof = self.prove_stage8(opening_proof_hints);
@@ -668,7 +676,8 @@ impl<
             stage3_sumcheck_proof,
             stage4_sumcheck_proof,
             stage5_sumcheck_proof,
-            stage6_sumcheck_proof,
+            stage6a_sumcheck_proof,
+            stage6b_sumcheck_proof,
             stage7_sumcheck_proof,
             #[cfg(feature = "zk")]
             blindfold_proof,
@@ -1305,25 +1314,25 @@ impl<
     }
 
     #[tracing::instrument(skip_all)]
-    fn prove_stage6(
+    fn prove_stage6a(
         &mut self,
     ) -> (
         SumcheckInstanceProof<F, C, ProofTranscript>,
-        Vec<F::Challenge>,
+        BytecodeReadRafSumcheckParams<F>,
+        BooleanitySumcheckParams<F>,
     ) {
         #[cfg(not(target_arch = "wasm32"))]
-        print_current_memory_usage("Stage 6 baseline");
+        print_current_memory_usage("Stage 6a baseline");
 
         let bytecode_read_raf_params = BytecodeReadRafSumcheckParams::gen(
-            self.preprocessing.shared.bytecode(),
+            Some(&self.preprocessing.shared.program),
             self.trace.len().log_2(),
             &self.one_hot_params,
+            false,
+            None,
             &self.opening_accumulator,
             &mut self.transcript,
         );
-
-        let ram_hamming_booleanity_params =
-            HammingBooleanitySumcheckParams::new(&self.opening_accumulator);
 
         let booleanity_params = BooleanitySumcheckParams::new(
             self.trace.len().log_2(),
@@ -1331,6 +1340,63 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+
+        let mut bytecode_read_raf = BytecodeReadRafAddressSumcheckProver::initialize(
+            bytecode_read_raf_params,
+            Arc::clone(&self.trace),
+            self.preprocessing.shared.bytecode_arc(),
+        );
+        let mut booleanity = BooleanityAddressSumcheckProver::initialize(
+            booleanity_params,
+            &self.trace,
+            self.preprocessing.shared.bytecode(),
+            &self.program_io.memory_layout,
+        );
+
+        #[cfg(feature = "allocative")]
+        {
+            print_data_structure_heap_usage(
+                "BytecodeReadRafAddressSumcheckProver",
+                &bytecode_read_raf,
+            );
+            print_data_structure_heap_usage("BooleanityAddressSumcheckProver", &booleanity);
+        }
+
+        let mut instances: Vec<&mut dyn SumcheckInstanceProver<_, _>> =
+            vec![&mut bytecode_read_raf, &mut booleanity];
+
+        #[cfg(feature = "allocative")]
+        write_instance_flamegraph_svg(&instances, "stage6a_start_flamechart.svg");
+        tracing::info!("Stage 6a proving");
+
+        let (sumcheck_proof, _r_stage6a, _initial_claim) =
+            self.prove_batched_sumcheck(instances.iter_mut().map(|v| &mut **v as _).collect());
+
+        #[cfg(feature = "allocative")]
+        write_instance_flamegraph_svg(&instances, "stage6a_end_flamechart.svg");
+        drop(instances);
+
+        (
+            sumcheck_proof,
+            bytecode_read_raf.into_params(),
+            booleanity.into_params(),
+        )
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn prove_stage6b(
+        &mut self,
+        bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
+        booleanity_params: BooleanitySumcheckParams<F>,
+    ) -> (
+        SumcheckInstanceProof<F, C, ProofTranscript>,
+        Vec<F::Challenge>,
+    ) {
+        #[cfg(not(target_arch = "wasm32"))]
+        print_current_memory_usage("Stage 6b baseline");
+
+        let ram_hamming_booleanity_params =
+            HammingBooleanitySumcheckParams::new(&self.opening_accumulator);
 
         let ram_ra_virtual_params = RamRaVirtualParams::new(
             self.trace.len(),
@@ -1393,20 +1459,22 @@ impl<
             };
         }
 
-        let mut bytecode_read_raf = BytecodeReadRafSumcheckProver::initialize(
+        let mut bytecode_read_raf = BytecodeReadRafCycleSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
             self.preprocessing.shared.bytecode_arc(),
+            &self.opening_accumulator,
         );
-        let mut ram_hamming_booleanity =
-            HammingBooleanitySumcheckProver::initialize(ram_hamming_booleanity_params, &self.trace);
-
-        let mut booleanity = BooleanitySumcheckProver::initialize(
-            booleanity_params,
+        let booleanity_cycle_params =
+            BooleanityCyclePhaseParams::new(booleanity_params, &self.opening_accumulator);
+        let mut booleanity = BooleanityCycleSumcheckProver::initialize(
+            booleanity_cycle_params,
             &self.trace,
             self.preprocessing.shared.bytecode(),
             &self.program_io.memory_layout,
         );
+        let mut ram_hamming_booleanity =
+            HammingBooleanitySumcheckProver::initialize(ram_hamming_booleanity_params, &self.trace);
 
         let mut ram_ra_virtual = RamRaVirtualSumcheckProver::initialize(
             ram_ra_virtual_params,
@@ -1421,8 +1489,11 @@ impl<
 
         #[cfg(feature = "allocative")]
         {
-            print_data_structure_heap_usage("BytecodeReadRafSumcheckProver", &bytecode_read_raf);
-            print_data_structure_heap_usage("BooleanitySumcheckProver", &booleanity);
+            print_data_structure_heap_usage(
+                "BytecodeReadRafCycleSumcheckProver",
+                &bytecode_read_raf,
+            );
+            print_data_structure_heap_usage("BooleanityCycleSumcheckProver", &booleanity);
             print_data_structure_heap_usage(
                 "ram HammingBooleanitySumcheckProver",
                 &ram_hamming_booleanity,
@@ -1457,13 +1528,13 @@ impl<
         }
 
         #[cfg(feature = "allocative")]
-        write_instance_flamegraph_svg(&instances, "stage6_start_flamechart.svg");
-        tracing::info!("Stage 6 proving");
+        write_instance_flamegraph_svg(&instances, "stage6b_start_flamechart.svg");
+        tracing::info!("Stage 6b proving");
 
-        let (sumcheck_proof, r_stage6, _initial_claim) =
+        let (sumcheck_proof, r_stage6b, _initial_claim) =
             self.prove_batched_sumcheck(instances.iter_mut().map(|v| &mut **v as _).collect());
         #[cfg(feature = "allocative")]
-        write_instance_flamegraph_svg(&instances, "stage6_end_flamechart.svg");
+        write_instance_flamegraph_svg(&instances, "stage6b_end_flamechart.svg");
         drop_in_background_thread(bytecode_read_raf);
         drop_in_background_thread(booleanity);
         drop_in_background_thread(ram_hamming_booleanity);
@@ -1474,7 +1545,7 @@ impl<
         self.advice_reduction_prover_trusted = advice_trusted;
         self.advice_reduction_prover_untrusted = advice_untrusted;
 
-        (sumcheck_proof, r_stage6)
+        (sumcheck_proof, r_stage6b)
     }
 
     #[tracing::instrument(skip_all)]
@@ -1499,8 +1570,8 @@ impl<
         let zk_stages = self.blindfold_accumulator.take_stage_data();
         assert_eq!(
             zk_stages.len(),
-            7,
-            "Expected 7 ZK stages, got {}",
+            8,
+            "Expected 8 ZK stages, got {}",
             zk_stages.len()
         );
 
@@ -1582,7 +1653,7 @@ impl<
                 };
                 stage_witnesses.push(stage_witness);
             } else {
-                // Stages 2-6: no uni-skip, push initial claim for regular rounds
+                // Stages 2-7: no uni-skip, push initial claim for regular rounds
                 initial_claims.push(zk_data.initial_claim);
             }
 
@@ -2442,17 +2513,6 @@ mod tests {
             memory_layout,
             max_trace_len,
         ))
-    }
-
-    #[test]
-    fn committed_bytecode_chunk_count_validation_rejects_invalid_counts() {
-        use crate::zkvm::bytecode::chunks::validate_committed_bytecode_chunk_count;
-
-        assert!(std::panic::catch_unwind(|| validate_committed_bytecode_chunk_count(0)).is_err());
-        assert!(std::panic::catch_unwind(|| validate_committed_bytecode_chunk_count(3)).is_err());
-        assert!(std::panic::catch_unwind(|| validate_committed_bytecode_chunk_count(512)).is_err());
-        validate_committed_bytecode_chunk_count(1);
-        validate_committed_bytecode_chunk_count(256);
     }
 
     #[test]
@@ -3333,9 +3393,9 @@ mod tests {
         );
         let (jolt_proof, _) = prover.prove();
 
-        println!("\n=== BlindFold R1CS Satisfaction Test (All 7 Stages) ===\n");
+        println!("\n=== BlindFold R1CS Satisfaction Test (All 8 Stages) ===\n");
 
-        // Process all 7 stages and verify each one
+        // Process all 8 stages and verify each one
         let stage_proofs: Vec<(&str, &SumcheckInstanceProof<Fr, Bn254Curve, _>)> = vec![
             ("Stage 1 (Spartan Outer)", &jolt_proof.stage1_sumcheck_proof),
             (
@@ -3346,8 +3406,12 @@ mod tests {
             ("Stage 4 (Registers+RAM)", &jolt_proof.stage4_sumcheck_proof),
             ("Stage 5 (Value+Lookup)", &jolt_proof.stage5_sumcheck_proof),
             (
-                "Stage 6 (OneHot+Hamming)",
-                &jolt_proof.stage6_sumcheck_proof,
+                "Stage 6a (OneHot Address)",
+                &jolt_proof.stage6a_sumcheck_proof,
+            ),
+            (
+                "Stage 6b (OneHot Cycle+Hamming)",
+                &jolt_proof.stage6b_sumcheck_proof,
             ),
             (
                 "Stage 7 (HammingWeight+ClaimReduction)",

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -25,8 +25,10 @@
 //! ## Stages Implemented
 //!
 //! This verifier implements stages 1-7 (all sumcheck stages):
-//! - Stages 1-6: Standard sumcheck verifications
-//! - Stage 7: HammingWeight claim reduction sumcheck
+//! - Stages 1-5: Standard sumcheck verifications
+//! - Stage 6a: Address-phase bytecode read-RAF and booleanity sumchecks
+//! - Stage 6b: Cycle-phase sumchecks and precommitted claim reductions
+//! - Stage 7: HammingWeight claim reduction and address-phase advice reductions
 //!
 //! Stage 8 (PCS verification) is NOT transpiled by this module. It requires
 //! native elliptic curve operations that are handled separately by the target
@@ -35,12 +37,13 @@
 //! ## Advice Verifiers
 //!
 //! `AdviceClaimReduction` verifiers are included when advice commitments are present.
-//! They span stages 6 and 7 with a phase transition between them:
-//! - Stage 6: CycleVariables phase (bind cycle-derived coordinates)
+//! They span stages 6b and 7 with a phase transition between them:
+//! - Stage 6b: CycleVariables phase (bind cycle-derived coordinates)
 //! - Stage 7: AddressVariables phase (bind address-derived coordinates)
 
 use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::DoryGlobals;
 #[cfg(not(feature = "zk"))]
 use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN};
 use crate::subprotocols::sumcheck::{BatchedSumcheck, ClearSumcheckProof, SumcheckInstanceProof};
@@ -48,9 +51,12 @@ use crate::zkvm::claim_reductions::{
     AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier, ReductionPhase,
     RegistersClaimReductionSumcheckVerifier,
 };
-use crate::zkvm::config::OneHotParams;
+use crate::zkvm::config::{OneHotParams, ProgramMode};
 use crate::zkvm::{
-    bytecode::read_raf_checking::BytecodeReadRafSumcheckVerifier,
+    bytecode::read_raf_checking::{
+        BytecodeReadRafAddressSumcheckVerifier, BytecodeReadRafCycleSumcheckVerifier,
+        BytecodeReadRafSumcheckParams,
+    },
     claim_reductions::{
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
         RamRaClaimReductionSumcheckVerifier,
@@ -79,7 +85,7 @@ use crate::zkvm::{
         product::ProductVirtualRemainderVerifier, shift::ShiftSumcheckVerifier,
         verify_stage1_uni_skip, verify_stage2_uni_skip,
     },
-    verifier::JoltVerifierPreprocessing,
+    verifier::{JoltSharedPreprocessing, JoltVerifierPreprocessing},
     ProverDebugInfo,
 };
 use crate::{
@@ -87,7 +93,10 @@ use crate::{
     poly::opening_proof::{AbstractVerifierOpeningAccumulator, VerifierOpeningAccumulator},
     pprof_scope,
     subprotocols::{
-        booleanity::{BooleanitySumcheckParams, BooleanitySumcheckVerifier},
+        booleanity::{
+            BooleanityAddressSumcheckVerifier, BooleanityCycleSumcheckVerifier,
+            BooleanitySumcheckParams,
+        },
         sumcheck_verifier::SumcheckInstanceVerifier,
     },
     transcripts::Transcript,
@@ -293,6 +302,20 @@ impl<
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
         }
+    }
+
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.proof.trace_length.log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
+            trace_log_t + log_k_chunk,
+            self.preprocessing.shared.precommitted_candidate_total_vars(
+                false,
+                self.trusted_advice_commitment.is_some(),
+                self.proof.untrusted_advice_commitment.is_some(),
+            ),
+        )
     }
 
     /// Verify the Jolt proof (stages 1-7).
@@ -554,25 +577,70 @@ impl<
     }
 
     fn verify_stage6(&mut self) -> Result<(), ProofVerifyError> {
+        let _ = DoryGlobals::initialize_main_with_log_embedding(
+            self.one_hot_params.k_chunk,
+            self.proof.trace_length,
+            self.main_total_vars(),
+            Some(self.proof.dory_layout),
+        );
+        let (bytecode_read_raf_params, booleanity_params) = self.verify_stage6a()?;
+        self.verify_stage6b(bytecode_read_raf_params, booleanity_params)?;
+        Ok(())
+    }
+
+    fn verify_stage6a(
+        &mut self,
+    ) -> Result<
+        (
+            BytecodeReadRafSumcheckParams<F>,
+            BooleanitySumcheckParams<F>,
+        ),
+        ProofVerifyError,
+    > {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let bytecode_read_raf = BytecodeReadRafSumcheckVerifier::gen(
-            self.preprocessing.shared.bytecode(),
+        let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
+            Some(&self.preprocessing.shared.program),
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-        );
-
-        let ram_hamming_booleanity =
-            HammingBooleanitySumcheckVerifier::new(&self.opening_accumulator);
+            ProgramMode::Full,
+            0,
+        )?;
         let booleanity_params = BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        let booleanity = BooleanityAddressSumcheckVerifier::new(booleanity_params.clone());
 
-        let booleanity = BooleanitySumcheckVerifier::new(booleanity_params);
+        let instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript, A>> =
+            vec![&bytecode_read_raf, &booleanity];
+
+        let _r_stage6a = BatchedSumcheck::verify_standard::<F, ProofTranscript, A>(
+            extract_clear_proof(&self.proof.stage6a_sumcheck_proof),
+            instances,
+            &mut self.opening_accumulator,
+            &mut self.transcript,
+        )?;
+
+        Ok((bytecode_read_raf.into_params(), booleanity_params))
+    }
+
+    fn verify_stage6b(
+        &mut self,
+        bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
+        booleanity_params: BooleanitySumcheckParams<F>,
+    ) -> Result<(), ProofVerifyError> {
+        let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
+            bytecode_read_raf_params,
+            &self.opening_accumulator,
+        );
+        let ram_hamming_booleanity =
+            HammingBooleanitySumcheckVerifier::new(&self.opening_accumulator);
+        let booleanity =
+            BooleanityCycleSumcheckVerifier::new(booleanity_params, &self.opening_accumulator);
         let ram_ra_virtual = RamRaVirtualSumcheckVerifier::new(
             self.proof.trace_length,
             &self.one_hot_params,
@@ -623,8 +691,8 @@ impl<
             instances.push(advice);
         }
 
-        let _r_stage6 = BatchedSumcheck::verify_standard::<F, ProofTranscript, A>(
-            extract_clear_proof(&self.proof.stage6_sumcheck_proof),
+        let _r_stage6b = BatchedSumcheck::verify_standard::<F, ProofTranscript, A>(
+            extract_clear_proof(&self.proof.stage6b_sumcheck_proof),
             instances,
             &mut self.opening_accumulator,
             &mut self.transcript,

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -27,13 +27,13 @@ use crate::subprotocols::sumcheck::SumcheckInstanceProof;
 use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 #[cfg(feature = "zk")]
 use crate::subprotocols::univariate_skip::UniSkipFirstRoundProofVariant;
+use crate::zkvm::bytecode::chunks::DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT;
 use crate::zkvm::bytecode::chunks::{
-    committed_lanes, validate_committed_bytecode_chunk_count,
-    DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT,
+    committed_lanes, is_valid_committed_bytecode_chunking_for_len,
 };
 use crate::zkvm::claim_reductions::advice::ReductionPhase;
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
-use crate::zkvm::config::OneHotParams;
+use crate::zkvm::config::{OneHotParams, ProgramMode};
 use crate::zkvm::program::{ProgramMetadata, ProgramPreprocessing};
 #[cfg(feature = "prover")]
 use crate::zkvm::prover::JoltProverPreprocessing;
@@ -46,7 +46,10 @@ use crate::zkvm::ram::RAMPreprocessing;
 use crate::zkvm::witness::all_committed_polynomials;
 use crate::zkvm::Serializable;
 use crate::zkvm::{
-    bytecode::read_raf_checking::BytecodeReadRafSumcheckVerifier,
+    bytecode::read_raf_checking::{
+        BytecodeReadRafAddressSumcheckVerifier, BytecodeReadRafCycleSumcheckVerifier,
+        BytecodeReadRafSumcheckParams,
+    },
     claim_reductions::{
         AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
@@ -86,7 +89,10 @@ use crate::{
     },
     pprof_scope,
     subprotocols::{
-        booleanity::{BooleanitySumcheckParams, BooleanitySumcheckVerifier},
+        booleanity::{
+            BooleanityAddressSumcheckVerifier, BooleanityCycleSumcheckVerifier,
+            BooleanitySumcheckParams,
+        },
         sumcheck_verifier::SumcheckInstanceVerifier,
     },
     transcripts::Transcript,
@@ -113,6 +119,12 @@ struct StageVerifyResult<F: JoltField> {
     #[allow(dead_code)]
     challenges: Vec<F::Challenge>,
 }
+
+type Stage6aVerifyResult<F> = (
+    BytecodeReadRafSumcheckParams<F>,
+    BooleanitySumcheckParams<F>,
+    StageVerifyResult<F>,
+);
 
 #[cfg(feature = "zk")]
 impl<F: JoltField> StageVerifyResult<F> {
@@ -552,7 +564,7 @@ impl<
         let stage5_result = self
             .verify_stage5()
             .inspect_err(|e| tracing::error!("Stage 5: {e}"))?;
-        let stage6_result = self
+        let (stage6a_result, stage6b_result) = self
             .verify_stage6()
             .inspect_err(|e| tracing::error!("Stage 6: {e}"))?;
         let stage7_result = self
@@ -571,7 +583,8 @@ impl<
                     stage3_result.challenges.clone(),
                     stage4_result.challenges.clone(),
                     stage5_result.challenges.clone(),
-                    stage6_result.challenges.clone(),
+                    stage6a_result.challenges.clone(),
+                    stage6b_result.challenges.clone(),
                     stage7_result.challenges.clone(),
                 ];
                 let uniskip_challenges = [uniskip_challenge1, uniskip_challenge2];
@@ -582,7 +595,8 @@ impl<
                     stage3_result.batched_output_constraint,
                     stage4_result.batched_output_constraint,
                     stage5_result.batched_output_constraint,
-                    stage6_result.batched_output_constraint,
+                    stage6a_result.batched_output_constraint,
+                    stage6b_result.batched_output_constraint,
                     stage7_result.batched_output_constraint,
                 ];
 
@@ -592,7 +606,8 @@ impl<
                     stage3_result.batched_input_constraint.clone(),
                     stage4_result.batched_input_constraint.clone(),
                     stage5_result.batched_input_constraint.clone(),
-                    stage6_result.batched_input_constraint.clone(),
+                    stage6a_result.batched_input_constraint.clone(),
+                    stage6b_result.batched_input_constraint.clone(),
                     stage7_result.batched_input_constraint.clone(),
                 ];
 
@@ -606,17 +621,19 @@ impl<
                     stage3_result.input_constraint_challenge_values.clone(),
                     stage4_result.input_constraint_challenge_values.clone(),
                     stage5_result.input_constraint_challenge_values.clone(),
-                    stage6_result.input_constraint_challenge_values.clone(),
+                    stage6a_result.input_constraint_challenge_values.clone(),
+                    stage6b_result.input_constraint_challenge_values.clone(),
                     stage7_result.input_constraint_challenge_values.clone(),
                 ];
 
-                let output_constraint_challenge_values: [Vec<F>; 7] = [
+                let output_constraint_challenge_values: [Vec<F>; 8] = [
                     stage1_result.output_constraint_challenge_values.clone(),
                     stage2_result.output_constraint_challenge_values.clone(),
                     stage3_result.output_constraint_challenge_values.clone(),
                     stage4_result.output_constraint_challenge_values.clone(),
                     stage5_result.output_constraint_challenge_values.clone(),
-                    stage6_result.output_constraint_challenge_values.clone(),
+                    stage6a_result.output_constraint_challenge_values.clone(),
+                    stage6b_result.output_constraint_challenge_values.clone(),
                     stage7_result.output_constraint_challenge_values.clone(),
                 ];
 
@@ -626,7 +643,8 @@ impl<
                 oc_blocks.extend(stage3_result.oc_block_ids);
                 oc_blocks.extend(stage4_result.oc_block_ids);
                 oc_blocks.extend(stage5_result.oc_block_ids);
-                oc_blocks.extend(stage6_result.oc_block_ids);
+                oc_blocks.extend(stage6a_result.oc_block_ids);
+                oc_blocks.extend(stage6b_result.oc_block_ids);
                 oc_blocks.extend(stage7_result.oc_block_ids);
 
                 let uniskip_output_constraints = [
@@ -1113,26 +1131,114 @@ impl<
     }
 
     #[cfg_attr(not(feature = "zk"), allow(unused_variables))]
-    fn verify_stage6(&mut self) -> Result<StageVerifyResult<F>, ProofVerifyError> {
+    fn verify_stage6(
+        &mut self,
+    ) -> Result<(StageVerifyResult<F>, StageVerifyResult<F>), ProofVerifyError> {
+        let _ = DoryGlobals::initialize_main_with_log_embedding(
+            self.one_hot_params.k_chunk,
+            self.proof.trace_length,
+            self.main_total_vars(),
+            Some(self.proof.dory_layout),
+        );
+        let (bytecode_read_raf_params, booleanity_params, stage6a_result) =
+            self.verify_stage6a()?;
+        let stage6b_result = self.verify_stage6b(bytecode_read_raf_params, booleanity_params)?;
+        Ok((stage6a_result, stage6b_result))
+    }
+
+    fn verify_stage6a(&mut self) -> Result<Stage6aVerifyResult<F>, ProofVerifyError> {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let bytecode_read_raf = BytecodeReadRafSumcheckVerifier::gen(
-            self.preprocessing.shared.bytecode(),
+        let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
+            Some(&self.preprocessing.shared.program),
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-        );
-
-        let ram_hamming_booleanity =
-            HammingBooleanitySumcheckVerifier::new(&self.opening_accumulator);
+            ProgramMode::Full,
+            0,
+        )?;
         let booleanity_params = BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
         );
+        let booleanity = BooleanityAddressSumcheckVerifier::new(booleanity_params.clone());
 
-        let booleanity = BooleanitySumcheckVerifier::new(booleanity_params);
+        let instances: Vec<
+            &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
+        > = vec![&bytecode_read_raf, &booleanity];
+
+        let (_batching_coefficients, r_stage6a) = BatchedSumcheck::verify(
+            &self.proof.stage6a_sumcheck_proof,
+            instances.clone(),
+            &mut self.opening_accumulator,
+            &mut self.transcript,
+        )
+        .inspect_err(|err| tracing::error!("Stage 6a: {err}"))?;
+
+        #[cfg(feature = "zk")]
+        {
+            let regular_oc_ids = self.opening_accumulator.take_pending_claim_ids();
+            let batched_output_constraint = batch_output_constraints(&instances);
+            let batched_input_constraint = batch_input_constraints(&instances);
+            let max_num_rounds = instances.iter().map(|i| i.num_rounds()).max().unwrap();
+            let mut output_constraint_challenge_values: Vec<F> = _batching_coefficients.clone();
+            let mut input_constraint_challenge_values: Vec<F> =
+                scale_batching_coefficients(&_batching_coefficients, &instances);
+            for instance in &instances {
+                let num_rounds = instance.num_rounds();
+                let offset = instance.round_offset(max_num_rounds);
+                let r_slice = &r_stage6a[offset..offset + num_rounds];
+                output_constraint_challenge_values.extend(
+                    instance
+                        .get_params()
+                        .output_constraint_challenge_values(r_slice),
+                );
+                input_constraint_challenge_values.extend(
+                    instance
+                        .get_params()
+                        .input_constraint_challenge_values(&self.opening_accumulator),
+                );
+            }
+            let stage_result = StageVerifyResult::new(
+                r_stage6a,
+                batched_output_constraint,
+                output_constraint_challenge_values,
+                batched_input_constraint,
+                input_constraint_challenge_values,
+                vec![regular_oc_ids],
+            );
+            Ok((
+                bytecode_read_raf.into_params(),
+                booleanity.into_params(),
+                stage_result,
+            ))
+        }
+        #[cfg(not(feature = "zk"))]
+        Ok((
+            bytecode_read_raf.into_params(),
+            booleanity.into_params(),
+            StageVerifyResult {
+                challenges: r_stage6a,
+            },
+        ))
+    }
+
+    #[cfg_attr(not(feature = "zk"), allow(unused_variables))]
+    fn verify_stage6b(
+        &mut self,
+        bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
+        booleanity_params: BooleanitySumcheckParams<F>,
+    ) -> Result<StageVerifyResult<F>, ProofVerifyError> {
+        let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
+            bytecode_read_raf_params,
+            &self.opening_accumulator,
+        );
+        let ram_hamming_booleanity =
+            HammingBooleanitySumcheckVerifier::new(&self.opening_accumulator);
+        let booleanity =
+            BooleanityCycleSumcheckVerifier::new(booleanity_params, &self.opening_accumulator);
         let ram_ra_virtual = RamRaVirtualSumcheckVerifier::new(
             self.proof.trace_length,
             &self.one_hot_params,
@@ -1185,12 +1291,13 @@ impl<
             instances.push(advice);
         }
 
-        let (batching_coefficients, r_stage6) = BatchedSumcheck::verify(
-            &self.proof.stage6_sumcheck_proof,
+        let (batching_coefficients, r_stage6b) = BatchedSumcheck::verify(
+            &self.proof.stage6b_sumcheck_proof,
             instances.clone(),
             &mut self.opening_accumulator,
             &mut self.transcript,
-        )?;
+        )
+        .inspect_err(|err| tracing::error!("Stage 6b: {err}"))?;
 
         #[cfg(feature = "zk")]
         {
@@ -1204,7 +1311,7 @@ impl<
             for instance in &instances {
                 let num_rounds = instance.num_rounds();
                 let offset = instance.round_offset(max_num_rounds);
-                let r_slice = &r_stage6[offset..offset + num_rounds];
+                let r_slice = &r_stage6b[offset..offset + num_rounds];
                 output_constraint_challenge_values.extend(
                     instance
                         .get_params()
@@ -1217,7 +1324,7 @@ impl<
                 );
             }
             Ok(StageVerifyResult::new(
-                r_stage6,
+                r_stage6b,
                 batched_output_constraint,
                 output_constraint_challenge_values,
                 batched_input_constraint,
@@ -1227,7 +1334,7 @@ impl<
         }
         #[cfg(not(feature = "zk"))]
         Ok(StageVerifyResult {
-            challenges: r_stage6,
+            challenges: r_stage6b,
         })
     }
 
@@ -1235,12 +1342,12 @@ impl<
     #[allow(clippy::too_many_arguments)]
     fn verify_blindfold(
         &mut self,
-        sumcheck_challenges: &[Vec<F::Challenge>; 7],
+        sumcheck_challenges: &[Vec<F::Challenge>; 8],
         uniskip_challenges: [F::Challenge; 2],
-        stage_output_constraints: &[Option<OutputClaimConstraint>; 7],
-        output_constraint_challenge_values: &[Vec<F>; 7],
-        stage_input_constraints: &[InputClaimConstraint; 7],
-        input_constraint_challenge_values: &[Vec<F>; 7],
+        stage_output_constraints: &[Option<OutputClaimConstraint>; 8],
+        output_constraint_challenge_values: &[Vec<F>; 8],
+        stage_input_constraints: &[InputClaimConstraint; 8],
+        input_constraint_challenge_values: &[Vec<F>; 8],
         // For stages 0-1: batched input constraint for regular rounds (different from uni-skip)
         stage1_batched_input: &InputClaimConstraint,
         stage2_batched_input: &InputClaimConstraint,
@@ -1259,7 +1366,8 @@ impl<
             &self.proof.stage3_sumcheck_proof,
             &self.proof.stage4_sumcheck_proof,
             &self.proof.stage5_sumcheck_proof,
-            &self.proof.stage6_sumcheck_proof,
+            &self.proof.stage6a_sumcheck_proof,
+            &self.proof.stage6b_sumcheck_proof,
             &self.proof.stage7_sumcheck_proof,
         ];
 
@@ -1276,7 +1384,7 @@ impl<
         let mut stage_configs = Vec::new();
         // Track which stage_config index corresponds to uni-skip and regular first rounds
         let mut uniskip_indices: Vec<usize> = Vec::new(); // Only 2 elements for stages 0-1
-        let mut regular_first_round_indices: Vec<usize> = Vec::new(); // 7 elements for all stages
+        let mut regular_first_round_indices: Vec<usize> = Vec::new(); // 8 elements for all stages
         let mut last_round_indices: Vec<usize> = Vec::new();
 
         for (stage_idx, proof) in stage_proofs.iter().enumerate() {
@@ -1367,7 +1475,7 @@ impl<
             }
         }
 
-        // Add initial_input configurations for regular first rounds (all 7 stages)
+        // Add initial_input configurations for regular first rounds (all 8 stages)
         // These use the batched input constraints from the stage results
         let regular_constraints = [
             stage1_batched_input.clone(),       // Stage 0 regular
@@ -1376,7 +1484,8 @@ impl<
             stage_input_constraints[3].clone(), // Stage 3
             stage_input_constraints[4].clone(), // Stage 4
             stage_input_constraints[5].clone(), // Stage 5
-            stage_input_constraints[6].clone(), // Stage 6
+            stage_input_constraints[6].clone(), // Stage 6a
+            stage_input_constraints[7].clone(), // Stage 6b
         ];
         for (i, constraint) in regular_constraints.iter().enumerate() {
             let idx = regular_first_round_indices[i];
@@ -1404,7 +1513,7 @@ impl<
             }
         }
 
-        let all_input_challenge_values: [&[F]; 9] = [
+        let all_input_challenge_values: [&[F]; 10] = [
             &input_constraint_challenge_values[0],
             stage1_batched_input_values,
             &input_constraint_challenge_values[1],
@@ -1414,6 +1523,7 @@ impl<
             &input_constraint_challenge_values[4],
             &input_constraint_challenge_values[5],
             &input_constraint_challenge_values[6],
+            &input_constraint_challenge_values[7],
         ];
         let mut baked_input_challenges: Vec<F> = Vec::new();
         for expected_values in all_input_challenge_values.iter() {
@@ -1896,13 +2006,17 @@ where
         let max_padded_trace_length =
             usize::deserialize_with_mode(&mut reader, compress, validate)?;
         let bytecode_chunk_count = usize::deserialize_with_mode(&mut reader, compress, validate)?;
-        Ok(Self {
+        let shared = Self {
             program,
             program_meta,
             memory_layout,
             max_padded_trace_length,
             bytecode_chunk_count,
-        })
+        };
+        if matches!(validate, ark_serialize::Validate::Yes) {
+            ark_serialize::Valid::check(&shared)?;
+        }
+        Ok(shared)
     }
 }
 
@@ -1914,6 +2028,14 @@ where
         self.program.check()?;
         self.program_meta.check()?;
         self.memory_layout.check()?;
+        if self.program.is_committed()
+            && !is_valid_committed_bytecode_chunking_for_len(
+                self.program.bytecode_len(),
+                self.bytecode_chunk_count,
+            )
+        {
+            return Err(ark_serialize::SerializationError::InvalidData);
+        }
         Ok(())
     }
 }
@@ -1941,11 +2063,12 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
         max_padded_trace_length: usize,
         bytecode_chunk_count: usize,
     ) -> JoltSharedPreprocessing<PCS> {
-        validate_committed_bytecode_chunk_count(bytecode_chunk_count);
+        let bytecode_len = program.bytecode_len();
         assert!(
-            program.bytecode_len().is_multiple_of(bytecode_chunk_count),
-            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode size ({})",
-            program.bytecode_len()
+            is_valid_committed_bytecode_chunking_for_len(bytecode_len, bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must be non-zero, a power of two, at \
+             most {}, and divide bytecode size ({bytecode_len})",
+            crate::zkvm::bytecode::chunks::MAX_COMMITTED_BYTECODE_CHUNK_COUNT,
         );
         let mut shared = Self {
             program_meta: program.meta(),

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -283,4 +283,9 @@ pub enum VirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
+    BytecodeReadRafAddrClaim,
+    BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }

--- a/transpiler/src/symbolic_proof.rs
+++ b/transpiler/src/symbolic_proof.rs
@@ -355,11 +355,18 @@ pub fn symbolize_proof<OutputTranscript: Transcript>(
             "stage5_sumcheck",
         );
 
-        // === Symbolize stage 6 sumcheck proof ===
-        let stage6_sumcheck = symbolize_sumcheck_variant::<Bn254Curve, _, OutputTranscript>(
-            &real_proof.stage6_sumcheck_proof,
+        // === Symbolize stage 6a sumcheck proof ===
+        let stage6a_sumcheck = symbolize_sumcheck_variant::<Bn254Curve, _, OutputTranscript>(
+            &real_proof.stage6a_sumcheck_proof,
             &mut alloc,
-            "stage6_sumcheck",
+            "stage6a_sumcheck",
+        );
+
+        // === Symbolize stage 6b sumcheck proof ===
+        let stage6b_sumcheck = symbolize_sumcheck_variant::<Bn254Curve, _, OutputTranscript>(
+            &real_proof.stage6b_sumcheck_proof,
+            &mut alloc,
+            "stage6b_sumcheck",
         );
 
         // === Symbolize stage 7 sumcheck proof ===
@@ -390,7 +397,8 @@ pub fn symbolize_proof<OutputTranscript: Transcript>(
             stage3_sumcheck_proof: stage3_sumcheck,
             stage4_sumcheck_proof: stage4_sumcheck,
             stage5_sumcheck_proof: stage5_sumcheck,
-            stage6_sumcheck_proof: stage6_sumcheck,
+            stage6a_sumcheck_proof: stage6a_sumcheck,
+            stage6b_sumcheck_proof: stage6b_sumcheck,
             stage7_sumcheck_proof: stage7_sumcheck,
             joint_opening_proof: AstProof::default(),
             untrusted_advice_commitment,


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.

Stack position: `04`
Base branch: `stack/03-precommitted-geometry-substrate`
Source implementation reference: `LayerZero-Research/amir/bytecode-commitment-merged@a351d5078b83577db8f3264fa53dfaddcf5ed687`

Owned paths:
```
jolt-core/src/poly/opening_proof.rs jolt-core/src/subprotocols/booleanity.rs jolt-core/src/subprotocols/mod.rs jolt-core/src/subprotocols/sumcheck.rs jolt-core/src/zkvm/bytecode/read_raf_checking.rs jolt-core/src/zkvm/proof_serialization.rs jolt-core/src/zkvm/prover.rs jolt-core/src/zkvm/transpilable_verifier.rs jolt-core/src/zkvm/verifier.rs jolt-core/src/zkvm/witness.rs transpiler/src/main.rs transpiler/src/symbolic_proof.rs
```

See `specs/1344-committed-bytecode-program-image.md` for the slice checklist and verification expectations.
