### PR TITLE
feat: wire committed program mode into zkVM protocol

### DIFF
--- a/jolt-core/benches/e2e_profiling.rs
+++ b/jolt-core/benches/e2e_profiling.rs
@@ -264,7 +264,7 @@ fn prove_example_with_trace(
     );
 
     let program_data =
-        ProgramPreprocessing::preprocess(bytecode.clone(), init_memory_state, e_entry).unwrap();
+        ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap();
     let shared_preprocessing = JoltSharedPreprocessing::new(
         program_data,
         program_io.memory_layout.clone(),

--- a/jolt-core/src/guest/verifier.rs
+++ b/jolt-core/src/guest/verifier.rs
@@ -4,12 +4,12 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment};
 use crate::utils::errors::ProofVerifyError;
 use crate::zkvm::bytecode::PreprocessingError;
-use crate::zkvm::program::ProgramPreprocessing;
 use crate::zkvm::verifier::BlindfoldSetup;
 
 use crate::guest::program::Program;
 use crate::poly::commitment::dory::DoryCommitmentScheme;
 use crate::transcripts::Transcript;
+use crate::zkvm::program::ProgramPreprocessing;
 use crate::zkvm::proof_serialization::JoltProof;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::zkvm::verifier::JoltVerifier;

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -36,7 +36,6 @@ pub enum AdviceKind {
 #[derive(Clone, Allocative)]
 pub struct AdviceClaimReductionParams<F: JoltField> {
     pub kind: AdviceKind,
-    pub phase: PrecommittedPhase,
     pub precommitted: PrecommittedClaimReduction<F>,
     pub advice_col_vars: usize,
     pub advice_row_vars: usize,
@@ -62,33 +61,17 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
 
         Self {
             kind,
-            phase: PrecommittedPhase::CycleVariables,
             precommitted,
             advice_col_vars,
             advice_row_vars,
             r_val,
         }
     }
-
-    pub fn num_address_phase_rounds(&self) -> usize {
-        self.precommitted.num_address_phase_rounds()
-    }
-
-    pub fn transition_to_address_phase(&mut self) {
-        self.phase = PrecommittedPhase::AddressVariables;
-    }
-
-    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.precommitted.round_offset(
-            self.phase == PrecommittedPhase::CycleVariables,
-            max_num_rounds,
-        )
-    }
 }
 
 impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 accumulator
                     .get_advice_opening(self.kind, SumcheckId::RamValCheck)
