### PR TITLE
feat: add committed bytecode and program image reductions

### DIFF
--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -1,0 +1,697 @@
+//! Two-phase bytecode claim reduction (Stage 6b cycle -> Stage 7 address).
+
+use std::cell::RefCell;
+
+use allocative::Allocative;
+use rayon::prelude::*;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+#[cfg(feature = "zk")]
+use crate::poly::opening_proof::OpeningId;
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint, ValueSource};
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::{committed_lanes, total_lanes, BYTECODE_LANE_LAYOUT};
+use crate::zkvm::bytecode::read_raf_checking::BytecodeReadRafSumcheckParams;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+use crate::zkvm::instruction::{CircuitFlags, InstructionFlags, NUM_CIRCUIT_FLAGS};
+use crate::zkvm::lookup_table::LookupTables;
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
+use common::constants::{REGISTER_COUNT, XLEN};
+use strum::EnumCount;
+
+const NUM_VAL_STAGES: usize = 5;
+
+#[derive(Clone, Allocative)]
+pub struct BytecodeClaimReductionParams<F: JoltField> {
+    pub phase: PrecommittedPhase,
+    pub precommitted: PrecommittedClaimReduction<F>,
+    pub eta: F,
+    pub eta_powers: [F; NUM_VAL_STAGES],
+    /// Eq weights over high bytecode address bits (one per committed chunk).
+    pub chunk_rbc_weights: Vec<F>,
+    pub bytecode_T: usize,
+    pub bytecode_chunk_count: usize,
+    pub bytecode_col_vars: usize,
+    pub bytecode_row_vars: usize,
+    pub r_bc: OpeningPoint<BIG_ENDIAN, F>,
+    pub lane_weights: Vec<F>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    pub fn new(
+        bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+        full_bytecode_len: usize,
+        bytecode_chunk_count: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &dyn OpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+    ) -> Self {
+        assert!(
+            full_bytecode_len.is_multiple_of(bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({full_bytecode_len})"
+        );
+        let bytecode_t = (full_bytecode_len / bytecode_chunk_count).log_2();
+        let bytecode_t_full = full_bytecode_len.log_2();
+
+        let eta: F = transcript.challenge_scalar();
+        let mut eta_powers = [F::one(); NUM_VAL_STAGES];
+        for i in 1..NUM_VAL_STAGES {
+            eta_powers[i] = eta_powers[i - 1] * eta;
+        }
+
+        let (r_bc_full, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        );
+        debug_assert_eq!(r_bc_full.r.len(), bytecode_t_full);
+        let dropped_bits = bytecode_t_full - bytecode_t;
+        let chunk_rbc_weights = if dropped_bits == 0 {
+            vec![F::one()]
+        } else {
+            EqPolynomial::<F>::evals(&r_bc_full.r[..dropped_bits])
+        };
+        debug_assert_eq!(chunk_rbc_weights.len(), bytecode_chunk_count);
+        let r_bc = OpeningPoint::new(r_bc_full.r[dropped_bits..].to_vec());
+
+        let lane_weights = compute_lane_weights(bytecode_read_raf_params, accumulator, &eta_powers);
+
+        // bytecode_K is the committed lane capacity (already next-power-of-two padded).
+        let bytecode_k = committed_lanes();
+        let total_vars = bytecode_k.log_2() + bytecode_t;
+        // Bytecode uses its own balanced dimensions (independent from Main).
+        // In Stage 8 it is embedded as a top-left block in Joint.
+        let (bytecode_col_vars, bytecode_row_vars) = DoryGlobals::balanced_sigma_nu(total_vars);
+        let precommitted = PrecommittedClaimReduction::new(
+            bytecode_row_vars,
+            bytecode_col_vars,
+            scheduling_reference,
+        );
+        // Align all precommitted scheduling/permutation to the shared reference domain.
+
+        Self {
+            phase: PrecommittedPhase::CycleVariables,
+            precommitted,
+            eta,
+            eta_powers,
+            chunk_rbc_weights,
+            bytecode_T: bytecode_t,
+            bytecode_chunk_count,
+            bytecode_col_vars,
+            bytecode_row_vars,
+            r_bc,
+            lane_weights,
+        }
+    }
+
+    pub fn num_address_phase_rounds(&self) -> usize {
+        self.precommitted.num_address_phase_rounds()
+    }
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    fn is_cycle_phase(&self) -> bool {
+        self.phase == PrecommittedPhase::CycleVariables
+    }
+
+    fn is_cycle_phase_round(&self, round: usize) -> bool {
+        self.precommitted.is_cycle_phase_round(round)
+    }
+
+    fn is_address_phase_round(&self, round: usize) -> bool {
+        self.precommitted.is_address_phase_round(round)
+    }
+
+    fn cycle_alignment_rounds(&self) -> usize {
+        self.precommitted.cycle_alignment_rounds()
+    }
+
+    fn address_alignment_rounds(&self) -> usize {
+        self.precommitted.address_alignment_rounds()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.phase = PrecommittedPhase::AddressVariables;
+    }
+
+    fn num_rounds_for_current_phase(&self) -> usize {
+        self.precommitted
+            .num_rounds_for_phase(self.is_cycle_phase())
+    }
+
+    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
+        self.precommitted
+            .round_offset(self.is_cycle_phase(), max_num_rounds)
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => (0..NUM_VAL_STAGES)
+                .map(|stage| {
+                    let (_, val_claim) = accumulator.get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeValStage(stage),
+                        SumcheckId::BytecodeReadRafAddressPhase,
+                    );
+                    self.eta_powers[stage] * val_claim
+                })
+                .sum(),
+            PrecommittedPhase::AddressVariables => {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn degree(&self) -> usize {
+        TWO_PHASE_DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.num_rounds_for_current_phase()
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted
+            .normalize_opening_point(self.is_cycle_phase(), challenges)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => {
+                let openings: Vec<OpeningId> = (0..NUM_VAL_STAGES)
+                    .map(|stage| {
+                        OpeningId::virt(
+                            VirtualPolynomial::BytecodeValStage(stage),
+                            SumcheckId::BytecodeReadRafAddressPhase,
+                        )
+                    })
+                    .collect();
+                InputClaimConstraint::all_weighted_openings(&openings)
+            }
+            PrecommittedPhase::AddressVariables => InputClaimConstraint::direct(OpeningId::virt(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+            )),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => self.eta_powers.to_vec(),
+            PrecommittedPhase::AddressVariables => Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => {
+                Some(OutputClaimConstraint::direct(OpeningId::virt(
+                    VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                    SumcheckId::BytecodeClaimReductionCyclePhase,
+                )))
+            }
+            PrecommittedPhase::AddressVariables => {
+                let terms = (0..self.bytecode_chunk_count)
+                    .map(|chunk_idx| {
+                        let opening = OpeningId::committed(
+                            CommittedPolynomial::BytecodeChunk(chunk_idx),
+                            SumcheckId::BytecodeClaimReduction,
+                        );
+                        (
+                            ValueSource::Challenge(chunk_idx),
+                            ValueSource::Opening(opening),
+                        )
+                    })
+                    .collect();
+                Some(OutputClaimConstraint::linear(terms))
+            }
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => vec![],
+            PrecommittedPhase::AddressVariables => {
+                let eq_combined = evaluate_bytecode_eq_combined(self, sumcheck_challenges);
+                let scale: F = precommitted_skip_round_scale(&self.precommitted);
+                self.chunk_rbc_weights
+                    .iter()
+                    .map(|w| *w * eq_combined * scale)
+                    .collect()
+            }
+        }
+    }
+}
+
+#[derive(Allocative)]
+pub struct BytecodeClaimReductionProver<F: JoltField> {
+    params: BytecodeClaimReductionParams<F>,
+    value_poly: MultilinearPolynomial<F>,
+    eq_poly: MultilinearPolynomial<F>,
+    scale: F,
+    chunk_value_polys: Vec<MultilinearPolynomial<F>>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionProver<F> {
+    pub fn params(&self) -> &BytecodeClaimReductionParams<F> {
+        &self.params
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.params.transition_to_address_phase();
+    }
+
+    pub fn initialize(
+        params: BytecodeClaimReductionParams<F>,
+        raw_chunk_coeffs: &[Vec<F>],
+    ) -> Self {
+        let eq_cycle = EqPolynomial::<F>::evals(&params.r_bc.r);
+        let eq_coeffs_template: Vec<F> = (0..raw_chunk_coeffs[0].len())
+            .map(|idx| {
+                let (lane, cycle) = native_index_to_lane_cycle(&params, idx);
+                params.lane_weights[lane] * eq_cycle[cycle]
+            })
+            .collect();
+
+        let raw_value_coeffs: Vec<F> = (0..raw_chunk_coeffs[0].len())
+            .into_par_iter()
+            .map(|idx| {
+                raw_chunk_coeffs
+                    .iter()
+                    .zip(params.chunk_rbc_weights.iter())
+                    .map(|(coeffs, weight)| coeffs[idx] * *weight)
+                    .sum::<F>()
+            })
+            .collect();
+        let mut coeffs_by_poly = Vec::with_capacity(2 + raw_chunk_coeffs.len());
+        coeffs_by_poly.push(raw_value_coeffs);
+        coeffs_by_poly.push(eq_coeffs_template);
+        for coeffs in raw_chunk_coeffs.iter() {
+            coeffs_by_poly.push(coeffs.clone());
+        }
+        let mut permuted_polys =
+            permute_precommitted_polys(coeffs_by_poly, &params.precommitted).into_iter();
+        let value_poly = permuted_polys
+            .next()
+            .expect("expected permuted bytecode value polynomial");
+        let eq_poly = permuted_polys
+            .next()
+            .expect("expected permuted bytecode eq polynomial");
+        let chunk_value_polys: Vec<MultilinearPolynomial<F>> = permuted_polys.collect();
+
+        Self {
+            params,
+            value_poly,
+            eq_poly,
+            scale: F::one(),
+            chunk_value_polys,
+        }
+    }
+
+    fn bind_aux_polys(&mut self, r_j: F::Challenge) {
+        for poly in self.chunk_value_polys.iter_mut() {
+            poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        }
+    }
+
+    fn compute_message_unscaled(&self, previous_claim_unscaled: F) -> UniPoly<F> {
+        let half = self.value_poly.len() / 2;
+        let evals: [F; TWO_PHASE_DEGREE_BOUND] = (0..half)
+            .into_par_iter()
+            .map(|j| {
+                let value_evals = self
+                    .value_poly
+                    .sumcheck_evals_array::<TWO_PHASE_DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                let eq_evals = self
+                    .eq_poly
+                    .sumcheck_evals_array::<TWO_PHASE_DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                let mut out = [F::zero(); TWO_PHASE_DEGREE_BOUND];
+                for i in 0..TWO_PHASE_DEGREE_BOUND {
+                    out[i] = value_evals[i] * eq_evals[i];
+                }
+                out
+            })
+            .reduce(
+                || [F::zero(); TWO_PHASE_DEGREE_BOUND],
+                |mut acc, arr| {
+                    acc.iter_mut().zip(arr.iter()).for_each(|(a, b)| *a += *b);
+                    acc
+                },
+            );
+        UniPoly::from_evals_and_hint(previous_claim_unscaled, &evals)
+    }
+
+    fn cycle_intermediate_claim(&self) -> F {
+        let len = self.value_poly.len();
+        debug_assert_eq!(len, self.eq_poly.len());
+        let mut sum = F::zero();
+        for i in 0..len {
+            sum += self.value_poly.get_bound_coeff(i) * self.eq_poly.get_bound_coeff(i);
+        }
+        sum * self.scale
+    }
+
+    fn final_claim_if_ready(&self) -> Option<F> {
+        if self.value_poly.len() == 1 {
+            Some(self.value_poly.get_bound_coeff(0))
+        } else {
+            None
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaimReductionProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        &self.params
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        self.params.round_offset(max_num_rounds)
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        let is_active_round = if self.params.is_cycle_phase() {
+            self.params.is_cycle_phase_round(round)
+        } else {
+            self.params.is_address_phase_round(round)
+        };
+        if !is_active_round {
+            return UniPoly::from_coeff(vec![previous_claim * F::from_u64(2).inverse().unwrap()]);
+        }
+
+        let trailing_cap = if self.params.is_cycle_phase() {
+            self.params.cycle_alignment_rounds()
+        } else {
+            self.params.address_alignment_rounds()
+        };
+        let num_trailing_variables =
+            trailing_cap.saturating_sub(self.params.num_rounds_for_current_phase());
+        let scaling_factor = self.scale * F::one().mul_pow_2(num_trailing_variables);
+        let prev_unscaled = previous_claim * scaling_factor.inverse().unwrap();
+        let poly_unscaled = self.compute_message_unscaled(prev_unscaled);
+        poly_unscaled * scaling_factor
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        let is_active_round = if self.params.is_cycle_phase() {
+            self.params.is_cycle_phase_round(round)
+        } else {
+            self.params.is_address_phase_round(round)
+        };
+        if !is_active_round {
+            self.scale *= F::from_u64(2).inverse().unwrap();
+            return;
+        }
+
+        self.value_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.bind_aux_polys(r_j);
+        if self.params.is_cycle_phase() {
+            self.params.precommitted.record_cycle_challenge(r_j);
+        }
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let params = &self.params;
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+
+        if params.phase == PrecommittedPhase::CycleVariables {
+            accumulator.append_virtual(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+                opening_point.clone(),
+                self.cycle_intermediate_claim(),
+            );
+        }
+
+        if let Some(bytecode_claim) = self.final_claim_if_ready() {
+            let chunk_claims: Vec<F> = self
+                .chunk_value_polys
+                .iter()
+                .map(|poly| poly.final_sumcheck_claim())
+                .collect();
+            let weighted_chunk_sum = chunk_claims
+                .iter()
+                .zip(params.chunk_rbc_weights.iter())
+                .map(|(claim, weight)| *claim * *weight)
+                .sum::<F>();
+            debug_assert_eq!(weighted_chunk_sum, bytecode_claim);
+            for (chunk_idx, claim) in chunk_claims.into_iter().enumerate() {
+                accumulator.append_dense(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                    opening_point.r.clone(),
+                    claim,
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct BytecodeClaimReductionVerifier<F: JoltField> {
+    pub params: RefCell<BytecodeClaimReductionParams<F>>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionVerifier<F> {
+    pub fn new(params: BytecodeClaimReductionParams<F>) -> Self {
+        Self {
+            params: RefCell::new(params),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for BytecodeClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        unsafe { &*self.params.as_ptr() }
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        let params = self.params.borrow();
+        params.round_offset(max_num_rounds)
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let params = self.params.borrow();
+        match params.phase {
+            PrecommittedPhase::CycleVariables => {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                let bytecode_opening: F = (0..params.bytecode_chunk_count)
+                    .map(|chunk_idx| {
+                        params.chunk_rbc_weights[chunk_idx]
+                            * accumulator
+                                .get_committed_polynomial_opening(
+                                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                                    SumcheckId::BytecodeClaimReduction,
+                                )
+                                .1
+                    })
+                    .sum();
+                let eq_combined = evaluate_bytecode_eq_combined(&params, sumcheck_challenges);
+                let scale: F = precommitted_skip_round_scale(&params.precommitted);
+
+                bytecode_opening * eq_combined * scale
+            }
+        }
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let mut params = self.params.borrow_mut();
+        if params.phase == PrecommittedPhase::CycleVariables {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            accumulator.append_virtual(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+                opening_point.clone(),
+            );
+            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
+            params
+                .precommitted
+                .set_cycle_var_challenges(opening_point_le.r);
+        }
+
+        if params.num_address_phase_rounds() == 0
+            || params.phase == PrecommittedPhase::AddressVariables
+        {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            for chunk_idx in 0..params.bytecode_chunk_count {
+                accumulator.append_dense(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                    opening_point.r.clone(),
+                );
+            }
+        }
+    }
+}
+
+fn evaluate_bytecode_eq_combined<F: JoltField>(
+    params: &BytecodeClaimReductionParams<F>,
+    sumcheck_challenges: &[F::Challenge],
+) -> F {
+    let opening_point = params.normalize_opening_point(sumcheck_challenges);
+    let lane_var_count = committed_lanes().log_2();
+
+    let (lane_challenges, cycle_challenges) = match DoryGlobals::get_layout() {
+        DoryLayout::CycleMajor => {
+            let (lane, cycle) = opening_point.r.split_at(lane_var_count);
+            (lane, cycle)
+        }
+        DoryLayout::AddressMajor => {
+            let (cycle, lane) = opening_point.r.split_at(params.bytecode_T);
+            (lane, cycle)
+        }
+    };
+
+    debug_assert_eq!(lane_challenges.len(), lane_var_count);
+    debug_assert_eq!(cycle_challenges.len(), params.r_bc.r.len());
+
+    let eq_cycle = EqPolynomial::mle(cycle_challenges, &params.r_bc.r);
+    let eq_lane = EqPolynomial::<F>::evals(lane_challenges);
+    let lane_weight_eval: F = params
+        .lane_weights
+        .iter()
+        .zip(eq_lane.iter())
+        .map(|(w, eq)| *w * *eq)
+        .sum();
+
+    lane_weight_eval * eq_cycle
+}
+
+#[inline(always)]
+fn native_index_to_lane_cycle<F: JoltField>(
+    params: &BytecodeClaimReductionParams<F>,
+    index: usize,
+) -> (usize, usize) {
+    let bytecode_len = 1usize << params.bytecode_T;
+    match DoryGlobals::get_layout() {
+        DoryLayout::CycleMajor => (index / bytecode_len, index % bytecode_len),
+        DoryLayout::AddressMajor => (index % committed_lanes(), index / committed_lanes()),
+    }
+}
+
+fn compute_lane_weights<F: JoltField>(
+    bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+    accumulator: &dyn OpeningAccumulator<F>,
+    eta_powers: &[F; NUM_VAL_STAGES],
+) -> Vec<F> {
+    let reg_count = REGISTER_COUNT as usize;
+    let layout = BYTECODE_LANE_LAYOUT;
+    debug_assert_eq!(layout.raf_flag_idx + 1, total_lanes());
+
+    let log_reg = reg_count.log_2();
+    let r_register_4 = accumulator
+        .get_virtual_polynomial_opening(
+            VirtualPolynomial::RdWa,
+            SumcheckId::RegistersReadWriteChecking,
+        )
+        .0
+        .r;
+    let eq_r_register_4 = EqPolynomial::<F>::evals(&r_register_4[..log_reg]);
+
+    let r_register_5 = accumulator
+        .get_virtual_polynomial_opening(VirtualPolynomial::RdWa, SumcheckId::RegistersValEvaluation)
+        .0
+        .r;
+    let eq_r_register_5 = EqPolynomial::<F>::evals(&r_register_5[..log_reg]);
+
+    let mut weights = vec![F::zero(); committed_lanes()];
+
+    {
+        let coeff = eta_powers[0];
+        let g = &bytecode_read_raf_params.stage1_gammas;
+        weights[layout.unexp_pc_idx] += coeff * g[0];
+        weights[layout.imm_idx] += coeff * g[1];
+        for i in 0..NUM_CIRCUIT_FLAGS {
+            weights[layout.circuit_start + i] += coeff * g[2 + i];
+        }
+    }
+    {
+        let coeff = eta_powers[1];
+        let g = &bytecode_read_raf_params.stage2_gammas;
+        weights[layout.circuit_start + (CircuitFlags::Jump as usize)] += coeff * g[0];
+        weights[layout.instr_start + (InstructionFlags::Branch as usize)] += coeff * g[1];
+        weights[layout.circuit_start + (CircuitFlags::WriteLookupOutputToRD as usize)] +=
+            coeff * g[2];
+        weights[layout.circuit_start + (CircuitFlags::VirtualInstruction as usize)] += coeff * g[3];
+    }
+    {
+        let coeff = eta_powers[2];
+        let g = &bytecode_read_raf_params.stage3_gammas;
+        weights[layout.imm_idx] += coeff * g[0];
+        weights[layout.unexp_pc_idx] += coeff * g[1];
+        weights[layout.instr_start + (InstructionFlags::LeftOperandIsRs1Value as usize)] +=
+            coeff * g[2];
+        weights[layout.instr_start + (InstructionFlags::LeftOperandIsPC as usize)] += coeff * g[3];
+        weights[layout.instr_start + (InstructionFlags::RightOperandIsRs2Value as usize)] +=
+            coeff * g[4];
+        weights[layout.instr_start + (InstructionFlags::RightOperandIsImm as usize)] +=
+            coeff * g[5];
+        weights[layout.instr_start + (InstructionFlags::IsNoop as usize)] += coeff * g[6];
+        weights[layout.circuit_start + (CircuitFlags::VirtualInstruction as usize)] += coeff * g[7];
+        weights[layout.circuit_start + (CircuitFlags::IsFirstInSequence as usize)] += coeff * g[8];
+    }
+    {
+        let coeff = eta_powers[3];
+        let g = &bytecode_read_raf_params.stage4_gammas;
+        for r in 0..reg_count {
+            weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_4[r];
+            weights[layout.rs1_start + r] += coeff * g[1] * eq_r_register_4[r];
+            weights[layout.rs2_start + r] += coeff * g[2] * eq_r_register_4[r];
+        }
+    }
+    {
+        let coeff = eta_powers[4];
+        let g = &bytecode_read_raf_params.stage5_gammas;
+        for r in 0..reg_count {
+            weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_5[r];
+        }
+        weights[layout.raf_flag_idx] += coeff * g[1];
+        for i in 0..LookupTables::<XLEN>::COUNT {
+            weights[layout.lookup_start + i] += coeff * g[2 + i];
+        }
+    }
+
+    weights
+}

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -1,14 +1,19 @@
 pub mod advice;
+pub mod bytecode;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction_lookups;
 mod precommitted;
+pub mod program_image;
 pub mod ram_ra;
 pub mod registers;
 
 pub use advice::{
     AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceClaimReductionVerifier,
     AdviceKind,
+};
+pub use bytecode::{
+    BytecodeClaimReductionParams, BytecodeClaimReductionProver, BytecodeClaimReductionVerifier,
 };
 pub use hamming_weight::{
     HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
@@ -26,6 +31,10 @@ pub use precommitted::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
     precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction, PrecommittedPhase,
     PrecommittedPolynomial, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+pub use program_image::{
+    ProgramImageClaimReductionParams, ProgramImageClaimReductionProver,
+    ProgramImageClaimReductionVerifier,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/program_image.rs
+++ b/jolt-core/src/zkvm/claim_reductions/program_image.rs
@@ -1,0 +1,615 @@
+//! Program-image (initial RAM) claim reduction.
+//!
+//! In committed bytecode mode, Stage 4 consumes prover-supplied scalar claims for the
+//! program-image contribution to `Val_init(r_address)` without materializing the initial RAM.
+//! This sumcheck binds those scalars to a trusted commitment to the program-image words polynomial.
+
+use allocative::Allocative;
+use std::cell::RefCell;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
+#[cfg(feature = "zk")]
+use crate::poly::opening_proof::OpeningId;
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint, ValueSource};
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+use crate::zkvm::ram::remap_address;
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
+use tracer::JoltDevice;
+
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
+
+#[derive(Clone, Allocative)]
+pub struct ProgramImageClaimReductionParams<F: JoltField> {
+    pub phase: PrecommittedPhase,
+    pub precommitted: PrecommittedClaimReduction<F>,
+    pub prog_col_vars: usize,
+    pub prog_row_vars: usize,
+    pub ram_num_vars: usize,
+    pub start_index: usize,
+    pub padded_len_words: usize,
+    pub m: usize,
+    pub r_addr_rw: Vec<F::Challenge>,
+    pub shifted_eq_coeffs: Vec<F>,
+}
+
+impl<F: JoltField> ProgramImageClaimReductionParams<F> {
+    pub fn num_address_phase_rounds(&self) -> usize {
+        self.precommitted.num_address_phase_rounds()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        program_io: &JoltDevice,
+        ram_min_bytecode_address: u64,
+        padded_len_words: usize,
+        ram_K: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &dyn OpeningAccumulator<F>,
+        _transcript: &mut impl Transcript,
+    ) -> Self {
+        let ram_num_vars = ram_K.log_2();
+        let start_index =
+            remap_address(ram_min_bytecode_address, &program_io.memory_layout).unwrap() as usize;
+        let m = padded_len_words.log_2();
+        debug_assert!(padded_len_words.is_power_of_two());
+        debug_assert!(padded_len_words > 0);
+        let (prog_col_vars, prog_row_vars) = DoryGlobals::balanced_sigma_nu(m);
+        let precommitted =
+            PrecommittedClaimReduction::new(prog_row_vars, prog_col_vars, scheduling_reference);
+
+        let (r_rw, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::RamVal,
+            SumcheckId::RamReadWriteChecking,
+        );
+        let (r_addr_rw, _) = r_rw.split_at(ram_num_vars);
+        let shifted_eq_coeffs =
+            shifted_program_image_eq_slice::<F>(&r_addr_rw.r, start_index, padded_len_words);
+
+        Self {
+            phase: PrecommittedPhase::CycleVariables,
+            precommitted,
+            prog_col_vars,
+            prog_row_vars,
+            ram_num_vars,
+            start_index,
+            padded_len_words,
+            m,
+            r_addr_rw: r_addr_rw.r,
+            shifted_eq_coeffs,
+        }
+    }
+}
+
+impl<F: JoltField> ProgramImageClaimReductionParams<F> {
+    fn is_cycle_phase(&self) -> bool {
+        self.phase == PrecommittedPhase::CycleVariables
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.phase = PrecommittedPhase::AddressVariables;
+    }
+
+    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
+        self.precommitted
+            .round_offset(self.is_cycle_phase(), max_num_rounds)
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => {
+                // Scalar claims were staged in Stage 4 as virtual openings.
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::ProgramImageInitContributionRw,
+                        SumcheckId::RamValCheck,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn degree(&self) -> usize {
+        TWO_PHASE_DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.precommitted
+            .num_rounds_for_phase(self.is_cycle_phase())
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted
+            .normalize_opening_point(self.is_cycle_phase(), challenges)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => InputClaimConstraint::direct(OpeningId::virt(
+                VirtualPolynomial::ProgramImageInitContributionRw,
+                SumcheckId::RamValCheck,
+            )),
+            PrecommittedPhase::AddressVariables => {
+                InputClaimConstraint::direct(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReductionCyclePhase,
+                ))
+            }
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => {
+                Some(OutputClaimConstraint::direct(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReductionCyclePhase,
+                )))
+            }
+            PrecommittedPhase::AddressVariables => Some(OutputClaimConstraint::linear(vec![(
+                ValueSource::Challenge(0),
+                ValueSource::Opening(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                )),
+            )])),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        match self.phase {
+            PrecommittedPhase::CycleVariables => vec![],
+            PrecommittedPhase::AddressVariables => {
+                let opening_point = self.normalize_opening_point(sumcheck_challenges);
+                let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
+                    &self.r_addr_rw,
+                    self.start_index,
+                    &opening_point.r,
+                );
+                debug_assert_eq!(
+                    eq_combined,
+                    evaluate_shifted_eq_poly::<F, _>(&self.shifted_eq_coeffs, &opening_point.r),
+                    "program_image eq_slice optimized evaluation mismatch"
+                );
+                let scale: F = precommitted_skip_round_scale(&self.precommitted);
+                vec![eq_combined * scale]
+            }
+        }
+    }
+}
+
+impl<F: JoltField> PrecommittedParams<F> for ProgramImageClaimReductionParams<F> {
+    fn is_cycle_phase(&self) -> bool {
+        self.phase == PrecommittedPhase::CycleVariables
+    }
+
+    fn is_cycle_phase_round(&self, round: usize) -> bool {
+        self.precommitted.is_cycle_phase_round(round)
+    }
+
+    fn is_address_phase_round(&self, round: usize) -> bool {
+        self.precommitted.is_address_phase_round(round)
+    }
+
+    fn cycle_alignment_rounds(&self) -> usize {
+        self.precommitted.cycle_alignment_rounds()
+    }
+
+    fn address_alignment_rounds(&self) -> usize {
+        self.precommitted.address_alignment_rounds()
+    }
+
+    fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
+        self.precommitted.record_cycle_challenge(challenge);
+    }
+}
+
+#[derive(Allocative)]
+pub struct ProgramImageClaimReductionProver<F: JoltField> {
+    core: PrecommittedProver<F, ProgramImageClaimReductionParams<F>>,
+}
+
+fn shifted_program_image_eq_slice<F>(
+    r_addr: &[F::Challenge],
+    start_index: usize,
+    padded_len_words: usize,
+) -> Vec<F>
+where
+    F: JoltField + std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
+{
+    let mut eq_slice = Vec::with_capacity(padded_len_words);
+    let mut idx = start_index;
+    let mut remaining = padded_len_words;
+
+    while remaining > 0 {
+        let (block_size, block_evals) =
+            EqPolynomial::<F>::evals_for_max_aligned_block(r_addr, idx, remaining);
+        eq_slice.extend(block_evals);
+        idx += block_size;
+        remaining -= block_size;
+    }
+
+    eq_slice
+}
+
+fn evaluate_shifted_eq_poly<F, C>(shifted_eq_coeffs: &[F], opening_point: &[C]) -> F
+where
+    C: Copy + Send + Sync + Into<F> + crate::field::ChallengeFieldOps<F>,
+    F: JoltField + crate::field::FieldChallengeOps<C>,
+{
+    MultilinearPolynomial::from(shifted_eq_coeffs.to_vec()).evaluate(opening_point)
+}
+
+impl<F: JoltField> ProgramImageClaimReductionProver<F> {
+    pub fn params(&self) -> &ProgramImageClaimReductionParams<F> {
+        self.core.params()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.core.params_mut().transition_to_address_phase();
+    }
+
+    #[tracing::instrument(skip_all, name = "ProgramImageClaimReductionProver::initialize")]
+    pub fn initialize(
+        params: ProgramImageClaimReductionParams<F>,
+        program_image_words_padded: Vec<u64>,
+    ) -> Self {
+        debug_assert_eq!(program_image_words_padded.len(), params.padded_len_words);
+        debug_assert_eq!(params.padded_len_words, 1usize << params.m);
+
+        let eq_slice = permute_precommitted_polys(
+            vec![params.shifted_eq_coeffs.clone()],
+            &params.precommitted,
+        )
+        .into_iter()
+        .next()
+        .expect("expected one permuted shifted eq polynomial");
+
+        // Permute ProgramWord and eq_slice so low-to-high binding follows the two-phase
+        // schedule while preserving top-left projection semantics against the joint point.
+        let program_word: MultilinearPolynomial<F> = {
+            let mut permuted =
+                permute_precommitted_polys(vec![program_image_words_padded], &params.precommitted)
+                    .into_iter();
+            permuted
+                .next()
+                .expect("expected one permuted program image polynomial")
+        };
+
+        Self {
+            core: PrecommittedProver::new(params, program_word, eq_slice),
+        }
+    }
+
+    pub fn from_bound_state(
+        params: ProgramImageClaimReductionParams<F>,
+        program_word_coeffs: Vec<F>,
+        eq_slice_coeffs: Vec<F>,
+    ) -> Self {
+        Self::from_bound_state_with_scale(params, program_word_coeffs, eq_slice_coeffs, F::one())
+    }
+
+    pub fn from_bound_state_with_scale(
+        params: ProgramImageClaimReductionParams<F>,
+        program_word_coeffs: Vec<F>,
+        eq_slice_coeffs: Vec<F>,
+        scale: F,
+    ) -> Self {
+        let mut prover = Self {
+            core: PrecommittedProver::new(
+                params,
+                MultilinearPolynomial::from(program_word_coeffs),
+                MultilinearPolynomial::from(eq_slice_coeffs),
+            ),
+        };
+        prover.core.set_scale(scale);
+        prover
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for ProgramImageClaimReductionProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        self.core.params()
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        self.core.params().round_offset(max_num_rounds)
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        self.core.compute_message(round, previous_claim)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        self.core.ingest_challenge(r_j, round);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let params = self.core.params();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+        if params.phase == PrecommittedPhase::CycleVariables {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReductionCyclePhase,
+                // This is a phase-boundary intermediate claim, not a real program-image opening.
+                // Keep a sentinel point so it cannot alias with the final opening claim.
+                vec![],
+                self.core.cycle_intermediate_claim(),
+            );
+        }
+
+        if let Some(claim) = self.core.final_claim_if_ready() {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+                opening_point.r,
+                claim,
+            );
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct ProgramImageClaimReductionVerifier<F: JoltField> {
+    pub params: RefCell<ProgramImageClaimReductionParams<F>>,
+}
+
+impl<F: JoltField> ProgramImageClaimReductionVerifier<F> {
+    pub fn new(params: ProgramImageClaimReductionParams<F>) -> Self {
+        Self {
+            params: RefCell::new(params),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for ProgramImageClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        unsafe { &*self.params.as_ptr() }
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        let params = self.params.borrow();
+        params.round_offset(max_num_rounds)
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let params = self.params.borrow();
+        match params.phase {
+            PrecommittedPhase::CycleVariables => {
+                accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                let opening_point = params.normalize_opening_point(sumcheck_challenges);
+                debug_assert_eq!(opening_point.len(), params.m);
+                let pw_eval = accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReduction,
+                    )
+                    .1;
+                let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
+                    &params.r_addr_rw,
+                    params.start_index,
+                    &opening_point.r,
+                );
+                debug_assert_eq!(
+                    eq_combined,
+                    evaluate_shifted_eq_poly::<F, _>(&params.shifted_eq_coeffs, &opening_point.r),
+                    "program_image eq_slice optimized evaluation mismatch"
+                );
+                let scale: F = precommitted_skip_round_scale(&params.precommitted);
+                pw_eval * eq_combined * scale
+            }
+        }
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let mut params = self.params.borrow_mut();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+        if params.phase == PrecommittedPhase::CycleVariables {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReductionCyclePhase,
+                // Match prover behavior: the cycle-phase intermediate claim is not a real opening.
+                vec![],
+            );
+            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
+            params
+                .precommitted
+                .set_cycle_var_challenges(opening_point_le.r);
+        }
+
+        if params.phase == PrecommittedPhase::AddressVariables
+            || params.num_address_phase_rounds() == 0
+        {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+                opening_point.r,
+            );
+        }
+    }
+}
+
+fn eval_shifted_eq_poly_at_opening_point<F>(
+    r_addr_be: &[F::Challenge],
+    start_index: usize,
+    opening_point_be: &[F::Challenge],
+) -> F
+where
+    F: JoltField,
+{
+    let ell = r_addr_be.len();
+    let m = opening_point_be.len();
+    debug_assert!(m <= ell);
+
+    let challenge_for_old_lsb = |old_lsb: usize| -> F {
+        debug_assert!(old_lsb < m);
+        opening_point_be[m - 1 - old_lsb].into()
+    };
+
+    // Match the current verifier path exactly: `opening_point_be` is already arranged in the
+    // variable order expected by `evaluate_shifted_eq_poly`.
+    let mut dp0 = F::one();
+    let mut dp1 = F::zero();
+
+    for old_lsb in 0..ell {
+        let start_bit = ((start_index >> old_lsb) & 1) as u8;
+        let r_addr_bit: F = r_addr_be[ell - 1 - old_lsb].into();
+        let k0 = F::one() - r_addr_bit;
+        let k1 = r_addr_bit;
+        let y_var = old_lsb < m;
+        let r_y = if y_var {
+            challenge_for_old_lsb(old_lsb)
+        } else {
+            F::zero()
+        };
+
+        let mut next_dp0 = F::zero();
+        let mut next_dp1 = F::zero();
+
+        let update_state = |weight: F, carry: u8, next_dp0: &mut F, next_dp1: &mut F| {
+            if weight.is_zero() {
+                return;
+            }
+
+            if y_var {
+                let sum0 = start_bit + carry;
+                let k_bit0 = sum0 & 1;
+                let carry0 = (sum0 >> 1) & 1;
+                let addr_factor0 = if k_bit0 == 1 { k1 } else { k0 };
+                let y_factor0 = F::one() - r_y;
+                if carry0 == 0 {
+                    *next_dp0 += weight * addr_factor0 * y_factor0;
+                } else {
+                    *next_dp1 += weight * addr_factor0 * y_factor0;
+                }
+
+                let sum1 = start_bit + carry + 1;
+                let k_bit1 = sum1 & 1;
+                let carry1 = (sum1 >> 1) & 1;
+                let addr_factor1 = if k_bit1 == 1 { k1 } else { k0 };
+                if carry1 == 0 {
+                    *next_dp0 += weight * addr_factor1 * r_y;
+                } else {
+                    *next_dp1 += weight * addr_factor1 * r_y;
+                }
+            } else {
+                let sum0 = start_bit + carry;
+                let k_bit0 = sum0 & 1;
+                let carry0 = (sum0 >> 1) & 1;
+                let addr_factor0 = if k_bit0 == 1 { k1 } else { k0 };
+                if carry0 == 0 {
+                    *next_dp0 += weight * addr_factor0;
+                } else {
+                    *next_dp1 += weight * addr_factor0;
+                }
+            }
+        };
+
+        update_state(dp0, 0, &mut next_dp0, &mut next_dp1);
+        update_state(dp1, 1, &mut next_dp0, &mut next_dp1);
+        dp0 = next_dp0;
+        dp1 = next_dp1;
+    }
+
+    dp0 + dp1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bn254::Fr;
+
+    type Challenge = <Fr as JoltField>::Challenge;
+
+    #[test]
+    fn shifted_program_image_eq_slice_matches_dense_eq_windows() {
+        let r_addr = [3_u128, 5, 7, 11].map(Challenge::from).to_vec();
+        let dense = EqPolynomial::<Fr>::evals(&r_addr);
+
+        for (start_index, padded_len_words) in [(0, 16), (3, 8), (5, 4), (14, 2)] {
+            let shifted =
+                shifted_program_image_eq_slice::<Fr>(&r_addr, start_index, padded_len_words);
+            assert_eq!(
+                shifted,
+                dense[start_index..start_index + padded_len_words],
+                "shifted eq slice mismatch at start={start_index}, len={padded_len_words}",
+            );
+        }
+    }
+
+    #[test]
+    fn optimized_shifted_eq_eval_matches_multilinear_eval() {
+        let r_addr = [2_u128, 3, 5, 7, 11].map(Challenge::from).to_vec();
+
+        for (start_index, opening_point) in [
+            (3, [13_u128, 17, 19].map(Challenge::from).to_vec()),
+            (16, [23_u128, 29].map(Challenge::from).to_vec()),
+        ] {
+            let shifted = shifted_program_image_eq_slice::<Fr>(
+                &r_addr,
+                start_index,
+                1 << opening_point.len(),
+            );
+            let direct = evaluate_shifted_eq_poly::<Fr, _>(&shifted, &opening_point);
+            let optimized =
+                eval_shifted_eq_poly_at_opening_point::<Fr>(&r_addr, start_index, &opening_point);
+
+            assert_eq!(
+                optimized, direct,
+                "optimized shifted eq eval mismatch at start={start_index}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.

Stack position: `06`
Base branch: `stack/05-precommitted-claim-reduction-advice`
Source implementation reference: `LayerZero-Research/amir/bytecode-commitment-merged@a351d5078b83577db8f3264fa53dfaddcf5ed687`

Owned paths:
```
jolt-core/src/zkvm/claim_reductions/bytecode.rs jolt-core/src/zkvm/claim_reductions/program_image.rs jolt-core/src/zkvm/claim_reductions/mod.rs jolt-core/src/zkvm/witness.rs jolt-core/src/zkvm/proof_serialization.rs jolt-core/src/zkvm/bytecode/read_raf_checking.rs jolt-core/src/zkvm/ram/mod.rs jolt-core/src/zkvm/ram/val_check.rs
```

See `specs/1344-committed-bytecode-program-image.md` for the slice checklist and verification expectations.