@@ -109,18 +92,16 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.precommitted
-            .num_rounds_for_phase(self.phase == PrecommittedPhase::CycleVariables)
+        self.precommitted.num_rounds_for_current_phase()
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        self.precommitted
-            .normalize_opening_point(self.phase == PrecommittedPhase::CycleVariables, challenges)
+        self.precommitted.normalize_opening_point(challenges)
     }
 
     #[cfg(feature = "zk")]
     fn input_claim_constraint(&self) -> InputClaimConstraint {
-        let opening = match self.phase {
+        let opening = match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => match self.kind {
                 AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::RamValCheck),
                 AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::RamValCheck),
@@ -144,9 +125,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
 
     #[cfg(feature = "zk")]
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
-                if self.num_address_phase_rounds() > 0 {
+                if self.precommitted.num_address_phase_rounds() > 0 {
                     let advice_opening = match self.kind {
                         AdviceKind::Trusted => {
                             OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
@@ -165,8 +146,12 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        match self.phase {
-            PrecommittedPhase::CycleVariables if self.num_address_phase_rounds() > 0 => vec![],
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if self.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                vec![]
+            }
             PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
                 vec![self.final_advice_output_scale(sumcheck_challenges)]
             }
@@ -189,7 +174,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
 
     fn final_advice_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
         let eq_eval = self.final_advice_eq_eval(sumcheck_challenges);
-        let scale = match self.phase {
+        let scale = match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
             PrecommittedPhase::AddressVariables => {
                 precommitted_skip_round_scale(&self.precommitted)
@@ -218,7 +203,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
     ) -> F::Challenge {
         let cycle_rounds = self.precommitted.cycle_alignment_rounds();
         if global_round < cycle_rounds {
-            return match self.phase {
+            return match self.precommitted.phase {
                 PrecommittedPhase::CycleVariables => sumcheck_challenges[global_round],
                 PrecommittedPhase::AddressVariables => {
                     let idx = self
@@ -232,7 +217,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         }
 
         assert_eq!(
-            self.phase,
+            self.precommitted.phase,
             PrecommittedPhase::AddressVariables,
             "cycle-phase final advice scale should not contain address rounds"
         );
@@ -241,28 +226,12 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
 }
 
 impl<F: JoltField> PrecommittedParams<F> for AdviceClaimReductionParams<F> {
-    fn is_cycle_phase(&self) -> bool {
-        self.phase == PrecommittedPhase::CycleVariables
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
     }
 
-    fn is_cycle_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_cycle_phase_round(round)
-    }
-
-    fn is_address_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_address_phase_round(round)
-    }
-
-    fn cycle_alignment_rounds(&self) -> usize {
-        self.precommitted.cycle_alignment_rounds()
-    }
-
-    fn address_alignment_rounds(&self) -> usize {
-        self.precommitted.address_alignment_rounds()
-    }
-
-    fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
-        self.precommitted.record_cycle_challenge(challenge);
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
     }
 }
 
@@ -277,7 +246,7 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
     }
 
     pub fn transition_to_address_phase(&mut self) {
-        self.core.params_mut().transition_to_address_phase();
+        self.core.transition_to_address_phase();
     }
 
     pub fn initialize(
@@ -300,7 +269,7 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
         };
 
         Self {
-            core: PrecommittedProver::new(params, advice_poly, eq_poly),
+            core: PrecommittedProver::new(params, advice_poly, eq_poly, None),
         }
     }
 
@@ -323,6 +292,7 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
                 params,
                 MultilinearPolynomial::from(advice_coeffs),
                 MultilinearPolynomial::from(eq_coeffs),
+                None,
             ),
         };
         prover.core.set_scale(scale);
@@ -335,8 +305,8 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
         self.core.params()
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.core.params().round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 
     fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
@@ -354,7 +324,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
     ) {
         let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             let c_mid = self.core.cycle_intermediate_claim();
 
             match params.kind {
@@ -426,8 +396,10 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
         let params = self.params.borrow();
-        match params.phase {
-            PrecommittedPhase::CycleVariables if params.num_address_phase_rounds() > 0 => {
+        match params.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if params.precommitted.num_address_phase_rounds() > 0 =>
+            {
                 accumulator
                     .get_advice_opening(params.kind, SumcheckId::AdviceClaimReductionCyclePhase)
                     .unwrap_or_else(|| panic!("Cycle phase intermediate claim not found"))
@@ -447,7 +419,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let mut params = self.params.borrow_mut();
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
@@ -465,9 +437,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                 .set_cycle_var_challenges(opening_point_le.r);
         }
 
-        if params.num_address_phase_rounds() == 0
-            || params.phase == PrecommittedPhase::AddressVariables
-        {
+        if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
                 AdviceKind::Trusted => accumulator
@@ -478,9 +448,8 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
         }
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        let params = self.params.borrow();
-        params.round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 }
 
@@ -507,7 +476,6 @@ mod tests {
         };
         let params = AdviceClaimReductionParams {
             kind: AdviceKind::Trusted,
-            phase: PrecommittedPhase::CycleVariables,
             precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
             advice_col_vars: 0,
             advice_row_vars: 1,
@@ -537,7 +505,6 @@ mod tests {
         };
         let params = AdviceClaimReductionParams {
             kind: AdviceKind::Trusted,
-            phase: PrecommittedPhase::CycleVariables,
             precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
             advice_col_vars: 0,
             advice_row_vars: 1,

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use crate::field::JoltField;
 use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
 use crate::poly::eq_poly::EqPolynomial;
-use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialBinding};
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
 use crate::poly::opening_proof::{
@@ -34,11 +34,12 @@ use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
 use common::constants::{REGISTER_COUNT, XLEN};
 use strum::EnumCount;
 
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
+
 const NUM_VAL_STAGES: usize = 5;
 
 #[derive(Clone, Allocative)]
 pub struct BytecodeClaimReductionParams<F: JoltField> {
-    pub phase: PrecommittedPhase,
     pub precommitted: PrecommittedClaimReduction<F>,
     pub eta: F,
     pub eta_powers: [F; NUM_VAL_STAGES],
@@ -104,7 +105,6 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
         // Align all precommitted scheduling/permutation to the shared reference domain.
 
         Self {
-            phase: PrecommittedPhase::CycleVariables,
             precommitted,
             eta,
             eta_powers,
@@ -117,51 +117,17 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
             lane_weights,
         }
     }
-
-    pub fn num_address_phase_rounds(&self) -> usize {
-        self.precommitted.num_address_phase_rounds()
-    }
 }
 
 impl<F: JoltField> BytecodeClaimReductionParams<F> {
-    fn is_cycle_phase(&self) -> bool {
-        self.phase == PrecommittedPhase::CycleVariables
-    }
-
-    fn is_cycle_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_cycle_phase_round(round)
-    }
-
-    fn is_address_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_address_phase_round(round)
-    }
-
-    fn cycle_alignment_rounds(&self) -> usize {
-        self.precommitted.cycle_alignment_rounds()
-    }
-
-    fn address_alignment_rounds(&self) -> usize {
-        self.precommitted.address_alignment_rounds()
-    }
-
-    pub fn transition_to_address_phase(&mut self) {
-        self.phase = PrecommittedPhase::AddressVariables;
-    }
-
     fn num_rounds_for_current_phase(&self) -> usize {
-        self.precommitted
-            .num_rounds_for_phase(self.is_cycle_phase())
-    }
-
-    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.precommitted
-            .round_offset(self.is_cycle_phase(), max_num_rounds)
+        self.precommitted.num_rounds_for_current_phase()
     }
 }
 
 impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F> {
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => (0..NUM_VAL_STAGES)
                 .map(|stage| {
                     let (_, val_claim) = accumulator.get_virtual_polynomial_opening(
@@ -191,13 +157,12 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F>
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        self.precommitted
-            .normalize_opening_point(self.is_cycle_phase(), challenges)
+        self.precommitted.normalize_opening_point(challenges)
     }
 
     #[cfg(feature = "zk")]
     fn input_claim_constraint(&self) -> InputClaimConstraint {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 let openings: Vec<OpeningId> = (0..NUM_VAL_STAGES)
                     .map(|stage| {
@@ -218,7 +183,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F>
 
     #[cfg(feature = "zk")]
     fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => self.eta_powers.to_vec(),
             PrecommittedPhase::AddressVariables => Vec::new(),
         }
@@ -226,7 +191,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F>
 
     #[cfg(feature = "zk")]
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 Some(OutputClaimConstraint::direct(OpeningId::virt(
                     VirtualPolynomial::BytecodeClaimReductionIntermediate,
@@ -253,7 +218,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F>
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => vec![],
             PrecommittedPhase::AddressVariables => {
                 let eq_combined = evaluate_bytecode_eq_combined(self, sumcheck_challenges);
@@ -267,22 +232,28 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F>
     }
 }
 
+impl<F: JoltField> PrecommittedParams<F> for BytecodeClaimReductionParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
+    }
+
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
+    }
+}
+
 #[derive(Allocative)]
 pub struct BytecodeClaimReductionProver<F: JoltField> {
-    params: BytecodeClaimReductionParams<F>,
-    value_poly: MultilinearPolynomial<F>,
-    eq_poly: MultilinearPolynomial<F>,
-    scale: F,
-    chunk_value_polys: Vec<MultilinearPolynomial<F>>,
+    core: PrecommittedProver<F, BytecodeClaimReductionParams<F>>,
 }
 
 impl<F: JoltField> BytecodeClaimReductionProver<F> {
     pub fn params(&self) -> &BytecodeClaimReductionParams<F> {
-        &self.params
+        self.core.params()
     }
 
     pub fn transition_to_address_phase(&mut self) {
-        self.params.transition_to_address_phase();
+        self.core.transition_to_address_phase();
     }
 
     pub fn initialize(
@@ -324,115 +295,26 @@ impl<F: JoltField> BytecodeClaimReductionProver<F> {
         let chunk_value_polys: Vec<MultilinearPolynomial<F>> = permuted_polys.collect();
 
         Self {
-            params,
-            value_poly,
-            eq_poly,
-            scale: F::one(),
-            chunk_value_polys,
-        }
-    }
-
-    fn bind_aux_polys(&mut self, r_j: F::Challenge) {
-        for poly in self.chunk_value_polys.iter_mut() {
-            poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-        }
-    }
-
-    fn compute_message_unscaled(&self, previous_claim_unscaled: F) -> UniPoly<F> {
-        let half = self.value_poly.len() / 2;
-        let evals: [F; TWO_PHASE_DEGREE_BOUND] = (0..half)
-            .into_par_iter()
-            .map(|j| {
-                let value_evals = self
-                    .value_poly
-                    .sumcheck_evals_array::<TWO_PHASE_DEGREE_BOUND>(j, BindingOrder::LowToHigh);
-                let eq_evals = self
-                    .eq_poly
-                    .sumcheck_evals_array::<TWO_PHASE_DEGREE_BOUND>(j, BindingOrder::LowToHigh);
-                let mut out = [F::zero(); TWO_PHASE_DEGREE_BOUND];
-                for i in 0..TWO_PHASE_DEGREE_BOUND {
-                    out[i] = value_evals[i] * eq_evals[i];
-                }
-                out
-            })
-            .reduce(
-                || [F::zero(); TWO_PHASE_DEGREE_BOUND],
-                |mut acc, arr| {
-                    acc.iter_mut().zip(arr.iter()).for_each(|(a, b)| *a += *b);
-                    acc
-                },
-            );
-        UniPoly::from_evals_and_hint(previous_claim_unscaled, &evals)
-    }
-
-    fn cycle_intermediate_claim(&self) -> F {
-        let len = self.value_poly.len();
-        debug_assert_eq!(len, self.eq_poly.len());
-        let mut sum = F::zero();
-        for i in 0..len {
-            sum += self.value_poly.get_bound_coeff(i) * self.eq_poly.get_bound_coeff(i);
-        }
-        sum * self.scale
-    }
-
-    fn final_claim_if_ready(&self) -> Option<F> {
-        if self.value_poly.len() == 1 {
-            Some(self.value_poly.get_bound_coeff(0))
-        } else {
-            None
+            core: PrecommittedProver::new(params, value_poly, eq_poly, Some(chunk_value_polys)),
         }
     }
 }
 
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaimReductionProver<F> {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        &self.params
+        self.core.params()
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.params.round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 
     fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
-        let is_active_round = if self.params.is_cycle_phase() {
-            self.params.is_cycle_phase_round(round)
-        } else {
-            self.params.is_address_phase_round(round)
-        };
-        if !is_active_round {
-            return UniPoly::from_coeff(vec![previous_claim * F::from_u64(2).inverse().unwrap()]);
-        }
-
-        let trailing_cap = if self.params.is_cycle_phase() {
-            self.params.cycle_alignment_rounds()
-        } else {
-            self.params.address_alignment_rounds()
-        };
-        let num_trailing_variables =
-            trailing_cap.saturating_sub(self.params.num_rounds_for_current_phase());
-        let scaling_factor = self.scale * F::one().mul_pow_2(num_trailing_variables);
-        let prev_unscaled = previous_claim * scaling_factor.inverse().unwrap();
-        let poly_unscaled = self.compute_message_unscaled(prev_unscaled);
-        poly_unscaled * scaling_factor
+        self.core.compute_message(round, previous_claim)
     }
 
     fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
-        let is_active_round = if self.params.is_cycle_phase() {
-            self.params.is_cycle_phase_round(round)
-        } else {
-            self.params.is_address_phase_round(round)
-        };
-        if !is_active_round {
-            self.scale *= F::from_u64(2).inverse().unwrap();
-            return;
-        }
-
-        self.value_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-        self.bind_aux_polys(r_j);
-        if self.params.is_cycle_phase() {
-            self.params.precommitted.record_cycle_challenge(r_j);
-        }
+        self.core.ingest_challenge(r_j, round);
     }
 
     fn cache_openings(
@@ -440,21 +322,22 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaim
         accumulator: &mut ProverOpeningAccumulator<F>,
         sumcheck_challenges: &[F::Challenge],
     ) {
-        let params = &self.params;
+        let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
 
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             accumulator.append_virtual(
                 VirtualPolynomial::BytecodeClaimReductionIntermediate,
                 SumcheckId::BytecodeClaimReductionCyclePhase,
                 opening_point.clone(),
-                self.cycle_intermediate_claim(),
+                self.core.cycle_intermediate_claim(),
             );
         }
 
-        if let Some(bytecode_claim) = self.final_claim_if_ready() {
+        if let Some(bytecode_claim) = self.core.final_claim_if_ready() {
             let chunk_claims: Vec<F> = self
-                .chunk_value_polys
+                .core
+                .aux_polys()
                 .iter()
                 .map(|poly| poly.final_sumcheck_claim())
                 .collect();
@@ -500,14 +383,13 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
         unsafe { &*self.params.as_ptr() }
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        let params = self.params.borrow();
-        params.round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
         let params = self.params.borrow();
-        match params.phase {
+        match params.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 accumulator
                     .get_virtual_polynomial_opening(
@@ -538,7 +420,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let mut params = self.params.borrow_mut();
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             accumulator.append_virtual(
                 VirtualPolynomial::BytecodeClaimReductionIntermediate,
@@ -551,9 +433,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                 .set_cycle_var_challenges(opening_point_le.r);
         }
 
-        if params.num_address_phase_rounds() == 0
-            || params.phase == PrecommittedPhase::AddressVariables
-        {
+        if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             for chunk_idx in 0..params.bytecode_chunk_count {
                 accumulator.append_dense(

--- a/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
+++ b/jolt-core/src/zkvm/claim_reductions/hamming_weight.rs
@@ -81,6 +81,7 @@ use allocative::Allocative;
 use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
+use crate::curve::JoltCurve;
 use crate::field::JoltField;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 #[cfg(feature = "zk")]
@@ -106,7 +107,7 @@ use crate::subprotocols::{
 use crate::transcripts::Transcript;
 use crate::zkvm::{
     config::OneHotParams,
-    verifier::JoltSharedPreprocessing,
+    prover::JoltProverPreprocessing,
     witness::{CommittedPolynomial, VirtualPolynomial},
 };
 
@@ -425,18 +426,22 @@ impl<F: JoltField> HammingWeightClaimReductionProver<F> {
     /// Initialize the prover by computing all G_i polynomials.
     /// Returns (prover, ram_hw_claims) where ram_hw_claims contains the computed H_i for RAM polynomials.
     #[tracing::instrument(skip_all, name = "HammingWeightClaimReductionProver::initialize")]
-    pub fn initialize<PCS: CommitmentScheme>(
+    pub fn initialize<C, PCS>(
         params: HammingWeightClaimReductionParams<F>,
         trace: &[Cycle],
-        preprocessing: &JoltSharedPreprocessing<PCS>,
+        preprocessing: &JoltProverPreprocessing<F, C, PCS>,
         one_hot_params: &OneHotParams,
-    ) -> Self {
+    ) -> Self
+    where
+        C: JoltCurve<F = F>,
+        PCS: CommitmentScheme<Field = F>,
+    {
         // Compute all G_i polynomials via streaming.
         // `params.r_cycle` is in BIG_ENDIAN (OpeningPoint) convention.
         let G_vecs = compute_all_G::<F>(
             trace,
-            preprocessing.bytecode(),
-            &preprocessing.memory_layout,
+            &preprocessing.materialized_program().bytecode,
+            &preprocessing.shared.memory_layout,
             one_hot_params,
             &params.r_cycle,
         );

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -56,6 +56,7 @@ pub struct PrecommittedSchedulingReference {
 pub struct PrecommittedClaimReduction<F: JoltField> {
     pub scheduling_reference: PrecommittedSchedulingReference,
     pub cycle_var_challenges: Vec<F::Challenge>,
+    pub phase: PrecommittedPhase,
     poly_opening_round_permutation_be: Vec<usize>,
     cycle_phase_rounds: Vec<usize>,
     cycle_phase_total_rounds: usize,
@@ -120,6 +121,7 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         Self {
             scheduling_reference,
             cycle_var_challenges: vec![],
+            phase: PrecommittedPhase::CycleVariables,
             poly_opening_round_permutation_be,
             cycle_phase_rounds,
             cycle_phase_total_rounds: scheduling_reference.cycle_alignment_rounds,
@@ -210,6 +212,16 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
     }
 
     #[inline]
+    pub fn is_cycle_phase(&self) -> bool {
+        self.phase == PrecommittedPhase::CycleVariables
+    }
+
+    #[inline]
+    pub fn transition_to_address_phase(&mut self) {
+        self.phase = PrecommittedPhase::AddressVariables;
+    }
+
+    #[inline]
     pub fn num_address_phase_rounds(&self) -> usize {
         self.address_phase_rounds.len()
     }
@@ -263,10 +275,6 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         (0..cycle_gap_len).fold(F::one(), |acc, _| acc * two_inv)
     }
 
-    pub fn is_address_phase_active_round(&self, round: usize) -> bool {
-        self.address_phase_rounds.contains(&round)
-    }
-
     #[inline]
     pub fn is_address_phase_round(&self, round: usize) -> bool {
         self.address_phase_rounds.contains(&round)
@@ -283,17 +291,12 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
     }
 
     #[inline]
-    pub fn num_rounds_for_phase(&self, is_cycle_phase: bool) -> usize {
-        if is_cycle_phase {
+    pub fn num_rounds_for_current_phase(&self) -> usize {
+        if self.is_cycle_phase() {
             self.cycle_phase_total_rounds
         } else {
             self.address_phase_total_rounds
         }
-    }
-
-    pub fn round_offset(&self, is_cycle_phase: bool, max_num_rounds: usize) -> usize {
-        let _ = (is_cycle_phase, max_num_rounds);
-        0
     }
 
     fn cycle_challenge_for_round(&self, round: usize) -> F::Challenge {
@@ -318,10 +321,9 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
 
     pub fn normalize_opening_point(
         &self,
-        is_cycle_phase: bool,
         challenges: &[F::Challenge],
     ) -> OpeningPoint<BIG_ENDIAN, F> {
-        if is_cycle_phase {
+        if self.is_cycle_phase() {
             let local_cycle_challenges: Vec<F::Challenge> = self
                 .cycle_phase_rounds
                 .iter()
@@ -527,12 +529,12 @@ pub fn precommitted_sumcheck_inverse_index_permutation(
 pub const TWO_PHASE_DEGREE_BOUND: usize = 2;
 
 pub trait PrecommittedParams<F: JoltField>: SumcheckInstanceParams<F> {
-    fn is_cycle_phase(&self) -> bool;
-    fn is_cycle_phase_round(&self, round: usize) -> bool;
-    fn is_address_phase_round(&self, round: usize) -> bool;
-    fn cycle_alignment_rounds(&self) -> usize;
-    fn address_alignment_rounds(&self) -> usize;
-    fn record_cycle_challenge(&mut self, challenge: F::Challenge);
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F>;
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F>;
+
+    fn is_cycle_phase(&self) -> bool {
+        self.precommitted().is_cycle_phase()
+    }
 }
 
 #[derive(Allocative)]
@@ -540,6 +542,7 @@ pub struct PrecommittedProver<F: JoltField, P: PrecommittedParams<F>> {
     params: P,
     value_poly: MultilinearPolynomial<F>,
     eq_poly: MultilinearPolynomial<F>,
+    aux_polys: Vec<MultilinearPolynomial<F>>,
     scale: F,
 }
 
@@ -548,11 +551,13 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
         params: P,
         value_poly: MultilinearPolynomial<F>,
         eq_poly: MultilinearPolynomial<F>,
+        aux_polys: Option<Vec<MultilinearPolynomial<F>>>,
     ) -> Self {
         Self {
             params,
             value_poly,
             eq_poly,
+            aux_polys: aux_polys.unwrap_or_default(),
             scale: F::one(),
         }
     }
@@ -561,12 +566,16 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
         &self.params
     }
 
-    pub fn params_mut(&mut self) -> &mut P {
-        &mut self.params
+    pub fn transition_to_address_phase(&mut self) {
+        self.params.precommitted_mut().transition_to_address_phase();
     }
 
     pub fn set_scale(&mut self, scale: F) {
         self.scale = scale;
+    }
+
+    pub fn aux_polys(&self) -> &[MultilinearPolynomial<F>] {
+        &self.aux_polys
     }
 
     fn compute_message_unscaled(&self, previous_claim_unscaled: F) -> UniPoly<F> {
@@ -598,19 +607,20 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
     }
 
     pub fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        let precommitted = self.params.precommitted();
         let is_active_round = if self.params.is_cycle_phase() {
-            self.params.is_cycle_phase_round(round)
+            precommitted.is_cycle_phase_round(round)
         } else {
-            self.params.is_address_phase_round(round)
+            precommitted.is_address_phase_round(round)
         };
         if !is_active_round {
             return UniPoly::from_coeff(vec![previous_claim * F::from_u64(2).inverse().unwrap()]);
         }
 
         let trailing_cap = if self.params.is_cycle_phase() {
-            self.params.cycle_alignment_rounds()
+            precommitted.cycle_alignment_rounds()
         } else {
-            self.params.address_alignment_rounds()
+            precommitted.address_alignment_rounds()
         };
         let num_trailing_variables = trailing_cap.saturating_sub(self.params.num_rounds());
         let scaling_factor = self.scale * F::one().mul_pow_2(num_trailing_variables);
@@ -621,19 +631,24 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
 
     pub fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
         let is_active_round = if self.params.is_cycle_phase() {
-            self.params.is_cycle_phase_round(round)
+            let precommitted = self.params.precommitted();
+            precommitted.is_cycle_phase_round(round)
         } else {
-            self.params.is_address_phase_round(round)
+            let precommitted = self.params.precommitted();
+            precommitted.is_address_phase_round(round)
         };
         if !is_active_round {
             self.scale *= F::from_u64(2).inverse().unwrap();
             return;
         }
+        if self.params.is_cycle_phase() {
+            self.params.precommitted_mut().record_cycle_challenge(r_j);
+        }
 
         self.value_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
         self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-        if self.params.is_cycle_phase() {
-            self.params.record_cycle_challenge(r_j);
+        for aux_poly in self.aux_polys.iter_mut() {
+            aux_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
         }
     }
 
@@ -693,6 +708,7 @@ mod tests {
         PrecommittedClaimReduction {
             scheduling_reference,
             cycle_var_challenges: vec![],
+            phase: PrecommittedPhase::CycleVariables,
             poly_opening_round_permutation_be,
             cycle_phase_rounds,
             cycle_phase_total_rounds,

--- a/jolt-core/src/zkvm/claim_reductions/program_image.rs
+++ b/jolt-core/src/zkvm/claim_reductions/program_image.rs
@@ -36,7 +36,6 @@ use super::precommitted::{PrecommittedParams, PrecommittedProver};
 
 #[derive(Clone, Allocative)]
 pub struct ProgramImageClaimReductionParams<F: JoltField> {
-    pub phase: PrecommittedPhase,
     pub precommitted: PrecommittedClaimReduction<F>,
     pub prog_col_vars: usize,
     pub prog_row_vars: usize,
@@ -49,10 +48,6 @@ pub struct ProgramImageClaimReductionParams<F: JoltField> {
 }
 
 impl<F: JoltField> ProgramImageClaimReductionParams<F> {
-    pub fn num_address_phase_rounds(&self) -> usize {
-        self.precommitted.num_address_phase_rounds()
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         program_io: &JoltDevice,
@@ -61,7 +56,6 @@ impl<F: JoltField> ProgramImageClaimReductionParams<F> {
         ram_K: usize,
         scheduling_reference: PrecommittedSchedulingReference,
         accumulator: &dyn OpeningAccumulator<F>,
-        _transcript: &mut impl Transcript,
     ) -> Self {
         let ram_num_vars = ram_K.log_2();
         let start_index =
@@ -82,7 +76,6 @@ impl<F: JoltField> ProgramImageClaimReductionParams<F> {
             shifted_program_image_eq_slice::<F>(&r_addr_rw.r, start_index, padded_len_words);
 
         Self {
-            phase: PrecommittedPhase::CycleVariables,
             precommitted,
             prog_col_vars,
             prog_row_vars,
@@ -96,24 +89,9 @@ impl<F: JoltField> ProgramImageClaimReductionParams<F> {
     }
 }
 
-impl<F: JoltField> ProgramImageClaimReductionParams<F> {
-    fn is_cycle_phase(&self) -> bool {
-        self.phase == PrecommittedPhase::CycleVariables
-    }
-
-    pub fn transition_to_address_phase(&mut self) {
-        self.phase = PrecommittedPhase::AddressVariables;
-    }
-
-    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.precommitted
-            .round_offset(self.is_cycle_phase(), max_num_rounds)
-    }
-}
-
 impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParams<F> {
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 // Scalar claims were staged in Stage 4 as virtual openings.
                 accumulator
@@ -139,18 +117,16 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParam
     }
 
     fn num_rounds(&self) -> usize {
-        self.precommitted
-            .num_rounds_for_phase(self.is_cycle_phase())
+        self.precommitted.num_rounds_for_current_phase()
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        self.precommitted
-            .normalize_opening_point(self.is_cycle_phase(), challenges)
+        self.precommitted.normalize_opening_point(challenges)
     }
 
     #[cfg(feature = "zk")]
     fn input_claim_constraint(&self) -> InputClaimConstraint {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => InputClaimConstraint::direct(OpeningId::virt(
                 VirtualPolynomial::ProgramImageInitContributionRw,
                 SumcheckId::RamValCheck,
@@ -171,7 +147,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParam
 
     #[cfg(feature = "zk")]
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 Some(OutputClaimConstraint::direct(OpeningId::committed(
                     CommittedPolynomial::ProgramImageInit,
@@ -190,7 +166,7 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParam
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => vec![],
             PrecommittedPhase::AddressVariables => {
                 let opening_point = self.normalize_opening_point(sumcheck_challenges);
@@ -212,28 +188,12 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParam
 }
 
 impl<F: JoltField> PrecommittedParams<F> for ProgramImageClaimReductionParams<F> {
-    fn is_cycle_phase(&self) -> bool {
-        self.phase == PrecommittedPhase::CycleVariables
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
     }
 
-    fn is_cycle_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_cycle_phase_round(round)
-    }
-
-    fn is_address_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_address_phase_round(round)
-    }
-
-    fn cycle_alignment_rounds(&self) -> usize {
-        self.precommitted.cycle_alignment_rounds()
-    }
-
-    fn address_alignment_rounds(&self) -> usize {
-        self.precommitted.address_alignment_rounds()
-    }
-
-    fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
-        self.precommitted.record_cycle_challenge(challenge);
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
     }
 }
 
@@ -279,7 +239,7 @@ impl<F: JoltField> ProgramImageClaimReductionProver<F> {
     }
 
     pub fn transition_to_address_phase(&mut self) {
-        self.core.params_mut().transition_to_address_phase();
+        self.core.transition_to_address_phase();
     }
 
     #[tracing::instrument(skip_all, name = "ProgramImageClaimReductionProver::initialize")]
@@ -310,7 +270,7 @@ impl<F: JoltField> ProgramImageClaimReductionProver<F> {
         };
 
         Self {
-            core: PrecommittedProver::new(params, program_word, eq_slice),
+            core: PrecommittedProver::new(params, program_word, eq_slice, None),
         }
     }
 
@@ -333,6 +293,7 @@ impl<F: JoltField> ProgramImageClaimReductionProver<F> {
                 params,
                 MultilinearPolynomial::from(program_word_coeffs),
                 MultilinearPolynomial::from(eq_slice_coeffs),
+                None,
             ),
         };
         prover.core.set_scale(scale);
@@ -347,8 +308,8 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
         self.core.params()
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.core.params().round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 
     fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
@@ -366,7 +327,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
     ) {
         let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             accumulator.append_dense(
                 CommittedPolynomial::ProgramImageInit,
                 SumcheckId::ProgramImageClaimReductionCyclePhase,
@@ -412,14 +373,13 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
         unsafe { &*self.params.as_ptr() }
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        let params = self.params.borrow();
-        params.round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
         let params = self.params.borrow();
-        match params.phase {
+        match params.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 accumulator
                     .get_committed_polynomial_opening(
@@ -456,7 +416,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let mut params = self.params.borrow_mut();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             accumulator.append_dense(
                 CommittedPolynomial::ProgramImageInit,
                 SumcheckId::ProgramImageClaimReductionCyclePhase,
@@ -469,9 +429,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                 .set_cycle_var_challenges(opening_point_le.r);
         }
 
-        if params.phase == PrecommittedPhase::AddressVariables
-            || params.num_address_phase_rounds() == 0
-        {
+        if !params.is_cycle_phase() || params.precommitted.num_address_phase_rounds() == 0 {
             accumulator.append_dense(
                 CommittedPolynomial::ProgramImageInit,
                 SumcheckId::ProgramImageClaimReduction,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 
-use crate::zkvm::config::{OneHotConfig, OneHotParams, ReadWriteConfig};
+use crate::zkvm::config::{OneHotConfig, OneHotParams, ProgramMode, ReadWriteConfig};
 use crate::zkvm::witness::CommittedPolynomial;
 use crate::{
     curve::Bn254Curve,
@@ -68,6 +68,8 @@ pub(crate) fn stage8_opening_ids(
     one_hot_params: &OneHotParams,
     include_trusted_advice: bool,
     include_untrusted_advice: bool,
+    program_mode: ProgramMode,
+    bytecode_chunk_count: usize,
 ) -> Vec<OpeningId> {
     let mut opening_ids = Vec::new();
 
@@ -104,6 +106,20 @@ pub(crate) fn stage8_opening_ids(
     }
     if include_untrusted_advice {
         opening_ids.push(OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction));
+    }
+    if program_mode == ProgramMode::Committed {
+        for i in 0..bytecode_chunk_count {
+            opening_ids.push(OpeningId::committed(
+                CommittedPolynomial::BytecodeChunk(i),
+                SumcheckId::BytecodeClaimReduction,
+            ));
+        }
+    }
+    if program_mode == ProgramMode::Committed {
+        opening_ids.push(OpeningId::committed(
+            CommittedPolynomial::ProgramImageInit,
+            SumcheckId::ProgramImageClaimReduction,
+        ));
     }
 
     opening_ids

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
-use crate::zkvm::config::OneHotConfig;
 #[cfg(feature = "zk")]
 use crate::zkvm::stage8_opening_ids;
 #[cfg(not(target_arch = "wasm32"))]
@@ -20,7 +19,10 @@ use crate::poly::commitment::dory::bind_opening_inputs_zk;
 use crate::poly::commitment::dory::DoryContext;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
+#[cfg(feature = "zk")]
+use crate::zkvm::config::ProgramMode;
 use crate::zkvm::config::ReadWriteConfig;
+use crate::zkvm::program::{build_program_image_words_padded, FullProgramPreprocessing};
 use crate::zkvm::ram::remap_address;
 use crate::zkvm::verifier::JoltSharedPreprocessing;
 use crate::zkvm::Serializable;
@@ -58,14 +60,19 @@ use crate::{
     transcripts::Transcript,
     utils::{math::Math, thread::drop_in_background_thread},
     zkvm::{
-        bytecode::read_raf_checking::BytecodeReadRafSumcheckParams,
+        bytecode::{
+            chunks::{build_committed_bytecode_chunk_coeffs, committed_bytecode_chunk_cycle_len},
+            read_raf_checking::BytecodeReadRafSumcheckParams,
+        },
         claim_reductions::{
             AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceKind,
+            BytecodeClaimReductionParams, BytecodeClaimReductionProver,
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
             InstructionLookupsClaimReductionSumcheckProver, PrecommittedClaimReduction,
-            PrecommittedPolynomial, RaReductionParams, RamRaClaimReductionSumcheckProver,
+            PrecommittedPolynomial, ProgramImageClaimReductionParams,
+            ProgramImageClaimReductionProver, RaReductionParams, RamRaClaimReductionSumcheckProver,
             RegistersClaimReductionSumcheckParams, RegistersClaimReductionSumcheckProver,
         },
         config::OneHotParams,
@@ -76,7 +83,7 @@ use crate::{
         ram::{
             hamming_booleanity::HammingBooleanitySumcheckParams,
             output_check::OutputSumcheckParams,
-            populate_memory_states,
+            populate_memory_states, prover_accumulate_program_image,
             ra_virtual::RamRaVirtualParams,
             raf_evaluation::RafEvaluationSumcheckParams,
             read_write_checking::RamReadWriteCheckingParams,
@@ -186,6 +193,10 @@ pub struct JoltCpuProver<
     /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
     /// Cache the prover state here between stages.
     advice_reduction_prover_untrusted: Option<AdviceClaimReductionProver<F>>,
+    /// Bytecode claim reduction spans stages 6b and 7 in committed mode.
+    bytecode_reduction_prover: Option<BytecodeClaimReductionProver<F>>,
+    /// Program-image claim reduction spans stages 6b and 7 in committed mode.
+    program_image_reduction_prover: Option<ProgramImageClaimReductionProver<F>>,
     pub unpadded_trace_len: usize,
     pub padded_trace_len: usize,
     pub transcript: ProofTranscript,
@@ -288,7 +299,7 @@ impl<
         JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
             trace_log_t + log_k_chunk,
             self.preprocessing.shared.precommitted_candidate_total_vars(
-                false,
+                self.preprocessing.is_committed_mode(),
                 !self.program_io.trusted_advice.is_empty(),
                 !self.program_io.untrusted_advice.is_empty(),
             ),
@@ -297,34 +308,50 @@ impl<
 
     fn stage8_opening_point(&self) -> OpeningPoint<BIG_ENDIAN, F> {
         let native_main_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
-        let mut opening_candidates: Vec<(&'static str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
-
+        let mut opening_candidates: Vec<(String, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
         if let Some((point, _)) = self
             .opening_accumulator
             .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
         {
-            opening_candidates.push(("trusted_advice", point));
+            opening_candidates.push(("trusted_advice".to_string(), point));
         }
         if let Some((point, _)) = self
             .opening_accumulator
             .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
         {
-            opening_candidates.push(("untrusted_advice", point));
+            opening_candidates.push(("untrusted_advice".to_string(), point));
+        }
+        if self.preprocessing.is_committed_mode() {
+            for chunk_idx in 0..self.preprocessing.shared.bytecode_chunk_count {
+                let (point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                );
+                opening_candidates.push((format!("bytecode_chunk[{chunk_idx}]"), point));
+            }
+        }
+        if self.preprocessing.is_committed_mode() {
+            let (program_image_point, _) =
+                self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                );
+            opening_candidates.push(("program_image".to_string(), program_image_point));
         }
 
         let max_len = opening_candidates
             .iter()
-            .map(|(_, point)| point.r.len())
+            .map(|(_, p)| p.r.len())
             .max()
             .unwrap_or(0);
-        if max_len > native_main_vars {
+        let final_point = if max_len > native_main_vars {
             let dominant = opening_candidates
                 .iter()
-                .find(|(_, point)| point.r.len() == max_len)
+                .find(|(_, p)| p.r.len() == max_len)
                 .expect("at least one dominant precommitted candidate expected");
             for (name, point) in opening_candidates
                 .iter()
-                .filter(|(_, point)| point.r.len() == max_len)
+                .filter(|(_, p)| p.r.len() == max_len)
             {
                 assert_eq!(
                     point.r, dominant.1.r,
@@ -332,120 +359,48 @@ impl<
                     dominant.0, name, max_len
                 );
             }
-            return OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone());
-        }
-
-        let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::InstructionRa(0),
-            SumcheckId::HammingWeightClaimReduction,
-        );
-        let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
-        let r_cycle_stage6 = self
-            .opening_accumulator
-            .get_committed_polynomial_opening(
-                CommittedPolynomial::RamInc,
-                SumcheckId::IncClaimReduction,
-            )
-            .0
-            .r;
-
-        match DoryGlobals::get_layout() {
-            DoryLayout::AddressMajor => OpeningPoint::<BIG_ENDIAN, F>::new(
-                [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
-            ),
-            DoryLayout::CycleMajor => {
-                let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
-                assert!(
-                    r_cycle_stage6.len() >= native_cycle.len(),
-                    "stage6 cycle challenges shorter than native cycle vars"
-                );
-                assert!(
-                    r_cycle_stage6[..native_cycle.len()] == *native_cycle,
-                    "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars"
-                );
-                let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
-                OpeningPoint::<BIG_ENDIAN, F>::new(
-                    [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat(),
+            OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone())
+        } else {
+            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::InstructionRa(0),
+                SumcheckId::HammingWeightClaimReduction,
+            );
+            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+            let r_cycle_stage6 = self
+                .opening_accumulator
+                .get_committed_polynomial_opening(
+                    CommittedPolynomial::RamInc,
+                    SumcheckId::IncClaimReduction,
                 )
+                .0
+                .r;
+
+            match DoryGlobals::get_layout() {
+                DoryLayout::AddressMajor => OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+                ),
+                DoryLayout::CycleMajor => {
+                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                    assert!(
+                        r_cycle_stage6.len() >= native_cycle.len(),
+                        "stage6 cycle challenges shorter than native cycle vars"
+                    );
+                    assert!(
+                        r_cycle_stage6[..native_cycle.len()] == *native_cycle,
+                        "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
+                         (cycle_full_len={}, native_len={})",
+                        r_cycle_stage6.len(),
+                        native_cycle.len()
+                    );
+                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                    let cycle_extra_and_anchor =
+                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
+                    OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor)
+                }
             }
-        }
-    }
+        };
 
-    /// Adjusts the padded trace length to ensure the main Dory matrix is large enough
-    /// to embed advice polynomials as the top-left block.
-    ///
-    /// Returns the adjusted padded_trace_len that satisfies:
-    /// - `sigma_main >= max_sigma_a`
-    /// - `nu_main >= max_nu_a`
-    ///
-    /// Panics if `max_padded_trace_length` is too small for the configured advice sizes.
-    fn adjust_trace_length_for_advice(
-        mut padded_trace_len: usize,
-        max_padded_trace_length: usize,
-        max_trusted_advice_size: u64,
-        max_untrusted_advice_size: u64,
-        has_trusted_advice: bool,
-        has_untrusted_advice: bool,
-    ) -> usize {
-        // Canonical advice shape policy (balanced):
-        // - advice_vars = log2(advice_len)
-        // - sigma_a = ceil(advice_vars/2)
-        // - nu_a    = advice_vars - sigma_a
-        let mut max_sigma_a = 0usize;
-        let mut max_nu_a = 0usize;
-
-        if has_trusted_advice {
-            let (sigma_a, nu_a) =
-                DoryGlobals::advice_sigma_nu_from_max_bytes(max_trusted_advice_size as usize);
-            max_sigma_a = max_sigma_a.max(sigma_a);
-            max_nu_a = max_nu_a.max(nu_a);
-        }
-        if has_untrusted_advice {
-            let (sigma_a, nu_a) =
-                DoryGlobals::advice_sigma_nu_from_max_bytes(max_untrusted_advice_size as usize);
-            max_sigma_a = max_sigma_a.max(sigma_a);
-            max_nu_a = max_nu_a.max(nu_a);
-        }
-
-        if max_sigma_a == 0 && max_nu_a == 0 {
-            return padded_trace_len;
-        }
-
-        // Require main matrix dimensions to be large enough to embed advice as the top-left
-        // block: sigma_main >= sigma_a and nu_main >= nu_a.
-        //
-        // This loop doubles padded_trace_len until the main Dory matrix is large enough.
-        // Each doubling increases log_t by 1, which increases total_vars by 1 (since
-        // log_k_chunk stays constant for a given log_t range), increasing both sigma_main
-        // and nu_main by roughly 0.5 each iteration.
-        while {
-            let log_t = padded_trace_len.log_2();
-            let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
-            let (sigma_main, nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
-            sigma_main < max_sigma_a || nu_main < max_nu_a
-        } {
-            if padded_trace_len >= max_padded_trace_length {
-                // This is a configuration error: the preprocessing was set up with
-                // max_padded_trace_length too small for the configured advice sizes.
-                // Cannot recover at runtime - user must fix their configuration.
-                let log_t = padded_trace_len.log_2();
-                let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
-                let total_vars = log_k_chunk + log_t;
-                let (sigma_main, nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
-                panic!(
-                    "Configuration error: trace too small to embed advice into Dory batch opening.\n\
-                    Current: (sigma_main={sigma_main}, nu_main={nu_main}) from total_vars={total_vars} (log_t={log_t}, log_k_chunk={log_k_chunk})\n\
-                    Required: (sigma_a={max_sigma_a}, nu_a={max_nu_a}) for advice embedding\n\
-                    Solutions:\n\
-                    1. Increase max_trace_length in preprocessing (currently {max_padded_trace_length})\n\
-                    2. Reduce max_trusted_advice_size or max_untrusted_advice_size\n\
-                    3. Run a program with more cycles"
-                );
-            }
-            padded_trace_len = (padded_trace_len * 2).min(max_padded_trace_length);
-        }
-
-        padded_trace_len
+        final_point
     }
 
     pub fn gen_from_trace(
@@ -483,20 +438,6 @@ impl<
             );
         }
 
-        // We may need extra padding so the main Dory matrix has enough (row, col) variables
-        // to embed advice commitments committed in their own preprocessing-only contexts.
-        let has_trusted_advice = !program_io.trusted_advice.is_empty();
-        let has_untrusted_advice = !program_io.untrusted_advice.is_empty();
-
-        let padded_trace_len = Self::adjust_trace_length_for_advice(
-            padded_trace_len,
-            preprocessing.shared.max_padded_trace_length,
-            preprocessing.shared.memory_layout.max_trusted_advice_size,
-            preprocessing.shared.memory_layout.max_untrusted_advice_size,
-            has_trusted_advice,
-            has_untrusted_advice,
-        );
-
         trace.resize(padded_trace_len, Cycle::NoOp);
 
         // Calculate K for DoryGlobals initialization
@@ -512,11 +453,11 @@ impl<
             .unwrap_or(0)
             .max(
                 remap_address(
-                    preprocessing.shared.ram().min_bytecode_address,
+                    preprocessing.shared.program_meta.min_bytecode_address,
                     &preprocessing.shared.memory_layout,
                 )
                 .unwrap_or(0)
-                    + preprocessing.shared.ram().bytecode_words.len() as u64
+                    + preprocessing.shared.program_meta.program_image_len_words as u64
                     + 1,
             )
             .next_power_of_two() as usize;
@@ -528,7 +469,7 @@ impl<
 
         let (initial_ram_state, final_ram_state) = gen_ram_memory_states::<F>(
             ram_K,
-            preprocessing.shared.ram(),
+            &preprocessing.materialized_program().ram,
             &program_io,
             &final_memory_state,
         );
@@ -536,8 +477,7 @@ impl<
         let log_T = trace.len().log_2();
         let ram_log_K = ram_K.log_2();
         let rw_config = ReadWriteConfig::new(log_T, ram_log_K);
-        let one_hot_params =
-            OneHotParams::new(log_T, preprocessing.shared.bytecode().code_size, ram_K);
+        let one_hot_params = OneHotParams::new(log_T, preprocessing.shared.bytecode_size(), ram_K);
 
         #[cfg(feature = "zk")]
         let pedersen_generators = {
@@ -559,6 +499,8 @@ impl<
             },
             advice_reduction_prover_trusted: None,
             advice_reduction_prover_untrusted: None,
+            bytecode_reduction_prover: None,
+            program_image_reduction_prover: None,
             unpadded_trace_len,
             padded_trace_len,
             transcript,
@@ -594,7 +536,7 @@ impl<
             &self.program_io,
             self.one_hot_params.ram_k,
             self.trace.len(),
-            self.preprocessing.shared.bytecode().entry_address,
+            self.preprocessing.shared.program_meta.entry_address,
             &self.rw_config,
             &self.one_hot_params.to_config(),
             DoryGlobals::get_layout(),
@@ -604,7 +546,7 @@ impl<
 
         tracing::info!(
             "bytecode size: {}",
-            self.preprocessing.shared.bytecode().code_size
+            self.preprocessing.shared.bytecode_size()
         );
 
         let (commitments, mut opening_proof_hints) = self.generate_and_commit_witness_polynomials();
@@ -618,6 +560,30 @@ impl<
         if let Some(hint) = self.advice.untrusted_advice_hint.take() {
             opening_proof_hints.insert(CommittedPolynomial::UntrustedAdvice, hint);
         }
+        if let Some(bytecode_hints) = self.preprocessing.shared.program.bytecode_hints() {
+            for (idx, hint) in bytecode_hints.hints.iter().cloned().enumerate() {
+                opening_proof_hints.insert(CommittedPolynomial::BytecodeChunk(idx), hint);
+            }
+        }
+        if let Some(program_hints) = self.preprocessing.shared.program.program_hints() {
+            opening_proof_hints.insert(
+                CommittedPolynomial::ProgramImageInit,
+                program_hints.program_image_hint.clone(),
+            );
+        }
+        if let Some(bytecode_commitments) = self.preprocessing.shared.program.bytecode_commitments()
+        {
+            for commitment in &bytecode_commitments.commitments {
+                self.transcript
+                    .append_serializable(b"bytecode_chunk_commit", commitment);
+            }
+        }
+        if let Some(program_commitments) = self.preprocessing.shared.program.program_commitments() {
+            self.transcript.append_serializable(
+                b"program_image_commitment",
+                &program_commitments.program_image_commitment,
+            );
+        }
 
         let (stage1_uni_skip_first_round_proof, stage1_sumcheck_proof, r_stage1) =
             self.prove_stage1();
@@ -628,12 +594,12 @@ impl<
         let (stage5_sumcheck_proof, r_stage5) = self.prove_stage5();
         let (stage6a_sumcheck_proof, bytecode_read_raf_params, booleanity_params) =
             self.prove_stage6a();
-        let (stage6b_sumcheck_proof, r_stage6b) =
+        let (stage6b_sumcheck_proof, r_stage6) =
             self.prove_stage6b(bytecode_read_raf_params, booleanity_params);
         let (stage7_sumcheck_proof, r_stage7) = self.prove_stage7();
 
         let _sumcheck_challenges = [
-            r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6b, r_stage7,
+            r_stage1, r_stage2, r_stage3, r_stage4, r_stage5, r_stage6, r_stage7,
         ];
 
         let joint_opening_proof = self.prove_stage8(opening_proof_hints);
@@ -784,7 +750,7 @@ impl<
         let T = DoryGlobals::get_embedded_t();
 
         // AddressMajor uses non-streaming commit path, and we also use non-streaming when
-        // the Stage 8 embedding domain exceeds the trace domain.
+        // Stage 6/8 embedding domain exceeds the trace domain.
         let use_materialized_commit =
             DoryGlobals::get_layout() == DoryLayout::AddressMajor || self.trace.len() != T;
         let (commitments, hint_map) = if use_materialized_commit {
@@ -798,7 +764,7 @@ impl<
                 .par_iter()
                 .map(|poly_id| {
                     let witness: MultilinearPolynomial<F> = poly_id.generate_witness(
-                        self.preprocessing.shared.bytecode(),
+                        &self.preprocessing.materialized_program().bytecode,
                         &self.preprocessing.shared.memory_layout,
                         &trace,
                         Some(&self.one_hot_params),
@@ -835,9 +801,8 @@ impl<
                     let res: Vec<_> = polys
                         .par_iter()
                         .map(|poly| {
-                            poly.stream_witness_and_commit_rows::<_, PCS>(
-                                &self.preprocessing.generators,
-                                &self.preprocessing.shared,
+                            poly.stream_witness_and_commit_rows::<_, _, PCS>(
+                                self.preprocessing,
                                 &chunk,
                                 &self.one_hot_params,
                             )
@@ -959,14 +924,14 @@ impl<
         let mut uni_skip = OuterUniSkipProver::initialize(
             uni_skip_params.clone(),
             &self.trace,
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
         );
         let first_round_proof = self.prove_uniskip(&mut uni_skip);
 
         let schedule = LinearOnlySchedule::new(uni_skip_params.tau.len() - 1);
         let shared = OuterSharedState::new(
             Arc::clone(&self.trace),
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &uni_skip_params,
             &self.opening_accumulator,
         );
@@ -1034,7 +999,7 @@ impl<
         let ram_read_write_checking = RamReadWriteCheckingProver::initialize(
             ram_read_write_checking_params,
             &self.trace,
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
             &self.initial_ram_state,
         );
@@ -1123,7 +1088,7 @@ impl<
         let spartan_shift = ShiftSumcheckProver::initialize(
             spartan_shift_params,
             Arc::clone(&self.trace),
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
         );
         let spartan_instruction_input = InstructionInputSumcheckProver::initialize(
             spartan_instruction_input_params,
@@ -1189,6 +1154,14 @@ impl<
             &self.one_hot_params,
             &mut self.opening_accumulator,
         );
+        if self.preprocessing.is_committed_mode() {
+            prover_accumulate_program_image(
+                self.one_hot_params.ram_k,
+                &self.preprocessing.materialized_program().ram,
+                &self.program_io,
+                &mut self.opening_accumulator,
+            );
+        }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
@@ -1198,20 +1171,22 @@ impl<
             &self.initial_ram_state,
             self.trace.len(),
             ram_val_check_gamma,
-            self.preprocessing.shared.ram(),
+            &self.preprocessing.materialized_program().ram,
             &self.program_io,
+            &self.rw_config,
+            self.preprocessing.is_committed_mode(),
         );
 
         let registers_read_write_checking = RegistersReadWriteCheckingProver::initialize(
             registers_read_write_checking_params,
             self.trace.clone(),
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
         let ram_val_check = RamValCheckSumcheckProver::initialize(
             ram_val_check_params,
             &self.trace,
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1280,7 +1255,7 @@ impl<
         let registers_val_evaluation = RegistersValEvaluationSumcheckProver::initialize(
             registers_val_evaluation_params,
             &self.trace,
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1328,7 +1303,7 @@ impl<
             Some(&self.preprocessing.shared.program),
             self.trace.len().log_2(),
             &self.one_hot_params,
-            false,
+            self.preprocessing.is_committed_mode(),
             None,
             &self.opening_accumulator,
             &mut self.transcript,
@@ -1340,16 +1315,15 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
-
         let mut bytecode_read_raf = BytecodeReadRafAddressSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            self.preprocessing.shared.bytecode_arc(),
+            Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
         );
         let mut booleanity = BooleanityAddressSumcheckProver::initialize(
             booleanity_params,
             &self.trace,
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
 
@@ -1413,9 +1387,10 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+
         let main_total_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
         let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
-            false,
+            self.preprocessing.is_committed_mode(),
             self.advice.trusted_advice_polynomial.is_some(),
             self.advice.untrusted_advice_polynomial.is_some(),
         );
@@ -1470,10 +1445,53 @@ impl<
             };
         }
 
+        if self.preprocessing.is_committed_mode() {
+            let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_reduction_params = BytecodeClaimReductionParams::new(
+                &bytecode_read_raf_params,
+                self.preprocessing.shared.bytecode_size(),
+                bytecode_chunk_count,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+                &mut self.transcript,
+            );
+            let bytecode_chunk_coeffs = build_committed_bytecode_chunk_coeffs(
+                &self.preprocessing.materialized_program().bytecode.bytecode,
+                bytecode_chunk_count,
+            );
+            self.bytecode_reduction_prover = Some(BytecodeClaimReductionProver::initialize(
+                bytecode_reduction_params,
+                &bytecode_chunk_coeffs,
+            ));
+
+            let padded_len_words = self
+                .preprocessing
+                .shared
+                .program
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let program_image_words = build_program_image_words_padded(
+                self.preprocessing.materialized_program(),
+                padded_len_words,
+            );
+            let program_image_reduction_params = ProgramImageClaimReductionParams::new(
+                &self.program_io,
+                self.preprocessing.shared.program_meta.min_bytecode_address,
+                padded_len_words,
+                self.one_hot_params.ram_k,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+            );
+            self.program_image_reduction_prover =
+                Some(ProgramImageClaimReductionProver::initialize(
+                    program_image_reduction_params,
+                    program_image_words,
+                ));
+        }
+
         let mut bytecode_read_raf = BytecodeReadRafCycleSumcheckProver::initialize(
             bytecode_read_raf_params,
             Arc::clone(&self.trace),
-            self.preprocessing.shared.bytecode_arc(),
+            Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
             &self.opening_accumulator,
         );
         let booleanity_cycle_params =
@@ -1481,7 +1499,7 @@ impl<
         let mut booleanity = BooleanityCycleSumcheckProver::initialize(
             booleanity_cycle_params,
             &self.trace,
-            self.preprocessing.shared.bytecode(),
+            &self.preprocessing.materialized_program().bytecode,
             &self.program_io.memory_layout,
         );
         let mut ram_hamming_booleanity =
@@ -1522,6 +1540,8 @@ impl<
 
         let mut advice_trusted = self.advice_reduction_prover_trusted.take();
         let mut advice_untrusted = self.advice_reduction_prover_untrusted.take();
+        let mut bytecode_reduction = self.bytecode_reduction_prover.take();
+        let mut program_image_reduction = self.program_image_reduction_prover.take();
 
         let mut instances: Vec<&mut dyn SumcheckInstanceProver<_, _>> = vec![
             &mut bytecode_read_raf,
@@ -1536,6 +1556,12 @@ impl<
         }
         if let Some(ref mut advice) = advice_untrusted {
             instances.push(advice);
+        }
+        if let Some(ref mut reduction) = bytecode_reduction {
+            instances.push(reduction);
+        }
+        if let Some(ref mut reduction) = program_image_reduction {
+            instances.push(reduction);
         }
 
         #[cfg(feature = "allocative")]
@@ -1555,6 +1581,8 @@ impl<
 
         self.advice_reduction_prover_trusted = advice_trusted;
         self.advice_reduction_prover_untrusted = advice_untrusted;
+        self.bytecode_reduction_prover = bytecode_reduction;
+        self.program_image_reduction_prover = program_image_reduction;
 
         (sumcheck_proof, r_stage6b)
     }
@@ -1664,7 +1692,7 @@ impl<
                 };
                 stage_witnesses.push(stage_witness);
             } else {
-                // Stages 2-7: no uni-skip, push initial claim for regular rounds
+                // Stages 2-6: no uni-skip, push initial claim for regular rounds
                 initial_claims.push(zk_data.initial_claim);
             }
 
@@ -2046,7 +2074,7 @@ impl<
         let hw_prover = HammingWeightClaimReductionProver::initialize(
             hw_params,
             &self.trace,
-            &self.preprocessing.shared,
+            self.preprocessing,
             &self.one_hot_params,
         );
 
@@ -2063,6 +2091,7 @@ impl<
         {
             if advice_reduction_prover_trusted
                 .params()
+                .precommitted
                 .num_address_phase_rounds()
                 > 0
             {
@@ -2076,12 +2105,36 @@ impl<
         {
             if advice_reduction_prover_untrusted
                 .params()
+                .precommitted
                 .num_address_phase_rounds()
                 > 0
             {
                 // Transition phase
                 advice_reduction_prover_untrusted.transition_to_address_phase();
                 instances.push(Box::new(advice_reduction_prover_untrusted));
+            }
+        }
+        if let Some(mut bytecode_reduction_prover) = self.bytecode_reduction_prover.take() {
+            if bytecode_reduction_prover
+                .params()
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                bytecode_reduction_prover.transition_to_address_phase();
+                instances.push(Box::new(bytecode_reduction_prover));
+            }
+        }
+        if let Some(mut program_image_reduction_prover) = self.program_image_reduction_prover.take()
+        {
+            if program_image_reduction_prover
+                .params()
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                program_image_reduction_prover.transition_to_address_phase();
+                instances.push(Box::new(program_image_reduction_prover));
             }
         }
 
@@ -2107,13 +2160,6 @@ impl<
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
-        let _guard = DoryGlobals::initialize_main_with_log_embedding(
-            self.one_hot_params.k_chunk,
-            self.padded_trace_len,
-            self.main_total_vars(),
-            Some(DoryGlobals::get_layout()),
-        );
-
         let opening_point = self.stage8_opening_point();
 
         let mut polynomial_claims = Vec::new();
@@ -2121,8 +2167,6 @@ impl<
         let mut precommitted_polys: HashMap<CommittedPolynomial, PrecommittedPolynomial<F>> =
             HashMap::new();
 
-        // Dense polynomials: RamInc and RdInc (from IncClaimReduction in Stage 6)
-        // at r_cycle_stage6 only (length log_T)
         let (ram_inc_point, ram_inc_claim) =
             self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RamInc,
@@ -2214,6 +2258,71 @@ impl<
             }
         }
 
+        if self.preprocessing.is_committed_mode() {
+            let chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let chunk_cycle_len = committed_bytecode_chunk_cycle_len(
+                self.preprocessing
+                    .materialized_program()
+                    .bytecode
+                    .bytecode
+                    .len(),
+                chunk_count,
+            );
+            for chunk_idx in 0..chunk_count {
+                let (chunk_point, chunk_claim) =
+                    self.opening_accumulator.get_committed_polynomial_opening(
+                        CommittedPolynomial::BytecodeChunk(chunk_idx),
+                        SumcheckId::BytecodeClaimReduction,
+                    );
+                let lagrange_factor =
+                    compute_lagrange_factor::<F>(&opening_point.r, &chunk_point.r);
+                polynomial_claims.push((
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    chunk_claim * lagrange_factor,
+                ));
+                scaling_factors.push(lagrange_factor);
+                precommitted_polys.insert(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    PrecommittedPolynomial::BytecodeChunk {
+                        chunk_index: chunk_idx,
+                        chunk_cycle_len,
+                    },
+                );
+            }
+        }
+
+        if self.preprocessing.is_committed_mode() {
+            let padded_len = self
+                .preprocessing
+                .shared
+                .program
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let (program_point, program_claim) =
+                self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                );
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &program_point.r);
+            polynomial_claims.push((
+                CommittedPolynomial::ProgramImageInit,
+                program_claim * lagrange_factor,
+            ));
+            scaling_factors.push(lagrange_factor);
+            precommitted_polys.insert(
+                CommittedPolynomial::ProgramImageInit,
+                PrecommittedPolynomial::ProgramImage {
+                    words: Arc::new(
+                        self.preprocessing
+                            .materialized_program()
+                            .ram
+                            .bytecode_words
+                            .clone(),
+                    ),
+                    padded_len,
+                },
+            );
+        }
+
         // 2. Sample gamma and compute powers for RLC
         let claims: Vec<F> = polynomial_claims.iter().map(|(_, c)| *c).collect();
         // In non-ZK mode, absorb claims before sampling gamma for Fiat-Shamir binding.
@@ -2238,6 +2347,12 @@ impl<
             &self.one_hot_params,
             include_trusted_advice,
             include_untrusted_advice,
+            if self.preprocessing.is_committed_mode() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            self.preprocessing.shared.bytecode_chunk_count,
         );
 
         // Build DoryOpeningState
@@ -2248,7 +2363,7 @@ impl<
         };
 
         let streaming_data = Arc::new(RLCStreamingData {
-            bytecode: self.preprocessing.shared.bytecode_arc(),
+            bytecode: Arc::new(self.preprocessing.materialized_program().bytecode.clone()),
             memory_layout: self.preprocessing.shared.memory_layout.clone(),
         });
 
@@ -2275,7 +2390,6 @@ impl<
             opening_proof_hints,
             precommitted_polys,
         );
-
         let (proof, _y_blinding) = PCS::prove(
             &self.preprocessing.generators,
             &joint_poly,
@@ -2340,7 +2454,7 @@ fn write_instance_flamegraph_svg(
     write_flamegraph_svg(flamegraph, path);
 }
 
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone)]
 pub struct JoltProverPreprocessing<
     F: JoltField,
     C: JoltCurve<F = F>,
@@ -2349,6 +2463,63 @@ pub struct JoltProverPreprocessing<
     pub generators: PCS::ProverSetup,
     pub shared: JoltSharedPreprocessing<PCS>,
     _curve: std::marker::PhantomData<C>,
+}
+
+impl<F, C, PCS> CanonicalSerialize for JoltProverPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+{
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.serialize_with_mode(&mut writer, compress)?;
+        self.shared.serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.generators.serialized_size(compress) + self.shared.serialized_size(compress)
+    }
+}
+
+impl<F, C, PCS> ark_serialize::Valid for JoltProverPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+{
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.check()?;
+        self.shared.check()?;
+        Ok(())
+    }
+}
+
+impl<F, C, PCS> CanonicalDeserialize for JoltProverPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+{
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        Ok(Self {
+            generators: PCS::ProverSetup::deserialize_with_mode(&mut reader, compress, validate)?,
+            shared: JoltSharedPreprocessing::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            _curve: std::marker::PhantomData,
+        })
+    }
 }
 
 impl<F, C, PCS> JoltProverPreprocessing<F, C, PCS>
@@ -2401,6 +2572,17 @@ where
         )
     }
 
+    pub fn is_committed_mode(&self) -> bool {
+        self.shared.program.is_committed()
+    }
+
+    pub fn materialized_program(&self) -> &FullProgramPreprocessing {
+        self.shared
+            .program
+            .as_full()
+            .expect("prover requires materialized program preprocessing")
+    }
+
     pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()> {
         let filename = Path::new(target_dir).join("jolt_prover_preprocessing.dat");
         let mut file = File::create(filename.as_path())?;
@@ -2430,9 +2612,9 @@ mod tests {
     extern crate jolt_inlines_keccak256;
     extern crate jolt_inlines_sha2;
 
+    use std::sync::Arc;
+
     use ark_bn254::Fr;
-    use common::jolt_device::MemoryLayout;
-    use jolt_riscv::JoltInstructionRow;
     use serial_test::serial;
 
     use crate::curve::Bn254Curve;
@@ -2461,6 +2643,7 @@ mod tests {
     };
     #[cfg(feature = "zk")]
     use crate::{curve::JoltCurve, field::JoltField};
+    use jolt_riscv::JoltInstructionRow;
 
     #[cfg(feature = "zk")]
     fn round_commitment_data<F: JoltField, C: JoltCurve<F = F>, R: rand_core::RngCore>(
@@ -2514,59 +2697,33 @@ mod tests {
     fn test_shared_preprocessing(
         bytecode: Vec<JoltInstructionRow>,
         init_memory_state: Vec<(u64, u8)>,
-        memory_layout: MemoryLayout,
+        memory_layout: common::jolt_device::MemoryLayout,
         max_trace_len: usize,
         entry_address: u64,
-    ) -> Result<JoltSharedPreprocessing, PreprocessingError> {
+    ) -> Result<(JoltSharedPreprocessing, Arc<ProgramPreprocessing>), PreprocessingError> {
         let program = ProgramPreprocessing::preprocess(bytecode, init_memory_state, entry_address)?;
-        Ok(JoltSharedPreprocessing::new(
-            program,
-            memory_layout,
-            max_trace_len,
-        ))
+        let shared = JoltSharedPreprocessing::new(program.clone(), memory_layout, max_trace_len);
+        let program = Arc::new(program);
+        Ok((shared, program))
     }
 
-    #[test]
-    #[serial]
-    fn committed_preprocessing_serialization_roundtrip_strips_prover_data() {
-        use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-
-        DoryGlobals::reset();
-        let mut program = host::Program::new("fibonacci-guest");
-        let inputs = postcard::to_stdvec(&5u32).unwrap();
-        let (bytecode, init_memory_state, _, e_entry) = program.decode();
-        let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let program_data =
-            ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap();
-
-        let shared = JoltSharedPreprocessing::<DoryCommitmentScheme>::new_committed(
-            program_data,
-            io_device.memory_layout.clone(),
-            1 << 16,
-            1,
+    fn test_shared_preprocessing_committed(
+        bytecode: Vec<JoltInstructionRow>,
+        init_memory_state: Vec<(u64, u8)>,
+        memory_layout: common::jolt_device::MemoryLayout,
+        max_trace_len: usize,
+        entry_address: u64,
+        bytecode_chunk_count: usize,
+    ) -> Result<(JoltSharedPreprocessing, Arc<ProgramPreprocessing>), PreprocessingError> {
+        let program = ProgramPreprocessing::preprocess(bytecode, init_memory_state, entry_address)?;
+        let shared = JoltSharedPreprocessing::new_committed(
+            program.clone(),
+            memory_layout,
+            max_trace_len,
+            bytecode_chunk_count,
         );
-        assert!(shared.program.is_committed());
-        assert!(
-            shared.program.full().is_some(),
-            "prover-side committed preprocessing should retain full program data"
-        );
-
-        let mut bytes = Vec::new();
-        shared.serialize_compressed(&mut bytes).unwrap();
-        let decoded =
-            JoltSharedPreprocessing::<DoryCommitmentScheme>::deserialize_compressed(&*bytes)
-                .unwrap();
-
-        assert!(decoded.program.is_committed());
-        assert_eq!(
-            decoded.program_meta.bytecode_len,
-            shared.program_meta.bytecode_len
-        );
-        assert_eq!(decoded.bytecode_chunk_count, shared.bytecode_chunk_count);
-        assert!(
-            decoded.program.full().is_none(),
-            "serialized verifier preprocessing must not retain prover-only full program data"
-        );
+        let program = Arc::new(program);
+        Ok((shared, program))
     }
 
     #[test]
@@ -2577,15 +2734,14 @@ mod tests {
         let inputs = postcard::to_stdvec(&100u32).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -2622,16 +2778,14 @@ mod tests {
         let inputs = postcard::to_stdvec(&5u32).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             8192,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -2679,15 +2833,14 @@ mod tests {
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -2737,15 +2890,14 @@ mod tests {
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -2801,8 +2953,8 @@ mod tests {
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
@@ -2865,8 +3017,8 @@ mod tests {
         let (lazy_trace, trace, final_memory_state, io_device) =
             program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             4096,
@@ -2928,8 +3080,8 @@ mod tests {
         trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
@@ -2994,8 +3146,8 @@ mod tests {
         let (lazy_trace, trace, final_memory_state, io_device) =
             program.trace(&inputs, &untrusted_advice, &trusted_advice);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
@@ -3085,15 +3237,14 @@ mod tests {
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&[], &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -3131,15 +3282,14 @@ mod tests {
         let inputs = postcard::to_stdvec(&50u32).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -3177,15 +3327,59 @@ mod tests {
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
+        let elf_contents_opt = program.get_elf_contents();
+        let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
+        let prover = RV64IMACProver::gen_from_elf(
+            &prover_preprocessing,
+            elf_contents,
+            &inputs,
+            &[],
+            &[],
+            None,
+            None,
+            None,
+        );
+        let io_device = prover.program_io.clone();
+        let (jolt_proof, debug_info) = prover.prove();
 
+        let verifier_preprocessing = JoltVerifierPreprocessing::from(&prover_preprocessing);
+        let verifier = RV64IMACVerifier::new(
+            &verifier_preprocessing,
+            jolt_proof,
+            io_device,
+            None,
+            debug_info,
+        )
+        .expect("Failed to create verifier");
+        verifier.verify().expect("Failed to verify proof");
+    }
+
+    #[test]
+    #[serial]
+    fn muldiv_e2e_dory_committed_program_commitments() {
+        DoryGlobals::reset();
+        let mut program = host::Program::new("muldiv-guest");
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
+        let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing_committed(
+            bytecode,
+            init_memory_state,
+            io_device.memory_layout.clone(),
+            1 << 16,
+            e_entry,
+            1,
+        )
+        .unwrap();
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -3227,15 +3421,14 @@ mod tests {
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
@@ -3380,9 +3573,8 @@ mod tests {
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
-
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
@@ -3404,9 +3596,9 @@ mod tests {
         );
         let (jolt_proof, _) = prover.prove();
 
-        println!("\n=== BlindFold R1CS Satisfaction Test (All 8 Stages) ===\n");
+        println!("\n=== BlindFold R1CS Satisfaction Test (All 7 Stages) ===\n");
 
-        // Process all 8 stages and verify each one
+        // Process all 7 stages and verify each one
         let stage_proofs: Vec<(&str, &SumcheckInstanceProof<Fr, Bn254Curve, _>)> = vec![
             ("Stage 1 (Spartan Outer)", &jolt_proof.stage1_sumcheck_proof),
             (
@@ -3417,11 +3609,7 @@ mod tests {
             ("Stage 4 (Registers+RAM)", &jolt_proof.stage4_sumcheck_proof),
             ("Stage 5 (Value+Lookup)", &jolt_proof.stage5_sumcheck_proof),
             (
-                "Stage 6a (OneHot Address)",
-                &jolt_proof.stage6a_sumcheck_proof,
-            ),
-            (
-                "Stage 6b (OneHot Cycle+Hamming)",
+                "Stage 6 (OneHot+Hamming)",
                 &jolt_proof.stage6b_sumcheck_proof,
             ),
             (
@@ -3509,15 +3697,14 @@ mod tests {
         trace.truncate(100);
         program_io.outputs[0] = 0; // change the output to 0
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             program_io.memory_layout.clone(),
             1 << 16,
             e_entry,
         )
         .unwrap();
-
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing.clone());
 
         let prover = RV64IMACProver::gen_from_trace(
@@ -3549,8 +3736,8 @@ mod tests {
             program.trace(&inputs, &[], &[]);
 
         // Since the preprocessing is done with the original memory layout, the verifier should fail
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             program_io.memory_layout.clone(),
             1 << 16,
@@ -3596,15 +3783,14 @@ mod tests {
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, program_io) = program.trace(&inputs, &[], &[]);
-
-        let shared = test_shared_preprocessing(
-            bytecode.clone(),
-            init_memory_state,
+        let original_program = Arc::new(
+            ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry).unwrap(),
+        );
+        let shared = JoltSharedPreprocessing::new(
+            (*original_program).clone(),
             program_io.memory_layout.clone(),
             1 << 16,
-            e_entry,
-        )
-        .unwrap();
+        );
         let prover_preprocessing = JoltProverPreprocessing::new(shared.clone());
         let prover = RV64IMACProver::gen_from_trace(
             &prover_preprocessing,
@@ -3617,18 +3803,20 @@ mod tests {
         );
         let (proof, _) = prover.prove();
 
-        let original_entry_index = crate::zkvm::bytecode::entry_bytecode_index(shared.bytecode());
+        let original_entry_index = original_program.entry_bytecode_index();
         // Tamper: give verifier a wrong entry_address so it computes a different
         // entry_bytecode_index and thus a different input_claim expectation.
         let mut tampered_shared = shared.clone();
-        let mut tampered_bytecode = tampered_shared.bytecode().clone();
-        tampered_bytecode.entry_address = e_entry.wrapping_add(4);
-        let ProgramPreprocessing::Full(full) = &mut tampered_shared.program else {
-            panic!("test_shared_preprocessing must produce full preprocessing")
-        };
-        full.bytecode = tampered_bytecode;
-        let tampered_entry_index =
-            crate::zkvm::bytecode::entry_bytecode_index(tampered_shared.bytecode());
+        match &mut tampered_shared.program {
+            ProgramPreprocessing::Full(full) => {
+                full.bytecode.entry_address = e_entry.wrapping_add(4);
+            }
+            ProgramPreprocessing::Committed(_) => {
+                panic!("test uses full program preprocessing");
+            }
+        }
+        tampered_shared.program_meta = tampered_shared.program.meta();
+        let tampered_entry_index = tampered_shared.program.entry_bytecode_index();
         assert_ne!(
             original_entry_index, tampered_entry_index,
             "tamper did not change entry_bytecode_index — test scenario is invalid"
@@ -3775,8 +3963,8 @@ mod tests {
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
 
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,
@@ -3824,8 +4012,8 @@ mod tests {
         trusted_advice.extend(postcard::to_stdvec(&[7u8; 32]).unwrap());
 
         let (_, _, _, io_device) = program.trace(&inputs, &untrusted_advice, &trusted_advice);
-        let shared_preprocessing = test_shared_preprocessing(
-            bytecode.clone(),
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
             init_memory_state,
             io_device.memory_layout.clone(),
             1 << 16,

--- a/jolt-core/src/zkvm/ram/mod.rs
+++ b/jolt-core/src/zkvm/ram/mod.rs
@@ -301,6 +301,61 @@ pub fn verifier_accumulate_advice<F: JoltField, A: AbstractVerifierOpeningAccumu
     }
 }
 
+/// Accumulates staged program-image scalar contribution claims into the prover accumulator.
+///
+/// These are scalar inner products:
+/// - `C_rw  = Σ_j ProgramWord[j] * eq(r_address_rw, start_index + j)`
+///
+/// This is stored as a virtual opening under `SumcheckId::RamValCheck`.
+pub fn prover_accumulate_program_image<F: JoltField>(
+    ram_K: usize,
+    ram_preprocessing: &RAMPreprocessing,
+    program_io: &JoltDevice,
+    opening_accumulator: &mut ProverOpeningAccumulator<F>,
+) {
+    let total_vars = ram_K.log_2();
+    let bytecode_start = remap_address(
+        ram_preprocessing.min_bytecode_address,
+        &program_io.memory_layout,
+    )
+    .unwrap() as usize;
+
+    let (r_rw, _) = opening_accumulator.get_virtual_polynomial_opening(
+        VirtualPolynomial::RamVal,
+        SumcheckId::RamReadWriteChecking,
+    );
+    let (r_address_rw, _) = r_rw.split_at(total_vars);
+    let c_rw = sparse_eval_block::<F, _>(
+        bytecode_start,
+        &ram_preprocessing.bytecode_words,
+        &r_address_rw.r,
+    );
+    opening_accumulator.append_virtual(
+        VirtualPolynomial::ProgramImageInitContributionRw,
+        SumcheckId::RamValCheck,
+        r_address_rw,
+        c_rw,
+    );
+}
+
+/// Mirrors [`prover_accumulate_program_image`] on verifier side by caching opening points.
+pub fn verifier_accumulate_program_image<F: JoltField>(
+    ram_K: usize,
+    opening_accumulator: &mut impl AbstractVerifierOpeningAccumulator<F>,
+) {
+    let total_vars = ram_K.log_2();
+    let (r_rw, _) = opening_accumulator.get_virtual_polynomial_opening(
+        VirtualPolynomial::RamVal,
+        SumcheckId::RamReadWriteChecking,
+    );
+    let (r_address_rw, _) = r_rw.split_at(total_vars);
+    opening_accumulator.append_virtual(
+        VirtualPolynomial::ProgramImageInitContributionRw,
+        SumcheckId::RamValCheck,
+        r_address_rw,
+    );
+}
+
 /// Calculates how advice inputs contribute to the evaluation of initial_ram_state at a given random point.
 ///
 /// ## Example with Two Commitments:
@@ -457,6 +512,34 @@ pub fn reconstruct_full_eval<F: JoltField>(
     eval
 }
 
+/// Evaluate just the public input words at a random RAM address point.
+///
+/// Inputs are packed into little-endian `u64` words and placed at
+/// `memory_layout.input_start`.
+pub fn eval_inputs_mle<F: JoltField>(program_io: &JoltDevice, r_address: &[F::Challenge]) -> F {
+    if program_io.inputs.is_empty() {
+        return F::zero();
+    }
+
+    let input_start = remap_address(
+        program_io.memory_layout.input_start,
+        &program_io.memory_layout,
+    )
+    .unwrap() as usize;
+    let input_words: Vec<u64> = program_io
+        .inputs
+        .chunks(8)
+        .map(|chunk| {
+            let mut word = [0u8; 8];
+            for (i, byte) in chunk.iter().enumerate() {
+                word[i] = *byte;
+            }
+            u64::from_le_bytes(word)
+        })
+        .collect();
+    sparse_eval_block::<F, _>(input_start, &input_words, r_address)
+}
+
 /// Trait for coefficient types usable in sparse MLE evaluation.
 ///
 /// `u64` uses Barrett-reduced accumulation (`MedAccumU`) for performance.
@@ -567,25 +650,7 @@ pub fn eval_initial_ram_mle<F: JoltField + 'static>(
     let mut acc =
         sparse_eval_block::<F, _>(bytecode_start, &ram_preprocessing.bytecode_words, r_address);
 
-    if !program_io.inputs.is_empty() {
-        let input_start = remap_address(
-            program_io.memory_layout.input_start,
-            &program_io.memory_layout,
-        )
-        .unwrap() as usize;
-        let input_words: Vec<u64> = program_io
-            .inputs
-            .chunks(8)
-            .map(|chunk| {
-                let mut word = [0u8; 8];
-                for (i, byte) in chunk.iter().enumerate() {
-                    word[i] = *byte;
-                }
-                u64::from_le_bytes(word)
-            })
-            .collect();
-        acc += sparse_eval_block::<F, _>(input_start, &input_words, r_address);
-    }
+    acc += eval_inputs_mle::<F>(program_io, r_address);
 
     acc
 }

--- a/jolt-core/src/zkvm/ram/val_check.rs
+++ b/jolt-core/src/zkvm/ram/val_check.rs
@@ -81,12 +81,14 @@ pub struct RamValCheckSumcheckParams<F: JoltField> {
     /// Val_init(r_address) evaluation to subtract on both LHS terms.
     pub init_eval: F,
 
-    /// Public-only portion of init_eval (bytecode + inputs), used by BlindFold constraint.
+    /// Public constant portion of init_eval used by BlindFold constraints.
+    /// In committed-program mode this is inputs-only; program image is an opening.
     #[cfg(feature = "zk")]
     pub init_eval_public: F,
     /// Advice contributions decomposed for BlindFold: each is (-selector, opening_id).
     #[cfg(feature = "zk")]
     pub advice_contributions: Vec<(F, OpeningId)>,
+    pub include_program_image_claims: bool,
 }
 
 impl<F: JoltField> RamValCheckSumcheckParams<F> {
@@ -98,6 +100,8 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         gamma: F,
         ram_preprocessing: &super::RAMPreprocessing,
         program_io: &JoltDevice,
+        _rw_config: &ReadWriteConfig,
+        include_program_image_claims: bool,
     ) -> Self {
         let K = one_hot_params.ram_k;
 
@@ -124,8 +128,11 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         let init_eval = val_init.evaluate(&r_address.r);
 
         #[cfg(feature = "zk")]
-        let init_eval_public =
-            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r);
+        let init_eval_public = if include_program_image_claims {
+            super::eval_inputs_mle::<F>(program_io, &r_address.r)
+        } else {
+            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r)
+        };
 
         #[cfg(feature = "zk")]
         let advice_contributions = super::compute_advice_init_contributions(
@@ -151,6 +158,7 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
             init_eval_public,
             #[cfg(feature = "zk")]
             advice_contributions,
+            include_program_image_claims,
         }
     }
 
@@ -163,6 +171,7 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         _rw_config: &ReadWriteConfig,
         gamma: F,
         opening_accumulator: &dyn OpeningAccumulator<F>,
+        include_program_image_claims: bool,
     ) -> Self {
         // (r_address, r_cycle) from RamVal/RamReadWriteChecking.
         let (r, _) = opening_accumulator.get_virtual_polynomial_opening(
@@ -183,8 +192,22 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         }
 
         let n_memory_vars = ram_K.log_2();
-        let init_eval_public =
-            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r);
+        let init_eval_public_base = if include_program_image_claims {
+            super::eval_inputs_mle::<F>(program_io, &r_address.r)
+        } else {
+            super::eval_initial_ram_mle::<F>(ram_preprocessing, program_io, &r_address.r)
+        };
+        let program_image_contribution = if include_program_image_claims {
+            opening_accumulator
+                .get_virtual_polynomial_opening(
+                    VirtualPolynomial::ProgramImageInitContributionRw,
+                    SumcheckId::RamValCheck,
+                )
+                .1
+        } else {
+            F::zero()
+        };
+        let init_eval_public = init_eval_public_base + program_image_contribution;
         let advice_contributions = super::compute_advice_init_contributions(
             opening_accumulator,
             &program_io.memory_layout,
@@ -199,7 +222,9 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
         );
 
         #[cfg(not(feature = "zk"))]
-        let _ = (init_eval_public, advice_contributions);
+        let _ = (init_eval_public_base, advice_contributions);
+        #[cfg(feature = "zk")]
+        let init_eval_public = init_eval_public_base;
 
         Self {
             T: trace_len,
@@ -212,6 +237,7 @@ impl<F: JoltField> RamValCheckSumcheckParams<F> {
             init_eval_public,
             #[cfg(feature = "zk")]
             advice_contributions,
+            include_program_image_claims,
         }
     }
 }
@@ -248,12 +274,17 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RamValCheckSumcheckParams<F> {
     fn input_claim_constraint(&self) -> InputClaimConstraint {
         // input_claim = (val_rw - init_eval) + γ*(val_final - init_eval)
         //             = val_rw + γ*val_final - (1+γ)*init_eval
-        //             = val_rw + γ*val_final - (1+γ)*(init_eval_public + Σ(sel_i * advice_i))
+        // where:
+        //   - in full-program mode:
+        //       init_eval = init_eval_public + Σ(sel_i * advice_i)
+        //   - in committed-program mode:
+        //       init_eval = init_eval_public + program_image_claim + Σ(sel_i * advice_i)
         //
         // Challenge layout:
         //   Challenge(0) = γ
         //   Challenge(1) = -(1+γ)*init_eval_public
-        //   Challenge(2..) = -(1+γ)*selector_i  (one per advice contribution)
+        //   Challenge(2) = -(1+γ)                      (program-image claim; committed mode only)
+        //   Challenge(next..) = -(1+γ)*selector_i      (one per advice contribution)
         let val_rw = OpeningId::virt(VirtualPolynomial::RamVal, SumcheckId::RamReadWriteChecking);
         let val_final = OpeningId::virt(VirtualPolynomial::RamValFinal, SumcheckId::RamOutputCheck);
 
@@ -265,11 +296,23 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RamValCheckSumcheckParams<F> {
             ),
             ProductTerm::single(ValueSource::Challenge(1)),
         ];
-        for (i, (_, advice_opening_id)) in self.advice_contributions.iter().enumerate() {
+        let mut challenge_idx = 2;
+        if self.include_program_image_claims {
             terms.push(ProductTerm::product(vec![
-                ValueSource::Challenge(i + 2),
+                ValueSource::Challenge(challenge_idx),
+                ValueSource::Opening(OpeningId::virt(
+                    VirtualPolynomial::ProgramImageInitContributionRw,
+                    SumcheckId::RamValCheck,
+                )),
+            ]));
+            challenge_idx += 1;
+        }
+        for (_, advice_opening_id) in self.advice_contributions.iter() {
+            terms.push(ProductTerm::product(vec![
+                ValueSource::Challenge(challenge_idx),
                 ValueSource::Opening(*advice_opening_id),
             ]));
+            challenge_idx += 1;
         }
         InputClaimConstraint::sum_of_products(terms)
     }
@@ -278,6 +321,9 @@ impl<F: JoltField> SumcheckInstanceParams<F> for RamValCheckSumcheckParams<F> {
     fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
         let one_plus_gamma = F::one() + self.gamma;
         let mut values = vec![self.gamma, -one_plus_gamma * self.init_eval_public];
+        if self.include_program_image_claims {
+            values.push(-one_plus_gamma);
+        }
         for (neg_selector, _) in &self.advice_contributions {
             // neg_selector is already negative (-selector_i), scale by (1+γ)
             values.push(one_plus_gamma * *neg_selector);
@@ -474,6 +520,7 @@ impl<F: JoltField> RamValCheckSumcheckVerifier<F> {
         rw_config: &ReadWriteConfig,
         gamma: F,
         opening_accumulator: &dyn OpeningAccumulator<F>,
+        include_program_image_claims: bool,
     ) -> Self {
         let params = RamValCheckSumcheckParams::new_from_verifier(
             initial_ram_state,
@@ -484,6 +531,7 @@ impl<F: JoltField> RamValCheckSumcheckVerifier<F> {
             rw_config,
             gamma,
             opening_accumulator,
+            include_program_image_claims,
         );
         Self { params }
     }

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -48,10 +48,12 @@ use crate::poly::commitment::dory::DoryGlobals;
 use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN};
 use crate::subprotocols::sumcheck::{BatchedSumcheck, ClearSumcheckProof, SumcheckInstanceProof};
 use crate::zkvm::claim_reductions::{
-    AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
+    AdviceClaimReductionVerifier, AdviceKind, BytecodeClaimReductionParams,
+    BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier,
+    ProgramImageClaimReductionParams, ProgramImageClaimReductionVerifier,
     RegistersClaimReductionSumcheckVerifier,
 };
-use crate::zkvm::config::{OneHotParams, ProgramMode};
+use crate::zkvm::config::OneHotParams;
 use crate::zkvm::{
     bytecode::read_raf_checking::{
         BytecodeReadRafAddressSumcheckVerifier, BytecodeReadRafCycleSumcheckVerifier,
@@ -59,8 +61,9 @@ use crate::zkvm::{
     },
     claim_reductions::{
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
-        PrecommittedClaimReduction, RamRaClaimReductionSumcheckVerifier,
+        RamRaClaimReductionSumcheckVerifier,
     },
+    config::ProgramMode,
     fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
@@ -74,7 +77,7 @@ use crate::zkvm::{
         output_check::OutputSumcheckVerifier, ra_virtual::RamRaVirtualSumcheckVerifier,
         raf_evaluation::RafEvaluationSumcheckVerifier as RamRafEvaluationSumcheckVerifier,
         read_write_checking::RamReadWriteCheckingVerifier, val_check::RamValCheckSumcheckVerifier,
-        verifier_accumulate_advice,
+        verifier_accumulate_advice, verifier_accumulate_program_image,
     },
     registers::{
         read_write_checking::RegistersReadWriteCheckingVerifier,
@@ -138,12 +141,10 @@ pub struct TranspilableVerifier<
     pub opening_accumulator: A,
     pub spartan_key: UniformSpartanKey<F>,
     pub one_hot_params: OneHotParams,
-    /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
-    /// Cache the verifier state here between stages.
     advice_reduction_verifier_trusted: Option<AdviceClaimReductionVerifier<F>>,
-    /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
-    /// Cache the verifier state here between stages.
     advice_reduction_verifier_untrusted: Option<AdviceClaimReductionVerifier<F>>,
+    bytecode_reduction_verifier: Option<BytecodeClaimReductionVerifier<F>>,
+    program_image_reduction_verifier: Option<ProgramImageClaimReductionVerifier<F>>,
 }
 
 impl<
@@ -236,10 +237,11 @@ impl<
             .validate()
             .map_err(ProofVerifyError::InvalidOneHotConfig)?;
 
-        let min_ram_K = compute_min_ram_K(
-            preprocessing.shared.ram(),
-            &preprocessing.shared.memory_layout,
-        );
+        let ram_preprocessing = crate::zkvm::ram::RAMPreprocessing {
+            min_bytecode_address: preprocessing.shared.program_meta.min_bytecode_address,
+            bytecode_words: vec![0; preprocessing.shared.program_meta.program_image_len_words],
+        };
+        let min_ram_K = compute_min_ram_K(&ram_preprocessing, &preprocessing.shared.memory_layout);
         let max_ram_K = compute_max_ram_K(&preprocessing.shared.memory_layout);
         if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K || proof.ram_K > max_ram_K {
             return Err(ProofVerifyError::InvalidRamK {
@@ -255,7 +257,7 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config
-        let bytecode_K = preprocessing.shared.bytecode().code_size;
+        let bytecode_K = preprocessing.shared.bytecode_size();
         let one_hot_params =
             OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
@@ -270,6 +272,8 @@ impl<
             one_hot_params,
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
+            bytecode_reduction_verifier: None,
+            program_image_reduction_verifier: None,
         })
     }
 
@@ -286,7 +290,7 @@ impl<
         opening_accumulator: A,
     ) -> Self {
         let spartan_key = UniformSpartanKey::new(proof.trace_length.next_power_of_two());
-        let bytecode_K = preprocessing.shared.bytecode().code_size;
+        let bytecode_K = preprocessing.shared.bytecode_size();
         let one_hot_params =
             OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
@@ -301,6 +305,8 @@ impl<
             one_hot_params,
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
+            bytecode_reduction_verifier: None,
+            program_image_reduction_verifier: None,
         }
     }
 
@@ -311,7 +317,7 @@ impl<
         JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
             trace_log_t + log_k_chunk,
             self.preprocessing.shared.precommitted_candidate_total_vars(
-                false,
+                self.preprocessing.shared.program.is_committed(),
                 self.trusted_advice_commitment.is_some(),
                 self.proof.untrusted_advice_commitment.is_some(),
             ),
@@ -332,7 +338,7 @@ impl<
             &self.program_io,
             self.proof.ram_K,
             self.proof.trace_length,
-            self.preprocessing.shared.bytecode().entry_address,
+            self.preprocessing.shared.program_meta.entry_address,
             &self.proof.rw_config,
             &self.proof.one_hot_config,
             self.proof.dory_layout,
@@ -510,23 +516,51 @@ impl<
             self.trusted_advice_commitment.is_some(),
             &mut self.opening_accumulator,
         );
+        if self.preprocessing.shared.program.is_committed() {
+            verifier_accumulate_program_image::<F>(self.proof.ram_K, &mut self.opening_accumulator);
+        }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
-        let initial_ram_state = crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
-            self.proof.ram_K,
-            self.preprocessing.shared.ram(),
-            &self.program_io,
-        );
+        let initial_ram_state = if self.preprocessing.shared.program.is_full() {
+            crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
+                self.proof.ram_K,
+                &self.preprocessing.shared.program.as_full().unwrap().ram,
+                &self.program_io,
+            )
+        } else {
+            vec![0u64; self.proof.ram_K]
+        };
+        let ram_preprocessing = if self.preprocessing.shared.program.is_full() {
+            self.preprocessing
+                .shared
+                .program
+                .as_full()
+                .unwrap()
+                .ram
+                .clone()
+        } else {
+            crate::zkvm::ram::RAMPreprocessing {
+                min_bytecode_address: self.preprocessing.shared.program_meta.min_bytecode_address,
+                bytecode_words: vec![
+                    0;
+                    self.preprocessing
+                        .shared
+                        .program_meta
+                        .program_image_len_words
+                ],
+            }
+        };
         let ram_val_check = RamValCheckSumcheckVerifier::new(
             &initial_ram_state,
             &self.program_io,
-            self.preprocessing.shared.ram(),
+            &ram_preprocessing,
             self.proof.trace_length,
             self.proof.ram_K,
             &self.proof.rw_config,
             ram_val_check_gamma,
             &self.opening_accumulator,
+            self.preprocessing.shared.program.is_committed(),
         );
 
         let instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript, A>> =
@@ -598,14 +632,28 @@ impl<
         ProofVerifyError,
     > {
         let n_cycle_vars = self.proof.trace_length.log_2();
+        let program_mode = if self.preprocessing.shared.program.is_committed() {
+            ProgramMode::Committed
+        } else {
+            ProgramMode::Full
+        };
+        let entry_bytecode_index = self
+            .preprocessing
+            .shared
+            .program_meta
+            .entry_address
+            .saturating_sub(self.preprocessing.shared.program_meta.min_bytecode_address)
+            as usize
+            / common::constants::BYTES_PER_INSTRUCTION
+            + 1;
         let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
             Some(&self.preprocessing.shared.program),
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-            ProgramMode::Full,
-            0,
+            program_mode,
+            entry_bytecode_index,
         )?;
         let booleanity_params = BooleanitySumcheckParams::new(
             n_cycle_vars,
@@ -633,6 +681,7 @@ impl<
         bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
         booleanity_params: BooleanitySumcheckParams<F>,
     ) -> Result<(), ProofVerifyError> {
+        let bytecode_reduction_seed_params = bytecode_read_raf_params.clone();
         let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
             bytecode_read_raf_params,
             &self.opening_accumulator,
@@ -657,19 +706,19 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+
         let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
         let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
-            false,
+            self.preprocessing.shared.program.is_committed(),
             self.trusted_advice_commitment.is_some(),
             self.proof.untrusted_advice_commitment.is_some(),
         );
         let precommitted_scheduling_reference =
-            PrecommittedClaimReduction::<F>::scheduling_reference(
+            crate::zkvm::claim_reductions::PrecommittedClaimReduction::<F>::scheduling_reference(
                 main_total_vars,
                 &precommitted_candidates,
             );
 
-        // Advice claim reduction (Phase 1 in Stage 6b): trusted and untrusted are separate instances.
         if self.trusted_advice_commitment.is_some() {
             self.advice_reduction_verifier_trusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Trusted,
@@ -687,6 +736,38 @@ impl<
             ));
         }
 
+        if self.preprocessing.shared.program.is_committed() {
+            let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_reduction_params = BytecodeClaimReductionParams::new(
+                &bytecode_reduction_seed_params,
+                self.preprocessing.shared.bytecode_size(),
+                bytecode_chunk_count,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+                &mut self.transcript,
+            );
+            self.bytecode_reduction_verifier = Some(BytecodeClaimReductionVerifier::new(
+                bytecode_reduction_params,
+            ));
+
+            let padded_len_words = self
+                .preprocessing
+                .shared
+                .program_meta
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let program_image_reduction_params = ProgramImageClaimReductionParams::new(
+                &self.program_io,
+                self.preprocessing.shared.program_meta.min_bytecode_address,
+                padded_len_words,
+                self.proof.ram_K,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+            );
+            self.program_image_reduction_verifier = Some(ProgramImageClaimReductionVerifier::new(
+                program_image_reduction_params,
+            ));
+        }
+
         let mut instances: Vec<&dyn SumcheckInstanceVerifier<F, ProofTranscript, A>> = vec![
             &bytecode_read_raf,
             &booleanity,
@@ -700,6 +781,12 @@ impl<
         }
         if let Some(ref advice) = self.advice_reduction_verifier_untrusted {
             instances.push(advice);
+        }
+        if let Some(ref reduction) = self.bytecode_reduction_verifier {
+            instances.push(reduction);
+        }
+        if let Some(ref reduction) = self.program_image_reduction_verifier {
+            instances.push(reduction);
         }
 
         let _r_stage6b = BatchedSumcheck::verify_standard::<F, ProofTranscript, A>(
@@ -732,8 +819,8 @@ impl<
             self.advice_reduction_verifier_trusted.as_mut()
         {
             let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
-                params.transition_to_address_phase();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
@@ -741,8 +828,8 @@ impl<
             self.advice_reduction_verifier_untrusted.as_mut()
         {
             let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
-                params.transition_to_address_phase();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1,14 +1,8 @@
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
-use std::sync::Arc;
-
 use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryGlobals, DoryLayout};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals, DoryLayout};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -41,7 +35,6 @@ use crate::zkvm::r1cs::constraints::{
     OUTER_FIRST_ROUND_POLY_NUM_COEFFS, OUTER_UNIVARIATE_SKIP_DOMAIN_SIZE,
     PRODUCT_VIRTUAL_FIRST_ROUND_POLY_NUM_COEFFS, PRODUCT_VIRTUAL_UNIVARIATE_SKIP_DOMAIN_SIZE,
 };
-use crate::zkvm::ram::RAMPreprocessing;
 use crate::zkvm::witness::all_committed_polynomials;
 use crate::zkvm::Serializable;
 use crate::zkvm::{
@@ -50,9 +43,11 @@ use crate::zkvm::{
         BytecodeReadRafSumcheckParams,
     },
     claim_reductions::{
-        AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
+        AdviceClaimReductionVerifier, AdviceKind, BytecodeClaimReductionParams,
+        BytecodeClaimReductionVerifier, HammingWeightClaimReductionVerifier,
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
-        PrecommittedClaimReduction, RamRaClaimReductionSumcheckVerifier,
+        PrecommittedClaimReduction, ProgramImageClaimReductionParams,
+        ProgramImageClaimReductionVerifier, RamRaClaimReductionSumcheckVerifier,
     },
     fiat_shamir_preamble,
     instruction_lookups::{
@@ -67,7 +62,7 @@ use crate::zkvm::{
         output_check::OutputSumcheckVerifier, ra_virtual::RamRaVirtualSumcheckVerifier,
         raf_evaluation::RafEvaluationSumcheckVerifier as RamRafEvaluationSumcheckVerifier,
         read_write_checking::RamReadWriteCheckingVerifier, val_check::RamValCheckSumcheckVerifier,
-        verifier_accumulate_advice,
+        verifier_accumulate_advice, verifier_accumulate_program_image,
     },
     registers::{
         read_write_checking::RegistersReadWriteCheckingVerifier,
@@ -98,6 +93,11 @@ use crate::{
     utils::{errors::ProofVerifyError, math::Math},
     zkvm::witness::CommittedPolynomial,
 };
+use common::constants::BYTES_PER_INSTRUCTION;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 
 #[cfg(feature = "zk")]
 struct StageVerifyResult<F: JoltField> {
@@ -249,6 +249,10 @@ pub struct JoltVerifier<
     /// The advice claim reduction sumcheck effectively spans two stages (6 and 7).
     /// Cache the verifier state here between stages.
     advice_reduction_verifier_untrusted: Option<AdviceClaimReductionVerifier<F>>,
+    /// Bytecode claim reduction spans stages 6b and 7 in committed mode.
+    bytecode_reduction_verifier: Option<BytecodeClaimReductionVerifier<F>>,
+    /// Program-image claim reduction spans stages 6b and 7 in committed mode.
+    program_image_reduction_verifier: Option<ProgramImageClaimReductionVerifier<F>>,
     pub spartan_key: UniformSpartanKey<F>,
     pub one_hot_params: OneHotParams,
 }
@@ -275,7 +279,7 @@ impl<
         JoltSharedPreprocessing::<PCS>::max_total_vars_from_candidates(
             trace_log_t + log_k_chunk,
             self.preprocessing.shared.precommitted_candidate_total_vars(
-                false,
+                self.preprocessing.shared.program.is_committed(),
                 self.trusted_advice_commitment.is_some(),
                 self.proof.untrusted_advice_commitment.is_some(),
             ),
@@ -297,20 +301,37 @@ impl<
         {
             opening_candidates.push(("untrusted_advice", point));
         }
+        if self.preprocessing.shared.program.is_committed() {
+            for chunk_idx in 0..self.preprocessing.shared.bytecode_chunk_count {
+                let (point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                );
+                opening_candidates.push(("bytecode_chunk", point));
+            }
+        }
+        if self.preprocessing.shared.program.is_committed() {
+            let (program_image_point, _) =
+                self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                );
+            opening_candidates.push(("program_image", program_image_point));
+        }
 
         let max_len = opening_candidates
             .iter()
-            .map(|(_, point)| point.r.len())
+            .map(|(_, p)| p.r.len())
             .max()
             .unwrap_or(0);
         if max_len > native_main_vars {
             let dominant = opening_candidates
                 .iter()
-                .find(|(_, point)| point.r.len() == max_len)
+                .find(|(_, p)| p.r.len() == max_len)
                 .expect("at least one dominant precommitted candidate expected");
             for (name, point) in opening_candidates
                 .iter()
-                .filter(|(_, point)| point.r.len() == max_len)
+                .filter(|(_, p)| p.r.len() == max_len)
             {
                 if point.r != dominant.1.r {
                     return Err(ProofVerifyError::DoryError(format!(
@@ -319,44 +340,46 @@ impl<
                     )));
                 }
             }
-            return Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()));
-        }
+            Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
+        } else {
+            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::InstructionRa(0),
+                SumcheckId::HammingWeightClaimReduction,
+            );
+            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+            let r_cycle_stage6 = self
+                .opening_accumulator
+                .get_committed_polynomial_opening(
+                    CommittedPolynomial::RamInc,
+                    SumcheckId::IncClaimReduction,
+                )
+                .0
+                .r;
 
-        let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::InstructionRa(0),
-            SumcheckId::HammingWeightClaimReduction,
-        );
-        let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
-        let r_cycle_stage6 = self
-            .opening_accumulator
-            .get_committed_polynomial_opening(
-                CommittedPolynomial::RamInc,
-                SumcheckId::IncClaimReduction,
-            )
-            .0
-            .r;
-
-        match self.proof.dory_layout {
-            DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
-                [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
-            )),
-            DoryLayout::CycleMajor => {
-                let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
-                if r_cycle_stage6.len() < native_cycle.len() {
-                    return Err(ProofVerifyError::DoryError(
-                        "stage6 cycle challenges shorter than native cycle vars".to_string(),
-                    ));
+            match self.proof.dory_layout {
+                DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+                )),
+                DoryLayout::CycleMajor => {
+                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                    if r_cycle_stage6.len() < native_cycle.len() {
+                        return Err(ProofVerifyError::DoryError(
+                            "stage6 cycle challenges shorter than native cycle vars".to_string(),
+                        ));
+                    }
+                    if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
+                        return Err(ProofVerifyError::DoryError(format!(
+                            "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
+                             (cycle_full_len={}, native_len={})",
+                            r_cycle_stage6.len(),
+                            native_cycle.len()
+                        )));
+                    }
+                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                    let cycle_extra_and_anchor =
+                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
+                    Ok(OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor))
                 }
-                if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
-                    return Err(ProofVerifyError::DoryError(
-                        "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars"
-                            .to_string(),
-                    ));
-                }
-                let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
-                Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
-                    [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat(),
-                ))
             }
         }
     }
@@ -444,10 +467,11 @@ impl<
             .validate()
             .map_err(ProofVerifyError::InvalidOneHotConfig)?;
 
-        let min_ram_K = compute_min_ram_K(
-            preprocessing.shared.ram(),
-            &preprocessing.shared.memory_layout,
-        );
+        let ram_preprocessing = crate::zkvm::ram::RAMPreprocessing {
+            min_bytecode_address: preprocessing.shared.program_meta.min_bytecode_address,
+            bytecode_words: vec![0; preprocessing.shared.program_meta.program_image_len_words],
+        };
+        let min_ram_K = compute_min_ram_K(&ram_preprocessing, &preprocessing.shared.memory_layout);
         let max_ram_K = compute_max_ram_K(&preprocessing.shared.memory_layout);
         if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_K || proof.ram_K > max_ram_K {
             return Err(ProofVerifyError::InvalidRamK {
@@ -463,7 +487,7 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config.
-        let bytecode_K = preprocessing.shared.bytecode().code_size;
+        let bytecode_K = preprocessing.shared.bytecode_size();
         let one_hot_params =
             OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
 
@@ -476,6 +500,8 @@ impl<
             opening_accumulator,
             advice_reduction_verifier_trusted: None,
             advice_reduction_verifier_untrusted: None,
+            bytecode_reduction_verifier: None,
+            program_image_reduction_verifier: None,
             spartan_key,
             one_hot_params,
         })
@@ -515,7 +541,7 @@ impl<
             &self.program_io,
             self.proof.ram_K,
             self.proof.trace_length,
-            self.preprocessing.shared.bytecode().entry_address,
+            self.preprocessing.shared.program_meta.entry_address,
             &self.proof.rw_config,
             &self.proof.one_hot_config,
             self.proof.dory_layout,
@@ -525,10 +551,10 @@ impl<
 
         // Initialize DoryGlobals with the layout from the proof
         // This ensures the verifier uses the same layout as the prover
-        let _guard = DoryGlobals::initialize_main_with_log_embedding(
+        let _guard = DoryGlobals::initialize_context(
             1 << self.one_hot_params.log_k_chunk,
             self.proof.trace_length.next_power_of_two(),
-            self.main_total_vars(),
+            DoryContext::Main,
             Some(self.proof.dory_layout),
         );
 
@@ -546,6 +572,19 @@ impl<
         if let Some(ref trusted_advice_commitment) = self.trusted_advice_commitment {
             self.transcript
                 .append_serializable(b"trusted_advice", trusted_advice_commitment);
+        }
+        if let Some(trusted_bytecode) = self.preprocessing.shared.program.bytecode_commitments() {
+            for commitment in &trusted_bytecode.commitments {
+                self.transcript
+                    .append_serializable(b"bytecode_chunk_commit", commitment);
+            }
+        }
+        if self.preprocessing.shared.program.is_committed() {
+            let trusted = self.preprocessing.shared.program.as_committed()?;
+            self.transcript.append_serializable(
+                b"program_image_commitment",
+                &trusted.program_image_commitment,
+            );
         }
 
         let (stage1_result, uniskip_challenge1) = self
@@ -987,23 +1026,45 @@ impl<
             self.trusted_advice_commitment.is_some(),
             &mut self.opening_accumulator,
         );
+        if self.preprocessing.shared.program.is_committed() {
+            verifier_accumulate_program_image::<F>(self.proof.ram_K, &mut self.opening_accumulator);
+        }
         // Domain-separate the batching challenge.
         self.transcript.append_bytes(b"ram_val_check_gamma", &[]);
         let ram_val_check_gamma: F = self.transcript.challenge_scalar::<F>();
-        let initial_ram_state = crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
-            self.proof.ram_K,
-            self.preprocessing.shared.ram(),
-            &self.program_io,
-        );
+        let initial_ram_state = if self.preprocessing.shared.program.is_full() {
+            crate::zkvm::ram::gen_ram_initial_memory_state::<F>(
+                self.proof.ram_K,
+                &self.preprocessing.shared.program.as_full()?.ram,
+                &self.program_io,
+            )
+        } else {
+            vec![0u64; self.proof.ram_K]
+        };
+        let ram_preprocessing = if self.preprocessing.shared.program.is_full() {
+            self.preprocessing.shared.program.as_full()?.ram.clone()
+        } else {
+            crate::zkvm::ram::RAMPreprocessing {
+                min_bytecode_address: self.preprocessing.shared.program_meta.min_bytecode_address,
+                bytecode_words: vec![
+                    0;
+                    self.preprocessing
+                        .shared
+                        .program_meta
+                        .program_image_len_words
+                ],
+            }
+        };
         let ram_val_check = RamValCheckSumcheckVerifier::new(
             &initial_ram_state,
             &self.program_io,
-            self.preprocessing.shared.ram(),
+            &ram_preprocessing,
             self.proof.trace_length,
             self.proof.ram_K,
             &self.proof.rw_config,
             ram_val_check_gamma,
             &self.opening_accumulator,
+            self.preprocessing.shared.program.is_committed(),
         );
 
         let instances: Vec<
@@ -1147,27 +1208,38 @@ impl<
 
     fn verify_stage6a(&mut self) -> Result<Stage6aVerifyResult<F>, ProofVerifyError> {
         let n_cycle_vars = self.proof.trace_length.log_2();
-        let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new::<PCS>(
-            Some(&self.preprocessing.shared.program),
+        let program_preprocessing = Some(&self.preprocessing.shared.program);
+        let entry_bytecode_index = self
+            .preprocessing
+            .shared
+            .program_meta
+            .entry_address
+            .saturating_sub(self.preprocessing.shared.program_meta.min_bytecode_address)
+            as usize
+            / BYTES_PER_INSTRUCTION
+            + 1;
+        let bytecode_read_raf = BytecodeReadRafAddressSumcheckVerifier::new(
+            program_preprocessing,
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-            ProgramMode::Full,
-            0,
+            if self.preprocessing.shared.program.is_committed() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            entry_bytecode_index,
         )?;
-        let booleanity_params = BooleanitySumcheckParams::new(
+        let booleanity = BooleanityAddressSumcheckVerifier::new(BooleanitySumcheckParams::new(
             n_cycle_vars,
             &self.one_hot_params,
             &self.opening_accumulator,
             &mut self.transcript,
-        );
-        let booleanity = BooleanityAddressSumcheckVerifier::new(booleanity_params.clone());
-
+        ));
         let instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
         > = vec![&bytecode_read_raf, &booleanity];
-
         let (_batching_coefficients, r_stage6a) = BatchedSumcheck::verify(
             &self.proof.stage6a_sumcheck_proof,
             instances.clone(),
@@ -1175,7 +1247,6 @@ impl<
             &mut self.transcript,
         )
         .inspect_err(|err| tracing::error!("Stage 6a: {err}"))?;
-
         #[cfg(feature = "zk")]
         {
             let regular_oc_ids = self.opening_accumulator.take_pending_claim_ids();
@@ -1230,6 +1301,7 @@ impl<
         bytecode_read_raf_params: BytecodeReadRafSumcheckParams<F>,
         booleanity_params: BooleanitySumcheckParams<F>,
     ) -> Result<StageVerifyResult<F>, ProofVerifyError> {
+        let bytecode_reduction_seed_params = bytecode_read_raf_params.clone();
         let bytecode_read_raf = BytecodeReadRafCycleSumcheckVerifier::new(
             bytecode_read_raf_params,
             &self.opening_accumulator,
@@ -1254,9 +1326,10 @@ impl<
             &self.opening_accumulator,
             &mut self.transcript,
         );
+
         let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
         let precommitted_candidates = self.preprocessing.shared.precommitted_candidate_total_vars(
-            false,
+            self.preprocessing.shared.program.is_committed(),
             self.trusted_advice_commitment.is_some(),
             self.proof.untrusted_advice_commitment.is_some(),
         );
@@ -1283,6 +1356,37 @@ impl<
                 &self.opening_accumulator,
             ));
         }
+        if self.preprocessing.shared.program.is_committed() {
+            let bytecode_chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            let bytecode_reduction_params = BytecodeClaimReductionParams::new(
+                &bytecode_reduction_seed_params,
+                self.preprocessing.shared.bytecode_size(),
+                bytecode_chunk_count,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+                &mut self.transcript,
+            );
+            self.bytecode_reduction_verifier = Some(BytecodeClaimReductionVerifier::new(
+                bytecode_reduction_params,
+            ));
+
+            let padded_len_words = self
+                .preprocessing
+                .shared
+                .program_meta
+                .committed_program_image_num_words(&self.program_io.memory_layout);
+            let program_image_reduction_params = ProgramImageClaimReductionParams::new(
+                &self.program_io,
+                self.preprocessing.shared.program_meta.min_bytecode_address,
+                padded_len_words,
+                self.proof.ram_K,
+                precommitted_scheduling_reference,
+                &self.opening_accumulator,
+            );
+            self.program_image_reduction_verifier = Some(ProgramImageClaimReductionVerifier::new(
+                program_image_reduction_params,
+            ));
+        }
 
         let mut instances: Vec<
             &dyn SumcheckInstanceVerifier<F, ProofTranscript, VerifierOpeningAccumulator<F>>,
@@ -1299,6 +1403,12 @@ impl<
         }
         if let Some(ref advice) = self.advice_reduction_verifier_untrusted {
             instances.push(advice);
+        }
+        if let Some(ref reduction) = self.bytecode_reduction_verifier {
+            instances.push(reduction);
+        }
+        if let Some(ref reduction) = self.program_image_reduction_verifier {
+            instances.push(reduction);
         }
 
         let (batching_coefficients, r_stage6b) = BatchedSumcheck::verify(
@@ -1493,9 +1603,9 @@ impl<
             stage_input_constraints[2].clone(), // Stage 2
             stage_input_constraints[3].clone(), // Stage 3
             stage_input_constraints[4].clone(), // Stage 4
-            stage_input_constraints[5].clone(), // Stage 5
-            stage_input_constraints[6].clone(), // Stage 6a
-            stage_input_constraints[7].clone(), // Stage 6b
+            stage_input_constraints[5].clone(), // Stage 5 (6a)
+            stage_input_constraints[6].clone(), // Stage 6 (6b)
+            stage_input_constraints[7].clone(), // Stage 7
         ];
         for (i, constraint) in regular_constraints.iter().enumerate() {
             let idx = regular_first_round_indices[i];
@@ -1648,9 +1758,9 @@ impl<
             self.advice_reduction_verifier_trusted.as_mut()
         {
             let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
+            if params.precommitted.num_address_phase_rounds() > 0 {
                 // Transition phase
-                params.transition_to_address_phase();
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
@@ -1658,10 +1768,26 @@ impl<
             self.advice_reduction_verifier_untrusted.as_mut()
         {
             let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
+            if params.precommitted.num_address_phase_rounds() > 0 {
                 // Transition phase
-                params.transition_to_address_phase();
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_untrusted);
+            }
+        }
+        if let Some(bytecode_reduction_verifier) = self.bytecode_reduction_verifier.as_mut() {
+            let mut params = bytecode_reduction_verifier.params.borrow_mut();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
+                instances.push(bytecode_reduction_verifier);
+            }
+        }
+        if let Some(program_image_reduction_verifier) =
+            self.program_image_reduction_verifier.as_mut()
+        {
+            let mut params = program_image_reduction_verifier.params.borrow_mut();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
+                instances.push(program_image_reduction_verifier);
             }
         }
 
@@ -1711,7 +1837,6 @@ impl<
         })
     }
 
-    /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
         let opening_point = self.stage8_opening_point()?;
 
@@ -1730,7 +1855,6 @@ impl<
                 CommittedPolynomial::RdInc,
                 SumcheckId::IncClaimReduction,
             );
-
         let ram_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ram_inc_point.r);
         let rd_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &rd_inc_point.r);
         polynomial_claims.push((
@@ -1802,6 +1926,37 @@ impl<
             include_untrusted_advice = true;
         }
 
+        if self.preprocessing.shared.program.is_committed() {
+            let chunk_count = self.preprocessing.shared.bytecode_chunk_count;
+            for chunk_idx in 0..chunk_count {
+                let (chunk_point, chunk_claim) =
+                    self.opening_accumulator.get_committed_polynomial_opening(
+                        CommittedPolynomial::BytecodeChunk(chunk_idx),
+                        SumcheckId::BytecodeClaimReduction,
+                    );
+                let lagrange_factor =
+                    compute_lagrange_factor::<F>(&opening_point.r, &chunk_point.r);
+                polynomial_claims.push((
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    chunk_claim * lagrange_factor,
+                ));
+                scaling_factors.push(lagrange_factor);
+            }
+        }
+        if self.preprocessing.shared.program.is_committed() {
+            let (program_point, program_claim) =
+                self.opening_accumulator.get_committed_polynomial_opening(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                );
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &program_point.r);
+            polynomial_claims.push((
+                CommittedPolynomial::ProgramImageInit,
+                program_claim * lagrange_factor,
+            ));
+            scaling_factors.push(lagrange_factor);
+        }
+
         // 2. Sample gamma and compute powers for RLC
         let claims: Vec<F> = polynomial_claims.iter().map(|(_, c)| *c).collect();
         // In non-ZK mode, absorb claims before sampling gamma for Fiat-Shamir binding.
@@ -1821,6 +1976,12 @@ impl<
             &self.one_hot_params,
             include_trusted_advice,
             include_untrusted_advice,
+            if self.preprocessing.shared.program.is_committed() {
+                ProgramMode::Committed
+            } else {
+                ProgramMode::Full
+            },
+            self.preprocessing.shared.bytecode_chunk_count,
         );
         let joint_claim: F = gamma_powers
             .iter()
@@ -1868,6 +2029,32 @@ impl<
                 .any(|(p, _)| *p == CommittedPolynomial::UntrustedAdvice)
             {
                 commitments_map.insert(CommittedPolynomial::UntrustedAdvice, commitment.clone());
+            }
+        }
+        if let Some(trusted_bytecode) = self.preprocessing.shared.program.bytecode_commitments() {
+            for (chunk_idx, commitment) in trusted_bytecode.commitments.iter().enumerate() {
+                if state
+                    .polynomial_claims
+                    .iter()
+                    .any(|(p, _)| *p == CommittedPolynomial::BytecodeChunk(chunk_idx))
+                {
+                    commitments_map.insert(
+                        CommittedPolynomial::BytecodeChunk(chunk_idx),
+                        commitment.clone(),
+                    );
+                }
+            }
+        }
+        if let Ok(trusted_program) = self.preprocessing.shared.program.as_committed() {
+            if state
+                .polynomial_claims
+                .iter()
+                .any(|(p, _)| *p == CommittedPolynomial::ProgramImageInit)
+            {
+                commitments_map.insert(
+                    CommittedPolynomial::ProgramImageInit,
+                    trusted_program.program_image_commitment.clone(),
+                );
             }
         }
 
@@ -1931,10 +2118,12 @@ impl<
         let (coeffs, commitments): (Vec<F>, Vec<PCS::Commitment>) = rlc_map
             .into_iter()
             .map(|(k, v)| {
-                commitment_map
-                    .remove(&k)
-                    .map(|c| (v, c))
-                    .ok_or(ProofVerifyError::InternalError)
+                commitment_map.remove(&k).map(|c| (v, c)).ok_or_else(|| {
+                    ProofVerifyError::DoryError(format!(
+                        "missing commitment for Stage 8 polynomial {:?}",
+                        k
+                    ))
+                })
             })
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
@@ -2099,26 +2288,6 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
         shared
     }
 
-    pub fn bytecode(&self) -> &crate::zkvm::bytecode::BytecodePreprocessing {
-        &self
-            .program
-            .as_full()
-            .expect("full program preprocessing required")
-            .bytecode
-    }
-
-    pub fn bytecode_arc(&self) -> Arc<crate::zkvm::bytecode::BytecodePreprocessing> {
-        Arc::new(self.bytecode().clone())
-    }
-
-    pub fn ram(&self) -> &RAMPreprocessing {
-        &self
-            .program
-            .as_full()
-            .expect("full program preprocessing required")
-            .ram
-    }
-
     pub fn is_committed_mode(&self) -> bool {
         self.program.is_committed()
     }
@@ -2133,6 +2302,7 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
             .committed_program_image_num_words(&self.memory_layout)
     }
 
+    #[inline]
     pub(crate) fn precommitted_candidate_total_vars(
         &self,
         include_committed: bool,
@@ -2182,18 +2352,19 @@ impl<PCS: CommitmentScheme> JoltSharedPreprocessing<PCS> {
         max_total_vars
     }
 
+    #[inline]
     pub(crate) fn compute_max_total_vars(&self, include_committed: bool) -> (usize, usize) {
         use common::constants::ONEHOT_CHUNK_THRESHOLD_LOG_T;
-
-        let max_T = self.max_padded_trace_length.next_power_of_two();
-        let max_log_T = max_T.log_2();
-        let max_log_k_chunk = if max_log_T < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+        let max_t_any = self.max_padded_trace_length.next_power_of_two();
+        let max_log_t = max_t_any.log_2();
+        let max_log_k_chunk = if max_log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
             4
         } else {
             8
         };
+
         let max_total_vars = Self::max_total_vars_from_candidates(
-            max_log_k_chunk + max_log_T,
+            max_log_k_chunk + max_log_t,
             self.precommitted_candidate_total_vars(include_committed, true, true),
         );
 
@@ -2218,16 +2389,90 @@ impl<C: JoltCurve> From<BlindfoldSetup<C>> for PedersenGenerators<C> {
     }
 }
 
-#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Clone)]
 pub struct JoltVerifierPreprocessing<F, C, PCS>
 where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
 {
+    _curve: std::marker::PhantomData<C>,
     pub generators: PCS::VerifierSetup,
     pub shared: JoltSharedPreprocessing<PCS>,
     pub blindfold_setup: Option<BlindfoldSetup<C>>,
+}
+
+impl<F, C, PCS> CanonicalSerialize for JoltVerifierPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalSerialize,
+    PCS::Commitment: CanonicalSerialize,
+{
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.serialize_with_mode(&mut writer, compress)?;
+        self.shared.serialize_with_mode(&mut writer, compress)?;
+        self.blindfold_setup
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.generators.serialized_size(compress)
+            + self.shared.serialized_size(compress)
+            + self.blindfold_setup.serialized_size(compress)
+    }
+}
+
+impl<F, C, PCS> CanonicalDeserialize for JoltVerifierPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalDeserialize,
+    PCS::Commitment: CanonicalDeserialize,
+{
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        Ok(Self {
+            _curve: std::marker::PhantomData,
+            generators: PCS::VerifierSetup::deserialize_with_mode(&mut reader, compress, validate)?,
+            shared: JoltSharedPreprocessing::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+            blindfold_setup: Option::<BlindfoldSetup<C>>::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+        })
+    }
+}
+
+impl<F, C, PCS> ark_serialize::Valid for JoltVerifierPreprocessing<F, C, PCS>
+where
+    F: JoltField,
+    C: JoltCurve<F = F>,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: ark_serialize::Valid,
+    PCS::Commitment: ark_serialize::Valid,
+{
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.generators.check()?;
+        self.shared.check()?;
+        self.blindfold_setup.check()?;
+        Ok(())
+    }
 }
 
 impl<F, C, PCS> Serializable for JoltVerifierPreprocessing<F, C, PCS>
@@ -2235,6 +2480,8 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalSerialize + CanonicalDeserialize,
+    PCS::Commitment: CanonicalSerialize + CanonicalDeserialize,
 {
 }
 
@@ -2243,6 +2490,8 @@ where
     F: JoltField,
     C: JoltCurve<F = F>,
     PCS: CommitmentScheme<Field = F>,
+    PCS::VerifierSetup: CanonicalSerialize + CanonicalDeserialize,
+    PCS::Commitment: CanonicalSerialize + CanonicalDeserialize,
 {
     pub fn save_to_target_dir(&self, target_dir: &str) -> std::io::Result<()> {
         let filename = Path::new(target_dir).join("jolt_verifier_preprocessing.dat");
@@ -2273,6 +2522,7 @@ impl<F: JoltField, C: JoltCurve<F = F>, PCS: CommitmentScheme<Field = F>>
     ) -> Self {
         shared.program = shared.program.to_verifier_program();
         Self {
+            _curve: std::marker::PhantomData,
             generators,
             shared,
             blindfold_setup,

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -6,11 +6,11 @@ use common::jolt_device::MemoryLayout;
 use rayon::prelude::*;
 use tracer::instruction::Cycle;
 
+use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
-use crate::zkvm::bytecode::BytecodePreprocessing;
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::instruction::InstructionFlags;
-use crate::zkvm::verifier::JoltSharedPreprocessing;
+use crate::zkvm::prover::JoltProverPreprocessing;
 use crate::{
     field::JoltField,
     poly::{multilinear_polynomial::MultilinearPolynomial, one_hot_polynomial::OneHotPolynomial},
@@ -64,15 +64,15 @@ pub fn all_committed_polynomials(one_hot_params: &OneHotParams) -> Vec<Committed
 
 impl CommittedPolynomial {
     /// Generate witness data and compute tier 1 commitment for a single row
-    pub fn stream_witness_and_commit_rows<F, PCS>(
+    pub fn stream_witness_and_commit_rows<F, C, PCS>(
         &self,
-        setup: &PCS::ProverSetup,
-        preprocessing: &JoltSharedPreprocessing<PCS>,
+        preprocessing: &JoltProverPreprocessing<F, C, PCS>,
         row_cycles: &[tracer::instruction::Cycle],
         one_hot_params: &OneHotParams,
     ) -> <PCS as StreamingCommitmentScheme>::ChunkState
     where
         F: JoltField,
+        C: JoltCurve<F = F>,
         PCS: StreamingCommitmentScheme<Field = F>,
     {
         match self {
@@ -84,7 +84,7 @@ impl CommittedPolynomial {
                         post_value as i128 - pre_value as i128
                     })
                     .collect();
-                PCS::process_chunk(setup, &row)
+                PCS::process_chunk(&preprocessing.generators, &row)
             }
             CommittedPolynomial::RamInc => {
                 let row: Vec<i128> = row_cycles
@@ -96,7 +96,7 @@ impl CommittedPolynomial {
                         _ => 0,
                     })
                     .collect();
-                PCS::process_chunk(setup, &row)
+                PCS::process_chunk(&preprocessing.generators, &row)
             }
             CommittedPolynomial::InstructionRa(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
@@ -106,20 +106,17 @@ impl CommittedPolynomial {
                         Some(one_hot_params.lookup_index_chunk(lookup_index, *idx) as usize)
                     })
                     .collect();
-                PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
+                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
             CommittedPolynomial::BytecodeRa(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
                     .iter()
                     .map(|cycle| {
-                        let pc = crate::zkvm::bytecode::get_pc_for_cycle(
-                            preprocessing.bytecode(),
-                            cycle,
-                        );
+                        let pc = preprocessing.materialized_program().get_pc(cycle);
                         Some(one_hot_params.bytecode_pc_chunk(pc, *idx) as usize)
                     })
                     .collect();
-                PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
+                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
             CommittedPolynomial::RamRa(idx) => {
                 let row: Vec<Option<usize>> = row_cycles
@@ -127,17 +124,17 @@ impl CommittedPolynomial {
                     .map(|cycle| {
                         remap_address(
                             cycle.ram_access().address() as u64,
-                            &preprocessing.memory_layout,
+                            &preprocessing.shared.memory_layout,
                         )
                         .map(|address| one_hot_params.ram_address_chunk(address, *idx) as usize)
                     })
                     .collect();
-                PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
+                PCS::process_chunk_onehot(&preprocessing.generators, one_hot_params.k_chunk, &row)
             }
             CommittedPolynomial::TrustedAdvice
             | CommittedPolynomial::UntrustedAdvice
-            | CommittedPolynomial::BytecodeChunk(_)
-            | CommittedPolynomial::ProgramImageInit => {
+            | CommittedPolynomial::ProgramImageInit
+            | CommittedPolynomial::BytecodeChunk(_) => {
                 panic!("Precommitted polynomials should not use streaming witness generation")
             }
         }
@@ -146,7 +143,7 @@ impl CommittedPolynomial {
     #[tracing::instrument(skip_all, name = "CommittedPolynomial::generate_witness")]
     pub fn generate_witness<F>(
         &self,
-        bytecode_preprocessing: &BytecodePreprocessing,
+        bytecode_preprocessing: &crate::zkvm::bytecode::BytecodePreprocessing,
         memory_layout: &MemoryLayout,
         trace: &[Cycle],
         one_hot_params: Option<&OneHotParams>,
@@ -225,8 +222,8 @@ impl CommittedPolynomial {
             }
             CommittedPolynomial::TrustedAdvice
             | CommittedPolynomial::UntrustedAdvice
-            | CommittedPolynomial::BytecodeChunk(_)
-            | CommittedPolynomial::ProgramImageInit => {
+            | CommittedPolynomial::ProgramImageInit
+            | CommittedPolynomial::BytecodeChunk(_) => {
                 panic!("Precommitted polynomials should not use generate_witness")
             }
         }

--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -179,11 +179,11 @@ fn main() {
     // AstCommitmentScheme satisfies the CommitmentScheme trait but performs no cryptographic
     // operations. PCS verification is skipped in stages 1-6.
     let symbolic_preprocessing: JoltVerifierPreprocessing<MleAst, AstCurve, AstCommitmentScheme> =
-        JoltVerifierPreprocessing {
-            generators: transpiler::symbolic_traits::ast_commitment_scheme::AstVerifierSetup,
-            shared: symbolic_shared,
-            blindfold_setup: None,
-        };
+        JoltVerifierPreprocessing::new(
+            symbolic_shared,
+            transpiler::symbolic_traits::ast_commitment_scheme::AstVerifierSetup,
+            None,
+        );
 
     // =========================================================================
     // Step 2: Convert proof to symbolic representation
@@ -244,7 +244,10 @@ fn main() {
         use jolt_core::zkvm::ram::{set_pending_initial_ram, PendingInitialRamValues};
         let bytecode_words: Vec<MleAst> = real_preprocessing
             .shared
-            .ram()
+            .program
+            .as_full()
+            .expect("transpiler only supports full preprocessing")
+            .ram
             .bytecode_words
             .iter()
             .map(|&w| MleAst::from_u64(w))


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.

Stack position: `07`
Base branch: `stack/06-bytecode-program-image-reductions`
Source implementation reference: `LayerZero-Research/amir/bytecode-commitment-merged@a351d5078b83577db8f3264fa53dfaddcf5ed687`

Owned paths:
```
jolt-core/src/zkvm/prover.rs jolt-core/src/zkvm/verifier.rs jolt-core/src/zkvm/mod.rs jolt-core/src/zkvm/bytecode/read_raf_checking.rs jolt-core/src/zkvm/ram/mod.rs jolt-core/src/zkvm/ram/val_check.rs jolt-core/src/zkvm/claim_reductions/hamming_weight.rs jolt-core/src/poly/commitment/dory/commitment_scheme.rs jolt-core/src/poly/commitment/dory/tests.rs
```

See `specs/1344-committed-bytecode-program-image.md` for the slice checklist and verification expectations.
